### PR TITLE
- Duke3D: Tie player input to framerate

### DIFF
--- a/source/duke3d/src/actors.cpp
+++ b/source/duke3d/src/actors.cpp
@@ -1279,6 +1279,23 @@ static int P_Submerge(int, DukePlayer_t *, int, int);
 static int P_Emerge(int, DukePlayer_t *, int, int);
 static void P_FinishWaterChange(int, DukePlayer_t *, int, int, int);
 
+static fix16_t P_GetQ16AngleDeltaForTic(DukePlayer_t const *pPlayer)
+{
+    auto oldAngle = pPlayer->oq16ang;
+    auto newAngle = pPlayer->q16ang;
+
+    if (klabs(fix16_sub(oldAngle, newAngle)) < F16(1024))
+        return fix16_sub(newAngle, oldAngle);
+
+    if (newAngle > F16(1024))
+        newAngle = fix16_sub(newAngle, F16(2048));
+
+    if (oldAngle > F16(1024))
+        oldAngle = fix16_sub(oldAngle, F16(2048));
+
+    return fix16_sub(newAngle, oldAngle);
+}
+
 ACTOR_STATIC void G_MovePlayers(void)
 {
     int spriteNum = headspritestat[STAT_PLAYER];
@@ -1331,6 +1348,11 @@ ACTOR_STATIC void G_MovePlayers(void)
 
                 if (G_HaveActor(sprite[spriteNum].picnum))
                     A_Execute(spriteNum, P_GetP(pSprite), otherPlayerDist);
+
+                pPlayer->q16angvel    = P_GetQ16AngleDeltaForTic(pPlayer);
+                pPlayer->oq16ang      = pPlayer->q16ang;
+                pPlayer->oq16horiz    = pPlayer->q16horiz;
+                pPlayer->oq16horizoff = pPlayer->q16horizoff;
 
                 if (g_netServer || ud.multimode > 1)
                 {

--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -5913,15 +5913,22 @@ MAIN_LOOP_RESTART:
                     P_GetInput(myconnectindex);
 
                     // this is where we fill the input_t struct that is actually processed by P_ProcessInput()
-                    auto const    pPlayer = g_player[myconnectindex].ps;
-                    int16_t const q16ang  = fix16_to_int(pPlayer->q16ang);
-                    auto &        input   = inputfifo[0][myconnectindex];
+                    auto const pPlayer = g_player[myconnectindex].ps;
+                    auto const q16ang  = fix16_to_int(pPlayer->q16ang);
+                    auto &     input   = inputfifo[0][myconnectindex];
 
                     input = localInput;
-                    input.fvel = mulscale9(localInput.fvel, sintable[(q16ang + 2560) & 2047])
-                                 + mulscale9(localInput.svel, sintable[(q16ang + 2048) & 2047]) + (FURY ? 0 : pPlayer->fric.x);
-                    input.svel = mulscale9(localInput.fvel, sintable[(q16ang + 2048) & 2047])
-                                 + mulscale9(localInput.svel, sintable[(q16ang + 1536) & 2047]) + (FURY ? 0 : pPlayer->fric.y);
+                    input.fvel = mulscale9(localInput.fvel, sintable[(q16ang + 2560) & 2047]) +
+                                 mulscale9(localInput.svel, sintable[(q16ang + 2048) & 2047]);
+                    input.svel = mulscale9(localInput.fvel, sintable[(q16ang + 2048) & 2047]) +
+                                 mulscale9(localInput.svel, sintable[(q16ang + 1536) & 2047]);
+
+                    if (FURY)
+                    {
+                        input.fvel += pPlayer->fric.x;
+                        input.svel += pPlayer->fric.y;
+                    }
+
                     localInput = {};
                 }
 

--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -801,11 +801,8 @@ void G_DrawRooms(int32_t playerNum, int32_t smoothRatio)
                                      pPlayer->opos.z + mulscale16(pPlayer->pos.z - pPlayer->opos.z, smoothRatio) };
 
             CAMERA(pos)      = camVect;
-            CAMERA(q16ang)   = pPlayer->oq16ang
-                             + mulscale16(((pPlayer->q16ang + F16(1024) - pPlayer->oq16ang) & 0x7FFFFFF) - F16(1024), smoothRatio)
-                             + fix16_from_int(pPlayer->look_ang);
-            CAMERA(q16horiz) = pPlayer->oq16horiz + pPlayer->oq16horizoff
-                             + mulscale16((pPlayer->q16horiz + pPlayer->q16horizoff - pPlayer->oq16horiz - pPlayer->oq16horizoff), smoothRatio);
+            CAMERA(q16ang)   = pPlayer->q16ang + fix16_from_int(pPlayer->look_ang);
+            CAMERA(q16horiz) = pPlayer->q16horiz + pPlayer->q16horizoff;
 
             if (cl_viewbob)
             {
@@ -5914,7 +5911,18 @@ MAIN_LOOP_RESTART:
                     frameJustDrawn = false;
 
                     P_GetInput(myconnectindex);
-                    inputfifo[0][myconnectindex] = localInput;
+
+                    // this is where we fill the input_t struct that is actually processed by P_ProcessInput()
+                    auto const    pPlayer = g_player[myconnectindex].ps;
+                    int16_t const q16ang  = fix16_to_int(pPlayer->q16ang);
+                    auto &        input   = inputfifo[0][myconnectindex];
+
+                    input = localInput;
+                    input.fvel = mulscale9(localInput.fvel, sintable[(q16ang + 2560) & 2047])
+                                 + mulscale9(localInput.svel, sintable[(q16ang + 2048) & 2047]) + (FURY ? 0 : pPlayer->fric.x);
+                    input.svel = mulscale9(localInput.fvel, sintable[(q16ang + 2048) & 2047])
+                                 + mulscale9(localInput.svel, sintable[(q16ang + 1536) & 2047]) + (FURY ? 0 : pPlayer->fric.y);
+                    localInput = {};
                 }
 
                 do
@@ -5968,6 +5976,11 @@ MAIN_LOOP_RESTART:
         }
         else if (G_FPSLimit() || g_saveRequested)
         {
+            if (!g_saveRequested)
+            {
+                P_GetInput(myconnectindex);
+            }
+
             int const smoothRatio = calc_smoothratio(totalclock, ototalclock);
 
             G_DrawRooms(screenpeek, smoothRatio);

--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -5923,7 +5923,7 @@ MAIN_LOOP_RESTART:
                     input.svel = mulscale9(localInput.fvel, sintable[(q16ang + 2048) & 2047]) +
                                  mulscale9(localInput.svel, sintable[(q16ang + 1536) & 2047]);
 
-                    if (FURY)
+                    if (!FURY)
                     {
                         input.fvel += pPlayer->fric.x;
                         input.svel += pPlayer->fric.y;

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -2899,13 +2899,10 @@ static int P_CheckLockedMovement(int const playerNum)
                 && pPlayer->kickback_pic < PWEAPON(playerNum, pPlayer->curr_weapon, FireDelay)));
 }
 
