### PR TITLE
Blood: Rebalance q16mlook.

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -349,7 +349,7 @@ void ctrlGetInput(void)
     if (buttonMap.ButtonDown(gamefunc_Strafe))
         input.strafe -= info.mousex;
     else
-        input.q16turn = fix16_sadd(input.q16turn, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
+        input.q16turn = fix16_sadd(input.q16turn, fix16_sdiv(fix16_from_int(info.mousex), fix16_from_int(32)));
 
     input.strafe -= -(info.dx<<5);
 
@@ -360,7 +360,7 @@ void ctrlGetInput(void)
         gInput.mlook = ClipRange(info.dz>>7, -127, 127);
 #endif
     if (mouseaim)
-        input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(info.mousey), F16(128)));
+        input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(info.mousey), fix16_from_int(208)));
     else
         input.forward -= info.mousey;
     if (!in_mouseflip)
@@ -384,26 +384,26 @@ void ctrlGetInput(void)
     gInput.forward = clamp(gInput.forward + input.forward, -2048, 2048);
     gInput.strafe = clamp(gInput.strafe + input.strafe, -2048, 2048);
     gInput.q16turn = fix16_sadd(gInput.q16turn, input.q16turn);
-    gInput.q16mlook = fix16_clamp(fix16_sadd(gInput.q16mlook, input.q16mlook), F16(-127)>>2, F16(127)>>2);
+    gInput.q16mlook = fix16_clamp(fix16_sadd(gInput.q16mlook, input.q16mlook), fix16_from_int(-127)>>2, fix16_from_int(127)>>2);
     if (gMe && gMe->pXSprite->health != 0 && !gPaused)
     {
-        CONSTEXPR int upAngle = 289;
-        CONSTEXPR int downAngle = -347;
-        CONSTEXPR double lookStepUp = 4.0*upAngle/60.0;
-        CONSTEXPR double lookStepDown = -4.0*downAngle/60.0;
+        constexpr int upAngle = 289;
+        constexpr int downAngle = -347;
+        constexpr double lookStepUp = 4.0*upAngle/60.0;
+        constexpr double lookStepDown = -4.0*downAngle/60.0;
         gViewAngle = (gViewAngle + input.q16turn + fix16_from_float(scaleAdjustmentToInterval(gViewAngleAdjust))) & 0x7ffffff;
         if (gViewLookRecenter)
         {
             if (gViewLook < 0)
-                gViewLook = fix16_min(gViewLook+fix16_from_float(scaleAdjustmentToInterval(lookStepDown)), F16(0));
+                gViewLook = fix16_min(gViewLook+fix16_from_float(scaleAdjustmentToInterval(lookStepDown)), fix16_from_int(0));
             if (gViewLook > 0)
-                gViewLook = fix16_max(gViewLook-fix16_from_float(scaleAdjustmentToInterval(lookStepUp)), F16(0));
+                gViewLook = fix16_max(gViewLook-fix16_from_float(scaleAdjustmentToInterval(lookStepUp)), fix16_from_int(0));
         }
         else
         {
-            gViewLook = fix16_clamp(gViewLook+fix16_from_float(scaleAdjustmentToInterval(gViewLookAdjust)), F16(downAngle), F16(upAngle));
+            gViewLook = fix16_clamp(gViewLook+fix16_from_float(scaleAdjustmentToInterval(gViewLookAdjust)), fix16_from_int(downAngle), fix16_from_int(upAngle));
         }
-        gViewLook = fix16_clamp(gViewLook+(input.q16mlook << 3), F16(downAngle), F16(upAngle));
+        gViewLook = fix16_clamp(gViewLook+(input.q16mlook << 3), fix16_from_int(downAngle), fix16_from_int(upAngle));
     }
 }
 

