### PR TITLE
Repair HUD scaling returning to 100% when relaunching Duke or RR games.

### DIFF
--- a/source/common/gamecvars.cpp
+++ b/source/common/gamecvars.cpp
@@ -179,7 +179,7 @@ CUSTOM_CVARD(Int, hud_scale, 100, CVAR_ARCHIVE | CVAR_NOINITCALL, "changes the h
 {
 	if (self < 35) self = 35;
 	else if (self > 100) self = 100;
-	else gi->set_hud_scale(hud_scale);
+	else gi->set_hud_scale(self);
 }
 
 // This is to allow flattening the overly complicated HUD configuration to one single value and keep the complexity safely inside the HUD code.

--- a/source/duke3d/src/config.cpp
+++ b/source/duke3d/src/config.cpp
@@ -54,7 +54,6 @@ int CONFIG_ReadSetup(void)
     ud.slidebar_paldisabled = 1;
     ud.statusbarflags = 0;//STATUSBAR_NOSHRINK;
     ud.statusbarmode = 1;
-    ud.statusbarscale = 100;
 
     ud.god = 0;
     ud.m_respawn_items = 0;

--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -5650,6 +5650,7 @@ int GameInterface::app_main()
     CONFIG_ReadSetup();
 
     hud_size.Callback();
+    hud_scale.Callback();
     S_InitSound();
 
     

--- a/source/rr/src/config.cpp
+++ b/source/rr/src/config.cpp
@@ -43,7 +43,6 @@ int32_t CONFIG_ReadSetup(void)
 
     ud.screen_tilting = 1;
     ud.statusbarflags = STATUSBAR_NOSHRINK;
-    ud.statusbarscale = 100;
     playerteam = 0;
     ud.angleinterpolation = 0;
 

--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -7163,6 +7163,7 @@ int GameInterface::app_main()
 
 
     hud_size.Callback();
+    hud_scale.Callback();
     S_InitSound();
 
     


### PR DESCRIPTION
- Resolves https://forum.zdoom.org/viewtopic.php?f=340&t=67811

I tried fixing this by shit-canning the entire config.cpp file and call to CONFIG_ReadSetup() but the intro video for Duke 3D played at full framerate rather than 13fps and it's not obvious why.

EDIT: Alternatively, can the cvar have 'CVAR_NOINITCALL' removed to avoid using Callback()? I chose this route as I assumed the cvar is meant to be like this and I didn't know the overall impact for other games, etc.