-static bool g_horizRecenter;
-static float g_horizAngleAdjust;
-static fix16_t g_horizSkew;
-
 void P_GetInput(int const playerNum)
 {
-    auto const pPlayer = g_player[playerNum].ps;
+    auto      &thisPlayer = g_player[playerNum];
+    auto const pPlayer    = thisPlayer.ps;
     ControlInfo info;
 
     if (g_cheatBufLen > 1 || (pPlayer->gm & (MODE_MENU|MODE_TYPE)) || (ud.pause_on && !inputState.GetKeyStatus(sc_Pause)))
@@ -3151,23 +3148,22 @@ void P_GetInput(int const playerNum)
         pPlayer->q16horiz = fix16_clamp(fix16_sadd(pPlayer->q16horiz, input.q16horz), F16(HORIZ_MIN), F16(HORIZ_MAX));
     }
 
-    // A horiz diff of 128 equal 45 degrees,
-    // so we convert horiz to 1024 angle units
+    // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
 
-    if (g_horizAngleAdjust)
+    if (thisPlayer.horizAngleAdjust)
     {
         float const horizAngle
-        = atan2f(pPlayer->q16horiz - F16(100), F16(128)) * (512.f / fPI) + scaleAdjustmentToInterval(g_horizAngleAdjust);
+        = atan2f(pPlayer->q16horiz - F16(100), F16(128)) * (512.f / fPI) + scaleAdjustmentToInterval(thisPlayer.horizAngleAdjust);
         pPlayer->q16horiz = F16(100) + Blrintf(F16(128) * tanf(horizAngle * (fPI / 512.f)));
     }
-    else if (pPlayer->return_to_center > 0 || g_horizRecenter)
+    else if (pPlayer->return_to_center > 0 || thisPlayer.horizRecenter)
     {
         pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(F16(66.666) - fix16_sdiv(pPlayer->q16horiz, F16(1.5))))));
 
-        if ((!pPlayer->return_to_center && g_horizRecenter) || (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1)))
+        if ((!pPlayer->return_to_center && thisPlayer.horizRecenter) || (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1)))
         {
             pPlayer->q16horiz = F16(100);
-            g_horizRecenter   = false;
+            thisPlayer.horizRecenter = false;
         }
 
         if (pPlayer->q16horizoff >= F16(-0.1) && pPlayer->q16horizoff <= F16(0.1))
@@ -3203,8 +3199,8 @@ void P_GetInput(int const playerNum)
         pPlayer->q16horizoff = fix16_min(pPlayer->q16horizoff, 0);
     }
 
-    if (g_horizSkew)
-        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(g_horizSkew))));
+    if (thisPlayer.horizSkew)
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(thisPlayer.horizSkew))));
 
     pPlayer->q16horiz = fix16_clamp(pPlayer->q16horiz, F16(HORIZ_MIN), F16(HORIZ_MAX));
 }
@@ -4705,20 +4701,22 @@ static void P_ClampZ(DukePlayer_t* const pPlayer, int const sectorLotag, int32_t
 
 void P_ProcessInput(int playerNum)
 {
-    g_horizAngleAdjust = 0;
-    g_horizSkew = 0;
+    auto &thisPlayer = g_player[playerNum];
 
-    if (g_player[playerNum].playerquitflag == 0)
+    thisPlayer.horizAngleAdjust = 0;
+    thisPlayer.horizSkew = 0;
+
+    if (thisPlayer.playerquitflag == 0)
         return;
 
-    auto const pPlayer = g_player[playerNum].ps;
+    auto const pPlayer = thisPlayer.ps;
     auto const pSprite = &sprite[pPlayer->i];
 
     ++pPlayer->player_par;
 
     VM_OnEvent(EVENT_PROCESSINPUT, pPlayer->i, playerNum);
 
-    uint32_t playerBits = g_player[playerNum].input->bits;
+    uint32_t playerBits = thisPlayer.input->bits;
 
     if (pPlayer->cheat_phase > 0)
         playerBits = 0;
@@ -5240,7 +5238,7 @@ void P_ProcessInput(int playerNum)
         pPlayer->vel.x   = 0;
         pPlayer->vel.y   = 0;
     }
-    else if (g_player[playerNum].input->q16avel)
+    else if (thisPlayer.input->q16avel)
         pPlayer->crack_time = PCRACKTIME;
 
     if (pPlayer->spritebridge == 0)
@@ -5278,18 +5276,18 @@ void P_ProcessInput(int playerNum)
         }
     }
 
-    if (g_player[playerNum].input->extbits & (1))      VM_OnEvent(EVENT_MOVEFORWARD,  pPlayer->i, playerNum);
-    if (g_player[playerNum].input->extbits & (1 << 1)) VM_OnEvent(EVENT_MOVEBACKWARD, pPlayer->i, playerNum);
-    if (g_player[playerNum].input->extbits & (1 << 2)) VM_OnEvent(EVENT_STRAFELEFT,   pPlayer->i, playerNum);
-    if (g_player[playerNum].input->extbits & (1 << 3)) VM_OnEvent(EVENT_STRAFERIGHT,  pPlayer->i, playerNum);
+    if (thisPlayer.input->extbits & (1))      VM_OnEvent(EVENT_MOVEFORWARD,  pPlayer->i, playerNum);
+    if (thisPlayer.input->extbits & (1 << 1)) VM_OnEvent(EVENT_MOVEBACKWARD, pPlayer->i, playerNum);
+    if (thisPlayer.input->extbits & (1 << 2)) VM_OnEvent(EVENT_STRAFELEFT,   pPlayer->i, playerNum);
+    if (thisPlayer.input->extbits & (1 << 3)) VM_OnEvent(EVENT_STRAFERIGHT,  pPlayer->i, playerNum);
 
-    if (g_player[playerNum].input->extbits & (1 << 4) || g_player[playerNum].input->q16avel < 0)
+    if (thisPlayer.input->extbits & (1 << 4) || thisPlayer.input->q16avel < 0)
         VM_OnEvent(EVENT_TURNLEFT, pPlayer->i, playerNum);
 
-    if (g_player[playerNum].input->extbits & (1 << 5) || g_player[playerNum].input->q16avel > 0)
+    if (thisPlayer.input->extbits & (1 << 5) || thisPlayer.input->q16avel > 0)
         VM_OnEvent(EVENT_TURNRIGHT, pPlayer->i, playerNum);
 
-    if (pPlayer->vel.x || pPlayer->vel.y || g_player[playerNum].input->fvel || g_player[playerNum].input->svel)
+    if (pPlayer->vel.x || pPlayer->vel.y || thisPlayer.input->fvel || thisPlayer.input->svel)
     {
         pPlayer->crack_time = PCRACKTIME;
 
@@ -5343,8 +5341,8 @@ void P_ProcessInput(int playerNum)
         }
 #endif
 
