### PR TITLE
Fix for shifting of the current item in save/load menus

### DIFF
--- a/source/common/menu/savegamemanager.cpp
+++ b/source/common/menu/savegamemanager.cpp
@@ -260,7 +260,7 @@ void FSavegameManager::NotifyNewSave(const FString &file, const FString &title, 
 			if (okForQuicksave)
 			{
 				if (quickSaveSlot == nullptr || quickSaveSlot == (FSaveGameNode*)1 || forceQuicksave) quickSaveSlot = node;
-				LastAccessed = LastSaved = i;
+				LastAccessed = LastSaved = i - 1; // without <new save> item
 			}
 			return;
 		}
@@ -276,7 +276,7 @@ void FSavegameManager::NotifyNewSave(const FString &file, const FString &title, 
 	if (okForQuicksave)
 	{
 		if (quickSaveSlot == nullptr || quickSaveSlot == (FSaveGameNode*)1 || forceQuicksave) quickSaveSlot = node;
-		LastAccessed = LastSaved = index;
+		LastAccessed = LastSaved = index - 1; // without <new save> item
 	}
 	else
 	{


### PR DESCRIPTION
Virtual <New save game> item wasn't taken into account

GZDoom has a different order of calls to `FSavegameManager::RemoveNewSaveNode()` and `FSavegameManager::NotifyNewSave()`. I would like to be sure that it wasn't an occasional change.