### PR TITLE
All games weapon selection workaround

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -144,13 +144,13 @@ void ctrlGetInput(void)
         cl_crosshair = !cl_crosshair;
     }
 
-    if (buttonMap.ButtonDown(gamefunc_Next_Weapon))
+    if (buttonMap.ButtonPressed(gamefunc_Next_Weapon))
     {
         buttonMap.ClearButton(gamefunc_Next_Weapon);
         gInput.keyFlags.nextWeapon = 1;
     }
 
-    if (buttonMap.ButtonDown(gamefunc_Previous_Weapon))
+    if (buttonMap.ButtonPressed(gamefunc_Previous_Weapon))
     {
         buttonMap.ClearButton(gamefunc_Previous_Weapon);
         gInput.keyFlags.prevWeapon = 1;

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3061,10 +3061,16 @@ void P_GetInput(int const playerNum)
         weaponSelection = 14;
     else if (buttonMap.ButtonDown(gamefunc_Alt_Weapon))
         weaponSelection = 13;
-    else if (buttonMap.ButtonDown(gamefunc_Next_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel > 0))
+    else if (buttonMap.ButtonPressed(gamefunc_Next_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel > 0))
+    {
         weaponSelection = 12;
-    else if (buttonMap.ButtonDown(gamefunc_Previous_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel < 0))
+        buttonMap.ClearButton(gamefunc_Next_Weapon);
+    }
+    else if (buttonMap.ButtonPressed(gamefunc_Previous_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel < 0))
+    {
         weaponSelection = 11;
+        buttonMap.ClearButton(gamefunc_Previous_Weapon);
+    }
     else if (weaponSelection == gamefunc_Weapon_1-1)
         weaponSelection = 0;
 

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3383,10 +3383,16 @@ void P_GetInput(int const playerNum)
         weaponSelection = 14;
     else if (buttonMap.ButtonDown(gamefunc_Alt_Weapon))
         weaponSelection = 13;
-    else if (buttonMap.ButtonDown(gamefunc_Next_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel > 0))
+    else if (buttonMap.ButtonPressed(gamefunc_Next_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel > 0))
+    {
         weaponSelection = 12;
-    else if (buttonMap.ButtonDown(gamefunc_Previous_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel < 0))
+        buttonMap.ClearButton(gamefunc_Next_Weapon);
+    }
+    else if (buttonMap.ButtonPressed(gamefunc_Previous_Weapon) || (buttonMap.ButtonDown(gamefunc_Dpad_Select) && input.fvel < 0))
+    {
         weaponSelection = 11;
+        buttonMap.ClearButton(gamefunc_Previous_Weapon);
+    }
     else if (weaponSelection == gamefunc_Weapon_1-1)
         weaponSelection = 0;
 

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -3256,7 +3256,7 @@ void getinput(SW_PACKET *loc)
         }
     }
 
-    if (buttonMap.ButtonDown(gamefunc_Next_Weapon))
+    if (buttonMap.ButtonPressed(gamefunc_Next_Weapon))
     {
         USERp u = User[pp->PlayerSprite];
         short next_weapon = u->WeaponNum + 1;
@@ -3296,7 +3296,7 @@ void getinput(SW_PACKET *loc)
     }
 
 
-    if (buttonMap.ButtonDown(gamefunc_Previous_Weapon))
+    if (buttonMap.ButtonPressed(gamefunc_Previous_Weapon))
     {
         USERp u = User[pp->PlayerSprite];
         short prev_weapon = u->WeaponNum - 1;


### PR DESCRIPTION
It was reported [here](https://forum.zdoom.org/viewtopic.php?f=340&t=67232#p1142970) that after changing the input for Duke 3D and RR that it was still not working on Linux.

Did some testing and changing the button event to ButtonPressed, then ClearButton made this work on Linux, while still working on Windows.

Blood and SW had a similar ClearButton remark which Duke 3D and RR never had, but while SW was working in Windows, Blood was not. Changing Blood to ButtonPressed also has the scroll wheel working now.

I don't believe these are true fixes, merely stop-gaps until something better can be done which you've talked about. This also doesn't resolve issues users might face if they elect to use the scroll wheel for anything other than weapon selection.