-        pPlayer->vel.x += (((g_player[playerNum].input->fvel) * velocityModifier) << 6);
-        pPlayer->vel.y += (((g_player[playerNum].input->svel) * velocityModifier) << 6);
+        pPlayer->vel.x += (((thisPlayer.input->fvel) * velocityModifier) << 6);
+        pPlayer->vel.y += (((thisPlayer.input->svel) * velocityModifier) << 6);
 
         int playerSpeedReduction = 0;
 
@@ -5520,8 +5518,8 @@ RECHECK:
         if (VM_OnEvent(EVENT_LOOKUP,pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
-            g_horizRecenter = true;
-            g_horizAngleAdjust = float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
+            thisPlayer.horizRecenter = true;
+            thisPlayer.horizAngleAdjust = float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
         }
     }
 
@@ -5530,8 +5528,8 @@ RECHECK:
         if (VM_OnEvent(EVENT_LOOKDOWN,pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
-            g_horizRecenter = true;
-            g_horizAngleAdjust = -float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
+            thisPlayer.horizRecenter = true;
+            thisPlayer.horizAngleAdjust = -float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
         }
     }
 
@@ -5539,8 +5537,8 @@ RECHECK:
     {
         if (VM_OnEvent(EVENT_AIMUP,pPlayer->i,playerNum) == 0)
         {
-            g_horizAngleAdjust = float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
-            g_horizRecenter    = false;
+            thisPlayer.horizAngleAdjust = float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
+            thisPlayer.horizRecenter    = false;
         }
     }
 
@@ -5548,14 +5546,14 @@ RECHECK:
     {
         if (VM_OnEvent(EVENT_AIMDOWN,pPlayer->i,playerNum) == 0)
         {
-            g_horizAngleAdjust = -float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
-            g_horizRecenter    = false;
+            thisPlayer.horizAngleAdjust = -float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
+            thisPlayer.horizRecenter    = false;
         }
     }
 
     if (pPlayer->hard_landing > 0)
     {
-        g_horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
         pPlayer->hard_landing--;
     }
 
@@ -5584,8 +5582,8 @@ RECHECK:
 #ifndef EDUKE32_STANDALONE
     if (!FURY && pPlayer->knee_incs > 0)
     {
-        g_horizSkew = F16(-48);
-        g_horizRecenter = true;
+        thisPlayer.horizSkew = F16(-48);
+        thisPlayer.horizRecenter = true;
         pPlayer->return_to_center = 9;
 
         if (++pPlayer->knee_incs > 15)

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -4798,9 +4798,6 @@ void P_ProcessInput(int playerNum)
     actor[pPlayer->i].floorz   = floorZ;
     actor[pPlayer->i].ceilingz = ceilZ;
 
-    pPlayer->oq16horiz    = pPlayer->q16horiz;
-    pPlayer->oq16horizoff = pPlayer->q16horizoff;
-
     if ((highZhit & 49152) == 49152)
     {
         int const spriteNum = highZhit & (MAXSPRITES-1);
@@ -4975,7 +4972,6 @@ void P_ProcessInput(int playerNum)
     pPlayer->bobpos  = pPlayer->pos.vec2;
     pPlayer->opos.z  = pPlayer->pos.z;
     pPlayer->opyoff  = pPlayer->pyoff;
-    pPlayer->oq16ang = pPlayer->q16ang;
 
     updatesector(pPlayer->pos.x, pPlayer->pos.y, &pPlayer->cursectnum);
 

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -2982,10 +2982,10 @@ void P_GetInput(int const playerNum)
         if (!localInput.svel)
         {
             if (buttonMap.ButtonDown(gamefunc_Turn_Left) && !(pPlayer->movement_lock & 4) && !localInput.svel)
-                input.svel = -keyMove;
+                input.svel = keyMove;
 
             if (buttonMap.ButtonDown(gamefunc_Turn_Right) && !(pPlayer->movement_lock & 8) && !localInput.svel)
-                input.svel = keyMove;
+                input.svel = -keyMove;
         }
     }
     else

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -2881,23 +2881,27 @@ enddisplayweapon:
 }
 
 #define TURBOTURNTIME (TICRATE/8) // 7
-#define NORMALTURN   15
-#define PREAMBLETURN 5
+#define NORMALTURN    15
+#define PREAMBLETURN  5
 #define NORMALKEYMOVE 40
