### PR TITLE
SW: Get PLAYER_TURN_SCALE to be just right.

### DIFF
--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -98,7 +98,7 @@ SWBOOL NightVision = FALSE;
 extern SWBOOL FinishedLevel;
 
 //#define PLAYER_TURN_SCALE (8)
-#define PLAYER_TURN_SCALE (2)
+#define PLAYER_TURN_SCALE 2.4f
 
 // the smaller the number the slower the going
 #define PLAYER_RUN_FRICTION (50000L)
@@ -1595,7 +1595,7 @@ DoPlayerTurn(PLAYERp pp)
             return;
     }
 
-    angvel = fix16_smul(pp->input.q16avel, fix16_from_int(PLAYER_TURN_SCALE));
+    angvel = fix16_smul(pp->input.q16avel, fix16_from_float(PLAYER_TURN_SCALE));
 
     if (angvel != 0)
     {
@@ -1637,7 +1637,7 @@ DoPlayerTurnBoat(PLAYERp pp)
     }
     else
     {
-        angvel = fix16_smul(pp->input.q16avel, fix16_from_int(PLAYER_TURN_SCALE));
+        angvel = fix16_smul(pp->input.q16avel, fix16_from_float(PLAYER_TURN_SCALE));
         angvel = fix16_sadd(angvel, fix16_ssub(angvel, fix16_sdiv(angvel, fix16_from_int(4))));
         angvel = fix16_sdiv(fix16_smul(angvel, fix16_from_int(synctics)), fix16_from_int(32));
     }


### PR DESCRIPTION
- Original value was 12 and was far, far too high following the Q16.16 implementation.
- Value of 3 is too fast.
- Value of 2 is too slow.
- Value of 2.4 (12 / 5) feels just right.

If it's too late for the release, it's too late. Apologies but I was just a but unsettled on this. So hard to get all this hard-coded shit just right.

Axis scaling is such a personal thing but I want the game to feel 1:1 with Duke 3D with:
- Mouse sensitivity at '1'.
- in_mousescalex at '1'.
- in_mousescaley at '1'.

I think it does now.