--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -387,10 +387,10 @@ void ctrlGetInput(void)
     gInput.q16mlook = fix16_clamp(fix16_sadd(gInput.q16mlook, input.q16mlook), fix16_from_int(-127)>>2, fix16_from_int(127)>>2);
     if (gMe && gMe->pXSprite->health != 0 && !gPaused)
     {
-        constexpr int upAngle = 289;
-        constexpr int downAngle = -347;
-        constexpr double lookStepUp = 4.0*upAngle/60.0;
-        constexpr double lookStepDown = -4.0*downAngle/60.0;
+        int upAngle = 289;
+        int downAngle = -347;
+        double lookStepUp = 4.0*upAngle/60.0;
+        double lookStepDown = -4.0*downAngle/60.0;
         gViewAngle = (gViewAngle + input.q16turn + fix16_from_float(scaleAdjustmentToInterval(gViewAngleAdjust))) & 0x7ffffff;
         if (gViewLookRecenter)
         {

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -1204,13 +1204,13 @@ void trPlayerCtrlSetScreenEffect(XSPRITE* pXSource, PLAYER* pPlayer) {
 
 void trPlayerCtrlSetLookAngle(XSPRITE* pXSource, PLAYER* pPlayer) {
     
-    CONSTEXPR int upAngle = 289; CONSTEXPR int downAngle = -347;
-    CONSTEXPR double lookStepUp = 4.0 * upAngle / 60.0;
-    CONSTEXPR double lookStepDown = -4.0 * downAngle / 60.0;
+    constexpr int upAngle = 289; constexpr int downAngle = -347;
+    constexpr double lookStepUp = 4.0 * upAngle / 60.0;
+    constexpr double lookStepDown = -4.0 * downAngle / 60.0;
 
     int look = pXSource->data2 << 5;
-    if (look > 0) pPlayer->q16look = fix16_min(mulscale8(F16(lookStepUp), look), F16(upAngle));
-    else if (look < 0) pPlayer->q16look = -fix16_max(mulscale8(F16(lookStepDown), abs(look)), F16(downAngle));
+    if (look > 0) pPlayer->q16look = fix16_min(mulscale8(fix16_from_dbl(lookStepUp), look), fix16_from_int(upAngle));
+    else if (look < 0) pPlayer->q16look = -fix16_max(mulscale8(fix16_from_dbl(lookStepDown), abs(look)), fix16_from_int(downAngle));
     else pPlayer->q16look = 0;
 
 }

--- a/source/blood/src/nnexts.cpp
+++ b/source/blood/src/nnexts.cpp
@@ -1204,9 +1204,9 @@ void trPlayerCtrlSetScreenEffect(XSPRITE* pXSource, PLAYER* pPlayer) {
 
 void trPlayerCtrlSetLookAngle(XSPRITE* pXSource, PLAYER* pPlayer) {
     
-    constexpr int upAngle = 289; constexpr int downAngle = -347;
-    constexpr double lookStepUp = 4.0 * upAngle / 60.0;
-    constexpr double lookStepDown = -4.0 * downAngle / 60.0;
+    int upAngle = 289; int downAngle = -347;
+    double lookStepUp = 4.0 * upAngle / 60.0;
+    double lookStepDown = -4.0 * downAngle / 60.0;
 
     int look = pXSource->data2 << 5;
     if (look > 0) pPlayer->q16look = fix16_min(mulscale8(fix16_from_dbl(lookStepUp), look), fix16_from_int(upAngle));

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -1335,7 +1335,7 @@ void ProcessInput(PLAYER *pPlayer)
             if (bVanilla)
                 pPlayer->q16horiz = fix16_from_int(mulscale16(0x8000-(Cos(ClipHigh(pPlayer->deathTime*8, 1024))>>15), 120));
             else
-                pPlayer->q16horiz = mulscale16(0x8000-(Cos(ClipHigh(pPlayer->deathTime*8, 1024))>>15), F16(120));
+                pPlayer->q16horiz = mulscale16(0x8000-(Cos(ClipHigh(pPlayer->deathTime*8, 1024))>>15), fix16_from_int(120));
         }
         if (pPlayer->curWeapon)
             pInput->newWeapon = pPlayer->curWeapon;
@@ -1551,20 +1551,20 @@ void ProcessInput(PLAYER *pPlayer)
         if (pInput->keyFlags.lookCenter && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown)
         {
             if (pPlayer->q16look < 0)
-                pPlayer->q16look = fix16_min(pPlayer->q16look+F16(4), F16(0));
+                pPlayer->q16look = fix16_min(pPlayer->q16look+fix16_from_int(4), fix16_from_int(0));
             if (pPlayer->q16look > 0)
-                pPlayer->q16look = fix16_max(pPlayer->q16look-F16(4), F16(0));
+                pPlayer->q16look = fix16_max(pPlayer->q16look-fix16_from_int(4), fix16_from_int(0));
             if (!pPlayer->q16look)
                 pInput->keyFlags.lookCenter = 0;
         }
         else
         {
             if (pInput->buttonFlags.lookUp)
-                pPlayer->q16look = fix16_min(pPlayer->q16look+F16(4), F16(60));
+                pPlayer->q16look = fix16_min(pPlayer->q16look+fix16_from_int(4), fix16_from_int(60));
             if (pInput->buttonFlags.lookDown)
-                pPlayer->q16look = fix16_max(pPlayer->q16look-F16(4), F16(-60));
+                pPlayer->q16look = fix16_max(pPlayer->q16look-fix16_from_int(4), fix16_from_int(-60));
         }
-        pPlayer->q16look = fix16_clamp(pPlayer->q16look+pInput->q16mlook, F16(-60), F16(60));
+        pPlayer->q16look = fix16_clamp(pPlayer->q16look+pInput->q16mlook, fix16_from_int(-60), fix16_from_int(60));
         if (pPlayer->q16look > 0)
             pPlayer->q16horiz = fix16_from_int(mulscale30(120, Sin(fix16_to_int(pPlayer->q16look)<<3)));
         else if (pPlayer->q16look < 0)
@@ -1574,25 +1574,25 @@ void ProcessInput(PLAYER *pPlayer)
     }
     else
     {
-        CONSTEXPR int upAngle = 289;
-        CONSTEXPR int downAngle = -347;
-        CONSTEXPR double lookStepUp = 4.0*upAngle/60.0;
-        CONSTEXPR double lookStepDown = -4.0*downAngle/60.0;
+        constexpr int upAngle = 289;
+        constexpr int downAngle = -347;
+        constexpr double lookStepUp = 4.0*upAngle/60.0;
+        constexpr double lookStepDown = -4.0*downAngle/60.0;
         if (pInput->keyFlags.lookCenter && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown)
         {
             if (pPlayer->q16look < 0)
-                pPlayer->q16look = fix16_min(pPlayer->q16look+F16(lookStepDown), F16(0));
+                pPlayer->q16look = fix16_min(pPlayer->q16look+fix16_from_dbl(lookStepDown), fix16_from_int(0));
             if (pPlayer->q16look > 0)
-                pPlayer->q16look = fix16_max(pPlayer->q16look-F16(lookStepUp), F16(0));
+                pPlayer->q16look = fix16_max(pPlayer->q16look-fix16_from_dbl(lookStepUp), fix16_from_int(0));
             if (!pPlayer->q16look)
                 pInput->keyFlags.lookCenter = 0;
         }
         else
         {
             if (pInput->buttonFlags.lookUp)
-                pPlayer->q16look = fix16_min(pPlayer->q16look+F16(lookStepUp), F16(upAngle));
+                pPlayer->q16look = fix16_min(pPlayer->q16look+fix16_from_dbl(lookStepUp), fix16_from_int(upAngle));
             if (pInput->buttonFlags.lookDown)
-                pPlayer->q16look = fix16_max(pPlayer->q16look-F16(lookStepDown), F16(downAngle));
+                pPlayer->q16look = fix16_max(pPlayer->q16look-fix16_from_dbl(lookStepDown), fix16_from_int(downAngle));
         }
         if (pPlayer == gMe && numplayers == 1)
         {
@@ -1606,7 +1606,7 @@ void ProcessInput(PLAYER *pPlayer)
             }
             gViewLookRecenter = pInput->keyFlags.lookCenter && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown;
         }
-        pPlayer->q16look = fix16_clamp(pPlayer->q16look+(pInput->q16mlook<<3), F16(downAngle), F16(upAngle));
+        pPlayer->q16look = fix16_clamp(pPlayer->q16look+(pInput->q16mlook<<3), fix16_from_int(downAngle), fix16_from_int(upAngle));
         pPlayer->q16horiz = fix16_from_float(100.f*tanf(fix16_to_float(pPlayer->q16look)*fPI/1024.f));
     }
     int nSector = pSprite->sectnum;
@@ -1631,7 +1631,7 @@ void ProcessInput(PLAYER *pPlayer)
     }
     else
     {
-        pPlayer->q16slopehoriz = interpolate(pPlayer->q16slopehoriz, F16(0), 0x4000);
+        pPlayer->q16slopehoriz = interpolate(pPlayer->q16slopehoriz, fix16_from_int(0), 0x4000);
         if (klabs(pPlayer->q16slopehoriz) < 4)
             pPlayer->q16slopehoriz = 0;
     }

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -1574,10 +1574,10 @@ void ProcessInput(PLAYER *pPlayer)
     }
     else
     {
-        constexpr int upAngle = 289;
-        constexpr int downAngle = -347;
-        constexpr double lookStepUp = 4.0*upAngle/60.0;
-        constexpr double lookStepDown = -4.0*downAngle/60.0;
+        int upAngle = 289;
+        int downAngle = -347;
+        double lookStepUp = 4.0*upAngle/60.0;
+        double lookStepDown = -4.0*downAngle/60.0;
         if (pInput->keyFlags.lookCenter && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown)
         {
             if (pPlayer->q16look < 0)

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -456,10 +456,10 @@ void fakeProcessInput(PLAYER *pPlayer, GINPUT *pInput)
     else
         predict.at24 = 0;
 #endif
-    constexpr int upAngle = 289;
-    constexpr int downAngle = -347;
-    constexpr double lookStepUp = 4.0*upAngle/60.0;
-    constexpr double lookStepDown = -4.0*downAngle/60.0;
+    int upAngle = 289;
+    int downAngle = -347;
+    double lookStepUp = 4.0*upAngle/60.0;
+    double lookStepDown = -4.0*downAngle/60.0;
     if (predict.at6e && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown)
     {
         if (predict.at20 < 0)
@@ -3189,8 +3189,8 @@ void viewDrawScreen(bool sceneonly)
         }
         if (gView == gMe && (numplayers <= 1 || gPrediction) && gView->pXSprite->health != 0 && !VanillaMode())
         {
-            constexpr int upAngle = 289;
-            constexpr int downAngle = -347;
+            int upAngle = 289;
+            int downAngle = -347;
             fix16_t q16look;
             cA = gViewAngle;
             q16look = gViewLook;

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -434,47 +434,47 @@ void fakeProcessInput(PLAYER *pPlayer, GINPUT *pInput)
     if (predict.at6e && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown)
     {
         if (predict.at20 < 0)
-            predict.at20 = fix16_min(predict.at20+F16(4), F16(0));
+            predict.at20 = fix16_min(predict.at20+fix16_from_int(4), fix16_from_int(0));
         if (predict.at20 > 0)
-            predict.at20 = fix16_max(predict.at20-F16(4), F16(0));
+            predict.at20 = fix16_max(predict.at20-fix16_from_int(4), fix16_from_int(0));
         if (predict.at20 == 0)
             predict.at6e = 0;
     }
     else
     {
         if (pInput->buttonFlags.lookUp)
-            predict.at20 = fix16_min(predict.at20+F16(4), F16(60));
+            predict.at20 = fix16_min(predict.at20+fix16_from_int(4), fix16_from_int(60));
         if (pInput->buttonFlags.lookDown)
-            predict.at20 = fix16_max(predict.at20-F16(4), F16(-60));
+            predict.at20 = fix16_max(predict.at20-fix16_from_int(4), fix16_from_int(-60));
     }
-    predict.at20 = fix16_clamp(predict.at20+pInput->q16mlook, F16(-60), F16(60));
+    predict.at20 = fix16_clamp(predict.at20+pInput->q16mlook, fix16_from_int(-60), fix16_from_int(60));
 
     if (predict.at20 > 0)
-        predict.at24 = mulscale30(F16(120), Sin(fix16_to_int(predict.at20<<3)));
+        predict.at24 = mulscale30(fix16_from_int(120), Sin(fix16_to_int(predict.at20<<3)));
     else if (predict.at20 < 0)
-        predict.at24 = mulscale30(F16(180), Sin(fix16_to_int(predict.at20<<3)));
+        predict.at24 = mulscale30(fix16_from_int(180), Sin(fix16_to_int(predict.at20<<3)));
     else
         predict.at24 = 0;
 #endif
-    CONSTEXPR int upAngle = 289;
-    CONSTEXPR int downAngle = -347;
-    CONSTEXPR double lookStepUp = 4.0*upAngle/60.0;
-    CONSTEXPR double lookStepDown = -4.0*downAngle/60.0;
+    constexpr int upAngle = 289;
+    constexpr int downAngle = -347;
+    constexpr double lookStepUp = 4.0*upAngle/60.0;
+    constexpr double lookStepDown = -4.0*downAngle/60.0;
     if (predict.at6e && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown)
     {
         if (predict.at20 < 0)
-            predict.at20 = fix16_min(predict.at20+F16(lookStepDown), F16(0));
+            predict.at20 = fix16_min(predict.at20+fix16_from_dbl(lookStepDown), fix16_from_int(0));
         if (predict.at20 > 0)
-            predict.at20 = fix16_max(predict.at20-F16(lookStepUp), F16(0));
+            predict.at20 = fix16_max(predict.at20-fix16_from_dbl(lookStepUp), fix16_from_int(0));
         if (predict.at20 == 0)
             predict.at6e = 0;
     }
     else
     {
         if (pInput->buttonFlags.lookUp)
-            predict.at20 = fix16_min(predict.at20+F16(lookStepUp), F16(upAngle));
+            predict.at20 = fix16_min(predict.at20+fix16_from_dbl(lookStepUp), fix16_from_int(upAngle));
         if (pInput->buttonFlags.lookDown)
-            predict.at20 = fix16_max(predict.at20-F16(lookStepDown), F16(downAngle));
+            predict.at20 = fix16_max(predict.at20-fix16_from_dbl(lookStepDown), fix16_from_int(downAngle));
     }
     if (numplayers > 1 && gPrediction)
     {
@@ -488,7 +488,7 @@ void fakeProcessInput(PLAYER *pPlayer, GINPUT *pInput)
         }
         gViewLookRecenter = predict.at6e && !pInput->buttonFlags.lookUp && !pInput->buttonFlags.lookDown;
     }
-    predict.at20 = fix16_clamp(predict.at20+(pInput->q16mlook<<3), F16(downAngle), F16(upAngle));
+    predict.at20 = fix16_clamp(predict.at20+(pInput->q16mlook<<3), fix16_from_int(downAngle), fix16_from_int(upAngle));
     predict.at24 = fix16_from_float(100.f*tanf(fix16_to_float(predict.at20)*fPI/1024.f));
 
     int nSector = predict.at68;
@@ -3189,8 +3189,8 @@ void viewDrawScreen(bool sceneonly)
         }
         if (gView == gMe && (numplayers <= 1 || gPrediction) && gView->pXSprite->health != 0 && !VanillaMode())
         {
-            CONSTEXPR int upAngle = 289;
-            CONSTEXPR int downAngle = -347;
+            constexpr int upAngle = 289;
+            constexpr int downAngle = -347;
             fix16_t q16look;
             cA = gViewAngle;
             q16look = gViewLook;
@@ -3383,7 +3383,7 @@ void viewDrawScreen(bool sceneonly)
         {
             cZ = vfc + (gLowerLink[nSectnum] >= 0 ? 0 : (8 << 8));
         }
-        q16horiz = ClipRange(q16horiz, F16(-200), F16(200));
+        q16horiz = ClipRange(q16horiz, fix16_from_int(-200), fix16_from_int(200));
     RORHACK:
         int ror_status[16];
         for (int i = 0; i < 16; i++)


### PR DESCRIPTION
This one is more subjective, I guess. I think the horizonal scaling is too fast and others on the forums have agreed with me, but I don't know if it's like that to be accurate to the DOS version. Being a Nuke.YKT project, I'd assume so.

I will leave this one in your good hands for consideration.

- Make scaling more consistent with other games.
- Fix CONSTEXPR to constexpr.
- Remove usage of macro 'F16()' by using explicit fix16_from_*() type.