-#define MAXVEL       ((NORMALKEYMOVE*2)+10)
-#define MAXSVEL      ((NORMALKEYMOVE*2)+10)
-#define MAXANGVEL    1024
-#define MAXHORIZ     256
+#define MAXVEL        ((NORMALKEYMOVE*2)+10)
+#define MAXSVEL       ((NORMALKEYMOVE*2)+10)
+#define MAXANGVEL     1024
+#define MAXHORIZVEL   256
 
 int32_t mouseyaxismode = -1;
 
 static int P_CheckLockedMovement(int const playerNum)
 {
     auto const pPlayer = g_player[playerNum].ps;
-    return (pPlayer->fist_incs || pPlayer->transporter_hold > 2 || pPlayer->hard_landing || pPlayer->access_incs > 0 || pPlayer->knee_incs > 0
+    return (pPlayer->dead_flag || pPlayer->fist_incs || pPlayer->transporter_hold > 2 || pPlayer->hard_landing || pPlayer->access_incs > 0 || pPlayer->knee_incs > 0
             || (PWEAPON(playerNum, pPlayer->curr_weapon, WorksLike) == TRIPBOMB_WEAPON && pPlayer->kickback_pic > 1
                 && pPlayer->kickback_pic < PWEAPON(playerNum, pPlayer->curr_weapon, FireDelay)));
 }
+
+static bool g_horizRecenter;
+static float g_horizAngleAdjust;
+static fix16_t g_horizSkew;
 
 void P_GetInput(int const playerNum)
 {
@@ -2909,8 +2913,7 @@ void P_GetInput(int const playerNum)
         if (!(pPlayer->gm&MODE_MENU))
             CONTROL_GetInput(&info);
 
-        Bmemset(&localInput, 0, sizeof(input_t));
-
+        localInput = {};
         localInput.bits    = (((int32_t)g_gameQuit) << SK_GAMEQUIT);
         localInput.extbits |= (1<<7);
 
@@ -2932,11 +2935,11 @@ void P_GetInput(int const playerNum)
     CONTROL_GetInput(&info);
 
     // JBF: Run key behaviour is selectable
-    int const playerRunning = G_CheckAutorun(buttonMap.ButtonDown(gamefunc_Run));
-    int const turnAmount = playerRunning ? (NORMALTURN << 1) : NORMALTURN;
-    constexpr int const analogTurnAmount = (NORMALTURN << 1);
-    int const keyMove    = playerRunning ? (NORMALKEYMOVE << 1) : NORMALKEYMOVE;
-    constexpr int const analogExtent = 32767; // KEEPINSYNC sdlayer.cpp
+    int const     playerRunning    = G_CheckAutorun(buttonMap.ButtonDown(gamefunc_Run));
+    int const     turnAmount       = playerRunning ? (NORMALTURN << 1) : NORMALTURN;
+    constexpr int analogTurnAmount = (NORMALTURN << 1);
+    int const     keyMove          = playerRunning ? (NORMALKEYMOVE << 1) : NORMALKEYMOVE;
+    constexpr int analogExtent     = 32767;  // KEEPINSYNC sdlayer.cpp
 
     input_t input {};
 
@@ -2951,12 +2954,12 @@ void P_GetInput(int const playerNum)
     }
     else
     {
-        input.q16avel = fix16_div(fix16_from_int(info.mousex), F16(32));
+        input.q16avel += fix16_div(fix16_from_int(info.mousex), F16(32));
         input.q16avel += fix16_from_int(info.dyaw) / analogExtent * (analogTurnAmount << 1);
     }
 
     if (mouseaim)
-        input.q16horz = fix16_div(fix16_from_int(info.mousey), F16(64));
+        input.q16horz += fix16_div(fix16_from_int(info.mousey), F16(64));
     else
         input.fvel = -(info.mousey >> 3);
 
@@ -2966,53 +2969,64 @@ void P_GetInput(int const playerNum)
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;
 
+    static double lastInputTicks;
+    auto const    currentHiTicks    = timerGetHiTicks();
+    double const  elapsedInputTicks = currentHiTicks - lastInputTicks;
+
+    lastInputTicks = currentHiTicks;
+
+    auto scaleAdjustmentToInterval = [=](double x) { return x * REALGAMETICSPERSEC / (1000.0 / elapsedInputTicks); };
+
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {
-        if (buttonMap.ButtonDown(gamefunc_Turn_Left) && !(pPlayer->movement_lock&4))
-            input.svel -= -keyMove;
+        if (!localInput.svel)
+        {
+            if (buttonMap.ButtonDown(gamefunc_Turn_Left) && !(pPlayer->movement_lock & 4) && !localInput.svel)
+                input.svel = -keyMove;
 
-        if (buttonMap.ButtonDown(gamefunc_Turn_Right) && !(pPlayer->movement_lock&8))
-            input.svel -= keyMove;
+            if (buttonMap.ButtonDown(gamefunc_Turn_Right) && !(pPlayer->movement_lock & 8) && !localInput.svel)
+                input.svel = keyMove;
+        }
     }
     else
     {
-        static int32_t turnHeldTime   = 0;
-        static int32_t lastInputClock = 0;  // MED
-        int32_t const  elapsedTics    = (int32_t) totalclock - lastInputClock;
+        static int32_t turnHeldTime;
+        static int32_t lastInputClock;  // MED
+        int32_t const  elapsedTics = (int32_t)totalclock - lastInputClock;
 
         lastInputClock = (int32_t) totalclock;
 
         if (buttonMap.ButtonDown(gamefunc_Turn_Left))
         {
             turnHeldTime += elapsedTics;
-            input.q16avel -= fix16_from_int((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1));
+            input.q16avel -= fix16_from_float(scaleAdjustmentToInterval((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1)));
         }
         else if (buttonMap.ButtonDown(gamefunc_Turn_Right))
         {
             turnHeldTime += elapsedTics;
-            input.q16avel += fix16_from_int((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1));
+            input.q16avel += fix16_from_float(scaleAdjustmentToInterval((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1)));
         }
         else
-            turnHeldTime=0;
+            turnHeldTime = 0;
     }
 
-    if (buttonMap.ButtonDown(gamefunc_Strafe_Left) && !(pPlayer->movement_lock & 4))
-        input.svel += keyMove;
+    if (localInput.svel < keyMove && localInput.svel > -keyMove)
+    {
+        if (buttonMap.ButtonDown(gamefunc_Strafe_Left) && !(pPlayer->movement_lock & 4))
+            input.svel += keyMove;
 
-    if (buttonMap.ButtonDown(gamefunc_Strafe_Right) && !(pPlayer->movement_lock & 8))
-        input.svel += -keyMove;
+        if (buttonMap.ButtonDown(gamefunc_Strafe_Right) && !(pPlayer->movement_lock & 8))
+            input.svel += -keyMove;
+    }
 
-    if (buttonMap.ButtonDown(gamefunc_Move_Forward) && !(pPlayer->movement_lock & 1))
-        input.fvel += keyMove;
+    if (localInput.fvel < keyMove && localInput.fvel > -keyMove)
+    {
+        if (buttonMap.ButtonDown(gamefunc_Move_Forward) && !(pPlayer->movement_lock & 1))
+            input.fvel += keyMove;
 
-    if (buttonMap.ButtonDown(gamefunc_Move_Backward) && !(pPlayer->movement_lock & 2))
-        input.fvel += -keyMove;
-
-    input.fvel = clamp(input.fvel, -MAXVEL, MAXVEL);
-    input.svel = clamp(input.svel, -MAXSVEL, MAXSVEL);
-
-    input.q16avel = fix16_clamp(input.q16avel, F16(-MAXANGVEL), F16(MAXANGVEL));
-    input.q16horz = fix16_clamp(input.q16horz, F16(-MAXHORIZ), F16(MAXHORIZ));
+        if (buttonMap.ButtonDown(gamefunc_Move_Backward) && !(pPlayer->movement_lock & 2))
+            input.fvel += -keyMove;
+    }
 
     // Ion Fury does not use the tenth slot and misbehaves if it gets selected.
     int weaponSelection = FURY? gamefunc_Weapon_9 : gamefunc_Weapon_10;
@@ -3037,7 +3051,10 @@ void P_GetInput(int const playerNum)
     else if (weaponSelection == gamefunc_Weapon_1-1)
         weaponSelection = 0;
 
-    localInput.bits = (weaponSelection << SK_WEAPON_BITS) | (buttonMap.ButtonDown(gamefunc_Fire) << SK_FIRE);
+    if ((localInput.bits & 0xf00) == 0)
+        localInput.bits |= (weaponSelection << SK_WEAPON_BITS);
+
+    localInput.bits |= (buttonMap.ButtonDown(gamefunc_Fire) << SK_FIRE);
     localInput.bits |= (buttonMap.ButtonDown(gamefunc_Open) << SK_OPEN);
 
     int const sectorLotag = pPlayer->cursectnum != -1 ? sector[pPlayer->cursectnum].lotag : 0;
@@ -3099,7 +3116,7 @@ void P_GetInput(int const playerNum)
     if (PWEAPON(playerNum, pPlayer->curr_weapon, Flags) & WEAPON_SEMIAUTO && buttonMap.ButtonDown(gamefunc_Fire))
         buttonMap.ClearButton(gamefunc_Fire);
 
-    localInput.extbits = (buttonMap.ButtonDown(gamefunc_Move_Forward) || (input.fvel > 0));
+    localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Move_Forward) || (input.fvel > 0));
     localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Move_Backward) || (input.fvel < 0)) << 1;
     localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Strafe_Left) || (input.svel > 0)) << 2;
     localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Strafe_Right) || (input.svel < 0)) << 3;
@@ -3107,32 +3124,89 @@ void P_GetInput(int const playerNum)
     localInput.extbits |= buttonMap.ButtonDown(gamefunc_Turn_Right)<<5;
     localInput.extbits |= buttonMap.ButtonDown(gamefunc_Alt_Fire)<<6;
 
-    if (ud.scrollmode && ud.overhead_on)
+    if ((ud.scrollmode && ud.overhead_on) || P_CheckLockedMovement(playerNum))
     {
-        ud.folfvel = input.fvel;
-        ud.folavel = fix16_to_int(input.q16avel);
+        if (ud.scrollmode && ud.overhead_on)
+        {
+            ud.folfvel = input.fvel;
+            ud.folavel = fix16_to_int(input.q16avel);
+        }
 
         localInput.fvel = 0;
         localInput.svel = 0;
 
         localInput.q16avel = 0;
         localInput.q16horz = 0;
+    }
+    else
+    {
+        localInput.q16avel = fix16_add(localInput.q16avel, input.q16avel);
+        localInput.q16horz = fix16_clamp(fix16_add(localInput.q16horz, input.q16horz), F16(-MAXHORIZVEL), F16(MAXHORIZVEL));
+        localInput.fvel    = clamp(localInput.fvel + input.fvel, -MAXVEL, MAXVEL);
+        localInput.svel    = clamp(localInput.svel + input.svel, -MAXSVEL, MAXSVEL);
 
-        return;
+        pPlayer->q16ang = fix16_add(pPlayer->q16ang, input.q16avel);
+        pPlayer->q16ang &= 0x7FFFFFF;
+
+        pPlayer->q16horiz = fix16_clamp(fix16_add(pPlayer->q16horiz, input.q16horz), F16(HORIZ_MIN), F16(HORIZ_MAX));
     }
 
-    int16_t const q16ang = fix16_to_int(pPlayer->q16ang);
+    // A horiz diff of 128 equal 45 degrees,
+    // so we convert horiz to 1024 angle units
 
-    localInput.fvel = mulscale9(input.fvel, sintable[(q16ang + 2560) & 2047]) +
-                      mulscale9(input.svel, sintable[(q16ang + 2048) & 2047]) +
-                      (FURY ? 0 : pPlayer->fric.x);
+    if (g_horizAngleAdjust)
+    {
+        float const horizAngle
+        = atan2f(pPlayer->q16horiz - F16(100), F16(128)) * (512.f / fPI) + scaleAdjustmentToInterval(g_horizAngleAdjust);
+        pPlayer->q16horiz = F16(100) + Blrintf(F16(128) * tanf(horizAngle * (fPI / 512.f)));
+    }
+    else if (pPlayer->return_to_center > 0 || g_horizRecenter)
+    {
+        pPlayer->q16horiz += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(F16(33) - fix16_div(pPlayer->q16horiz, F16(3)))));
 
-    localInput.svel = mulscale9(input.fvel, sintable[(q16ang + 2048) & 2047]) +
-                      mulscale9(input.svel, sintable[(q16ang + 1536) & 2047]) +
-                      (FURY ? 0 : pPlayer->fric.y);
+        if (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1))
+        {
+            pPlayer->q16horiz = F16(100);
+            g_horizRecenter   = 0;
+        }
 
-    localInput.q16avel = input.q16avel;
-    localInput.q16horz = input.q16horz;
+        if (pPlayer->q16horizoff >= F16(-0.1) && pPlayer->q16horizoff <= F16(0.1))
+            pPlayer->q16horizoff = 0;
+    }
+
+    // calculates automatic view angle for playing without a mouse
+    if (!pPlayer->aim_mode && pPlayer->on_ground && sectorLotag != ST_2_UNDERWATER && (sector[pPlayer->cursectnum].floorstat & 2))
+    {
+        // this is some kind of horse shit approximation of where the player is looking, I guess?
+        vec2_t const adjustedPosition = { pPlayer->pos.x + (sintable[(fix16_to_int(pPlayer->q16ang) + 512) & 2047] >> 5),
+                                          pPlayer->pos.y + (sintable[fix16_to_int(pPlayer->q16ang) & 2047] >> 5) };
+        int16_t currentSector = pPlayer->cursectnum;
+
+        updatesector(adjustedPosition.x, adjustedPosition.y, &currentSector);
+
+        if (currentSector >= 0)
+        {
+            int const slopeZ = getflorzofslope(pPlayer->cursectnum, adjustedPosition.x, adjustedPosition.y);
+            if ((pPlayer->cursectnum == currentSector) || (klabs(getflorzofslope(currentSector, adjustedPosition.x, adjustedPosition.y) - slopeZ) <= ZOFFSET6))
+                pPlayer->q16horizoff += fix16_from_float(scaleAdjustmentToInterval(mulscale16(pPlayer->truefz - slopeZ, 160)));
+        }
+    }
+
+    if (pPlayer->q16horizoff > 0)
+    {
+        pPlayer->q16horizoff -= fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((pPlayer->q16horizoff >> 3) + fix16_one)));
+        pPlayer->q16horizoff = fix16_max(pPlayer->q16horizoff, 0);
+    }
+    else if (pPlayer->q16horizoff < 0)
+    {
+        pPlayer->q16horizoff += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((-pPlayer->q16horizoff >> 3) + fix16_one)));
+        pPlayer->q16horizoff = fix16_min(pPlayer->q16horizoff, 0);
+    }
+
+    if (g_horizSkew)
+        pPlayer->q16horiz += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(g_horizSkew)));
+
+    pPlayer->q16horiz = fix16_clamp(pPlayer->q16horiz, F16(HORIZ_MIN), F16(HORIZ_MAX));
 }
 
 static int32_t P_DoCounters(int playerNum)
@@ -3336,7 +3410,7 @@ access_incs:
 void P_DropWeapon(int const playerNum)
 {
     auto const pPlayer       = g_player[playerNum].ps;
-    int const                 currentWeapon = PWEAPON(playerNum, pPlayer->curr_weapon, WorksLike);
+    int const  currentWeapon = PWEAPON(playerNum, pPlayer->curr_weapon, WorksLike);
 
     if ((unsigned)currentWeapon >= MAX_WEAPONS)
         return;
@@ -4631,6 +4705,9 @@ static void P_ClampZ(DukePlayer_t* const pPlayer, int const sectorLotag, int32_t
 
 void P_ProcessInput(int playerNum)
 {
+    g_horizAngleAdjust = 0;
+    g_horizSkew = 0;
+
     if (g_player[playerNum].playerquitflag == 0)
         return;
 
@@ -4717,36 +4794,6 @@ void P_ProcessInput(int playerNum)
 
     pPlayer->oq16horiz    = pPlayer->q16horiz;
     pPlayer->oq16horizoff = pPlayer->q16horizoff;
-
-    // calculates automatic view angle for playing without a mouse
-    if (pPlayer->aim_mode == 0 && pPlayer->on_ground && sectorLotag != ST_2_UNDERWATER
-        && (sector[pPlayer->cursectnum].floorstat & 2))
-    {
-        vec2_t const adjustedPlayer = { pPlayer->pos.x + (sintable[(fix16_to_int(pPlayer->q16ang) + 512) & 2047] >> 5),
-                                        pPlayer->pos.y + (sintable[fix16_to_int(pPlayer->q16ang) & 2047] >> 5) };
-        int16_t curSectNum = pPlayer->cursectnum;
-
-        updatesector(adjustedPlayer.x, adjustedPlayer.y, &curSectNum);
-
-        if (curSectNum >= 0)
-        {
-            int const slopeZ = getflorzofslope(pPlayer->cursectnum, adjustedPlayer.x, adjustedPlayer.y);
-            if ((pPlayer->cursectnum == curSectNum) ||
-                (klabs(getflorzofslope(curSectNum, adjustedPlayer.x, adjustedPlayer.y) - slopeZ) <= ZOFFSET6))
-                pPlayer->q16horizoff += fix16_from_int(mulscale16(trueFloorZ - slopeZ, 160));
-        }
-    }
-
-    if (pPlayer->q16horizoff > 0)
-    {
-        pPlayer->q16horizoff -= ((pPlayer->q16horizoff >> 3) + fix16_one);
-        pPlayer->q16horizoff = max(pPlayer->q16horizoff, 0);
-    }
-    else if (pPlayer->q16horizoff < 0)
-    {
-        pPlayer->q16horizoff += (((-pPlayer->q16horizoff) >> 3) + fix16_one);
-        pPlayer->q16horizoff = min(pPlayer->q16horizoff, 0);
-    }
 
     if ((highZhit & 49152) == 49152)
     {
@@ -4934,7 +4981,7 @@ void P_ProcessInput(int playerNum)
         pPlayer->one_eighty_count += 128;
         pPlayer->q16ang += F16(128);
     }
-
+    
     // Shrinking code
 
     if (sectorLotag == ST_2_UNDERWATER)
@@ -5078,7 +5125,9 @@ void P_ProcessInput(int playerNum)
 
             if ((sectorLotag != ST_1_ABOVE_WATER && sectorLotag != ST_2_UNDERWATER) &&
                 (pPlayer->on_ground == 0 && pPlayer->vel.z > (ACTOR_MAXFALLINGZVEL >> 1)))
-                pPlayer->hard_landing = pPlayer->vel.z>>10;
+            {
+                pPlayer->hard_landing = pPlayer->vel.z >> 10;
+            }
 
             pPlayer->on_ground = 1;
 
@@ -5191,16 +5240,8 @@ void P_ProcessInput(int playerNum)
         pPlayer->vel.x   = 0;
         pPlayer->vel.y   = 0;
     }
-    else if (g_player[playerNum].input->q16avel)            //p->ang += syncangvel * constant
-    {
-        fix16_t const inputAng  = g_player[playerNum].input->q16avel;
-
-        pPlayer->q16angvel     = (sectorLotag == ST_2_UNDERWATER) ? fix16_mul(inputAng - (inputAng >> 3), fix16_from_int(ksgn(velocityModifier)))
-                                                               : fix16_mul(inputAng, fix16_from_int(ksgn(velocityModifier)));
-        pPlayer->q16ang       += pPlayer->q16angvel;
-        pPlayer->q16ang       &= 0x7FFFFFF;
+    else if (g_player[playerNum].input->q16avel)
         pPlayer->crack_time = PCRACKTIME;
-    }
 
     if (pPlayer->spritebridge == 0)
     {
@@ -5467,24 +5508,22 @@ RECHECK:
             G_ActivateBySector(pPlayer->cursectnum, pPlayer->i);
     }
 
-    int centerHoriz = 0;
+    if (pPlayer->return_to_center > 0)
+    {
+        pPlayer->return_to_center--;
+        g_horizRecenter = true;
+    }
 
     if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
-        if (VM_OnEvent(EVENT_RETURNTOCENTER,pPlayer->i,playerNum) == 0)
+        if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
             pPlayer->return_to_center = 9;
-
-    // A horiz diff of 128 equal 45 degrees,
-    // so we convert horiz to 1024 angle units
-
-    float horizAngle = atan2f(pPlayer->q16horiz - F16(100), F16(128)) * (512.f / fPI) + fix16_to_float(g_player[playerNum].input->q16horz);
 
     if (TEST_SYNC_KEY(playerBits, SK_LOOK_UP))
     {
         if (VM_OnEvent(EVENT_LOOKUP,pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
-            horizAngle += float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
-            centerHoriz++;
+            g_horizAngleAdjust = float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
         }
     }
 
@@ -5493,8 +5532,7 @@ RECHECK:
         if (VM_OnEvent(EVENT_LOOKDOWN,pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
-            horizAngle -= float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
-            centerHoriz++;
+            g_horizAngleAdjust = -float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
         }
     }
 
@@ -5502,8 +5540,8 @@ RECHECK:
     {
         if (VM_OnEvent(EVENT_AIMUP,pPlayer->i,playerNum) == 0)
         {
-            horizAngle += float(6<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
-            centerHoriz++;
+            g_horizAngleAdjust = float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
+            g_horizRecenter    = false;
         }
     }
 
@@ -5511,34 +5549,16 @@ RECHECK:
     {
         if (VM_OnEvent(EVENT_AIMDOWN,pPlayer->i,playerNum) == 0)
         {
-            horizAngle -= float(6<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
-            centerHoriz++;
+            g_horizAngleAdjust = -float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
+            g_horizRecenter    = false;
         }
-    }
-
-    horizAngle = clamp(horizAngle, -255.f, 255.f);  // keep the angle within ]-90°..90°[
-    pPlayer->q16horiz = F16(100) + Blrintf(F16(128) * tanf(horizAngle * (fPI / 512.f)));
-
-    if (pPlayer->return_to_center > 0 && !TEST_SYNC_KEY(playerBits, SK_LOOK_UP) && !TEST_SYNC_KEY(playerBits, SK_LOOK_DOWN))
-    {
-        pPlayer->return_to_center--;
-        pPlayer->q16horiz += F16(33)-fix16_div(pPlayer->q16horiz, F16(3));
-        centerHoriz++;
     }
 
     if (pPlayer->hard_landing > 0)
     {
+        g_horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
         pPlayer->hard_landing--;
-        pPlayer->q16horiz -= fix16_from_int(pPlayer->hard_landing<<4);
     }
-
-    if (centerHoriz)
-    {
-        if (pPlayer->q16horiz > F16(95) && pPlayer->q16horiz < F16(105)) pPlayer->q16horiz = F16(100);
-        if (pPlayer->q16horizoff > F16(-5) && pPlayer->q16horizoff < F16(5)) pPlayer->q16horizoff = 0;
-    }
-
-    pPlayer->q16horiz = fix16_clamp(pPlayer->q16horiz, F16(HORIZ_MIN), F16(HORIZ_MAX));
 
     //Shooting code/changes
 
@@ -5565,7 +5585,7 @@ RECHECK:
 #ifndef EDUKE32_STANDALONE
     if (!FURY && pPlayer->knee_incs > 0)
     {
-        pPlayer->q16horiz -= F16(48);
+        g_horizSkew = F16(-48);
         pPlayer->return_to_center = 9;
 
         if (++pPlayer->knee_incs > 15)

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -2891,15 +2891,32 @@ enddisplayweapon:
 
 int32_t mouseyaxismode = -1;
 
+enum inputlock_t
+{
+    IL_NOANGLE = 0x1,
+    IL_NOHORIZ = 0x2,
+    IL_NOMOVE  = 0x4,
+
+    IL_NOTHING = IL_NOANGLE|IL_NOHORIZ|IL_NOMOVE,
+};
+
 static int P_CheckLockedMovement(int const playerNum)
 {
     auto const pPlayer = g_player[playerNum].ps;
 
-    if (pPlayer->on_crane >= 0) return 2;
+    if (pPlayer->on_crane >= 0)
+        return IL_NOMOVE|IL_NOANGLE;
 
-    return (pPlayer->dead_flag || pPlayer->fist_incs || pPlayer->transporter_hold > 2 || pPlayer->hard_landing || pPlayer->access_incs > 0 || pPlayer->knee_incs > 0
-            || (PWEAPON(playerNum, pPlayer->curr_weapon, WorksLike) == TRIPBOMB_WEAPON && pPlayer->kickback_pic > 1
-                && pPlayer->kickback_pic < PWEAPON(playerNum, pPlayer->curr_weapon, FireDelay)));
+    if (pPlayer->newowner != -1)
+        return IL_NOANGLE|IL_NOHORIZ;
+
+    if (pPlayer->dead_flag || pPlayer->fist_incs || pPlayer->transporter_hold > 2 || pPlayer->hard_landing || pPlayer->access_incs > 0
+        || pPlayer->knee_incs > 0
+        || (PWEAPON(playerNum, pPlayer->curr_weapon, WorksLike) == TRIPBOMB_WEAPON && pPlayer->kickback_pic > 1
+            && pPlayer->kickback_pic < PWEAPON(playerNum, pPlayer->curr_weapon, FireDelay)))
+        return IL_NOTHING;
+
+    return 0;
 }
 
 void P_GetInput(int const playerNum)
@@ -3126,7 +3143,7 @@ void P_GetInput(int const playerNum)
 
     int const movementLocked = P_CheckLockedMovement(playerNum);
 
-    if ((ud.scrollmode && ud.overhead_on) || movementLocked == 1)
+    if ((ud.scrollmode && ud.overhead_on) || (movementLocked & IL_NOTHING) == IL_NOTHING)
     {
         if (ud.scrollmode && ud.overhead_on)
         {
@@ -3134,26 +3151,28 @@ void P_GetInput(int const playerNum)
             ud.folavel = fix16_to_int(input.q16avel);
         }
 
-        localInput.fvel = 0;
-        localInput.svel = 0;
-
-        localInput.q16avel = 0;
-        localInput.q16horz = 0;
+        localInput.fvel = localInput.svel = 0;
+        localInput.q16avel = localInput.q16horz = 0;
     }
     else
     {
-        if (movementLocked != 2)
+        if (!(movementLocked & IL_NOMOVE))
         {
-            localInput.q16avel = fix16_sadd(localInput.q16avel, input.q16avel);
-            localInput.fvel    = clamp(localInput.fvel + input.fvel, -MAXVEL, MAXVEL);
-            localInput.svel    = clamp(localInput.svel + input.svel, -MAXSVEL, MAXSVEL);
-
-            pPlayer->q16ang = fix16_sadd(pPlayer->q16ang, input.q16avel);
-            pPlayer->q16ang &= 0x7FFFFFF;
+            localInput.fvel = clamp(localInput.fvel + input.fvel, -MAXVEL, MAXVEL);
+            localInput.svel = clamp(localInput.svel + input.svel, -MAXSVEL, MAXSVEL);
         }
 
-        localInput.q16horz = fix16_clamp(fix16_sadd(localInput.q16horz, input.q16horz), F16(-MAXHORIZVEL), F16(MAXHORIZVEL));
-        pPlayer->q16horiz = fix16_clamp(fix16_sadd(pPlayer->q16horiz, input.q16horz), F16(HORIZ_MIN), F16(HORIZ_MAX));
+        if (!(movementLocked & IL_NOANGLE))
+        {
+            localInput.q16avel = fix16_sadd(localInput.q16avel, input.q16avel);
+            pPlayer->q16ang    = fix16_sadd(pPlayer->q16ang, input.q16avel) & 0x7FFFFFF;
+        }
+
+        if (!(movementLocked & IL_NOHORIZ))
+        {
+            localInput.q16horz = fix16_clamp(fix16_sadd(localInput.q16horz, input.q16horz), F16(-MAXHORIZVEL), F16(MAXHORIZVEL));
+            pPlayer->q16horiz  = fix16_clamp(fix16_sadd(pPlayer->q16horiz, input.q16horz), F16(HORIZ_MIN), F16(HORIZ_MAX));
+        }
     }
 
     // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
@@ -5236,7 +5255,7 @@ void P_ProcessInput(int playerNum)
         }
     }
 
-    if (P_CheckLockedMovement(playerNum))
+    if (P_CheckLockedMovement(playerNum) & IL_NOMOVE)
     {
         velocityModifier = 0;
         pPlayer->vel.x   = 0;

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -2954,18 +2954,18 @@ void P_GetInput(int const playerNum)
     }
     else
     {
-        input.q16avel += fix16_div(fix16_from_int(info.mousex), F16(32));
-        input.q16avel += fix16_from_int(info.dyaw) / analogExtent * (analogTurnAmount << 1);
+        input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
+        input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw / analogExtent * (analogTurnAmount << 1)));
     }
 
     if (mouseaim)
-        input.q16horz += fix16_div(fix16_from_int(info.mousey), F16(64));
+        input.q16horz = fix16_sadd(input.q16horz, fix16_sdiv(fix16_from_int(info.mousey), F16(64)));
     else
         input.fvel = -(info.mousey >> 3);
 
     if (!in_mouseflip) input.q16horz = -input.q16horz;
 
-    input.q16horz -= fix16_from_int(info.dpitch) / analogExtent * analogTurnAmount;
+    input.q16horz = fix16_ssub(input.q16horz, fix16_from_int(info.dpitch * analogTurnAmount / analogExtent));
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;
 
@@ -2999,12 +2999,12 @@ void P_GetInput(int const playerNum)
         if (buttonMap.ButtonDown(gamefunc_Turn_Left))
         {
             turnHeldTime += elapsedTics;
-            input.q16avel -= fix16_from_float(scaleAdjustmentToInterval((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1)));
+            input.q16avel = fix16_ssub(input.q16avel, fix16_from_float(scaleAdjustmentToInterval((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1))));
         }
         else if (buttonMap.ButtonDown(gamefunc_Turn_Right))
         {
             turnHeldTime += elapsedTics;
-            input.q16avel += fix16_from_float(scaleAdjustmentToInterval((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1)));
+            input.q16avel = fix16_sadd(input.q16avel, fix16_from_float(scaleAdjustmentToInterval((turnHeldTime >= TURBOTURNTIME) ? (turnAmount << 1) : (PREAMBLETURN << 1))));
         }
         else
             turnHeldTime = 0;
@@ -3140,15 +3140,15 @@ void P_GetInput(int const playerNum)
     }
     else
     {
-        localInput.q16avel = fix16_add(localInput.q16avel, input.q16avel);
-        localInput.q16horz = fix16_clamp(fix16_add(localInput.q16horz, input.q16horz), F16(-MAXHORIZVEL), F16(MAXHORIZVEL));
+        localInput.q16avel = fix16_sadd(localInput.q16avel, input.q16avel);
+        localInput.q16horz = fix16_clamp(fix16_sadd(localInput.q16horz, input.q16horz), F16(-MAXHORIZVEL), F16(MAXHORIZVEL));
         localInput.fvel    = clamp(localInput.fvel + input.fvel, -MAXVEL, MAXVEL);
         localInput.svel    = clamp(localInput.svel + input.svel, -MAXSVEL, MAXSVEL);
 
-        pPlayer->q16ang = fix16_add(pPlayer->q16ang, input.q16avel);
+        pPlayer->q16ang = fix16_sadd(pPlayer->q16ang, input.q16avel);
         pPlayer->q16ang &= 0x7FFFFFF;
 
-        pPlayer->q16horiz = fix16_clamp(fix16_add(pPlayer->q16horiz, input.q16horz), F16(HORIZ_MIN), F16(HORIZ_MAX));
+        pPlayer->q16horiz = fix16_clamp(fix16_sadd(pPlayer->q16horiz, input.q16horz), F16(HORIZ_MIN), F16(HORIZ_MAX));
     }
 
     // A horiz diff of 128 equal 45 degrees,
@@ -3162,7 +3162,7 @@ void P_GetInput(int const playerNum)
     }
     else if (pPlayer->return_to_center > 0 || g_horizRecenter)
     {
-        pPlayer->q16horiz += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(F16(66.666) - fix16_div(pPlayer->q16horiz, F16(1.5)))));
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(F16(66.666) - fix16_sdiv(pPlayer->q16horiz, F16(1.5))))));
 
         if ((!pPlayer->return_to_center && g_horizRecenter) || (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1)))
         {
@@ -3188,23 +3188,23 @@ void P_GetInput(int const playerNum)
         {
             int const slopeZ = getflorzofslope(pPlayer->cursectnum, adjustedPosition.x, adjustedPosition.y);
             if ((pPlayer->cursectnum == currentSector) || (klabs(getflorzofslope(currentSector, adjustedPosition.x, adjustedPosition.y) - slopeZ) <= ZOFFSET6))
-                pPlayer->q16horizoff += fix16_from_float(scaleAdjustmentToInterval(mulscale16(pPlayer->truefz - slopeZ, 160)));
+                pPlayer->q16horizoff = fix16_sadd(pPlayer->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(mulscale16(pPlayer->truefz - slopeZ, 160))));
         }
     }
 
     if (pPlayer->q16horizoff > 0)
     {
-        pPlayer->q16horizoff -= fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((pPlayer->q16horizoff >> 3) + fix16_one)));
+        pPlayer->q16horizoff = fix16_ssub(pPlayer->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((pPlayer->q16horizoff >> 3) + fix16_one))));
         pPlayer->q16horizoff = fix16_max(pPlayer->q16horizoff, 0);
     }
     else if (pPlayer->q16horizoff < 0)
     {
-        pPlayer->q16horizoff += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((-pPlayer->q16horizoff >> 3) + fix16_one)));
+        pPlayer->q16horizoff = fix16_sadd(pPlayer->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((-pPlayer->q16horizoff >> 3) + fix16_one))));
         pPlayer->q16horizoff = fix16_min(pPlayer->q16horizoff, 0);
     }
 
     if (g_horizSkew)
-        pPlayer->q16horiz += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(g_horizSkew)));
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(g_horizSkew))));
 
     pPlayer->q16horiz = fix16_clamp(pPlayer->q16horiz, F16(HORIZ_MIN), F16(HORIZ_MAX));
 }

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3162,12 +3162,12 @@ void P_GetInput(int const playerNum)
     }
     else if (pPlayer->return_to_center > 0 || g_horizRecenter)
     {
-        pPlayer->q16horiz += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(F16(33) - fix16_div(pPlayer->q16horiz, F16(3)))));
+        pPlayer->q16horiz += fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(F16(66.666) - fix16_div(pPlayer->q16horiz, F16(1.5)))));
 
-        if (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1))
+        if ((!pPlayer->return_to_center && g_horizRecenter) || (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1)))
         {
             pPlayer->q16horiz = F16(100);
-            g_horizRecenter   = 0;
+            g_horizRecenter   = false;
         }
 
         if (pPlayer->q16horizoff >= F16(-0.1) && pPlayer->q16horizoff <= F16(0.1))
@@ -5509,10 +5509,7 @@ RECHECK:
     }
 
     if (pPlayer->return_to_center > 0)
-    {
         pPlayer->return_to_center--;
-        g_horizRecenter = true;
-    }
 
     if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
         if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
@@ -5523,6 +5520,7 @@ RECHECK:
         if (VM_OnEvent(EVENT_LOOKUP,pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
+            g_horizRecenter = true;
             g_horizAngleAdjust = float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
         }
     }
@@ -5532,6 +5530,7 @@ RECHECK:
         if (VM_OnEvent(EVENT_LOOKDOWN,pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
+            g_horizRecenter = true;
             g_horizAngleAdjust = -float(12<<(int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
         }
     }
@@ -5586,6 +5585,7 @@ RECHECK:
     if (!FURY && pPlayer->knee_incs > 0)
     {
         g_horizSkew = F16(-48);
+        g_horizRecenter = true;
         pPlayer->return_to_center = 9;
 
         if (++pPlayer->knee_incs > 15)

--- a/source/duke3d/src/player.h
+++ b/source/duke3d/src/player.h
@@ -208,9 +208,14 @@ typedef struct {
 } DukePlayer_t;
 
 // KEEPINSYNC lunatic/_defs_game.lua
-typedef struct {
+typedef struct
+{
     DukePlayer_t *ps;
     input_t *input;
+
+    bool    horizRecenter;
+    float   horizAngleAdjust;
+    fix16_t horizSkew;
 
     int32_t netsynctime;
     int16_t ping, filler;


### PR DESCRIPTION
OK, third time's the charm...

Been familiarising myself with git and with a powerful combination of git, SVN and Sublime Merge, I've been able to properly cherry-pick commits, edit accordingly and preserve proper credits for the originating code.

These commits, cherry-picked and adjusted to suit Raze really improve input response for the mouse. The game with these commits feels 1:1 with GZDoom, yquake2 etc and I think truly improves the experience.