### PR TITLE
SW: Don't process input at frame rate if ScrollMode2D is true.

### DIFF
--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -2574,8 +2574,9 @@ void RunLevel(void)
             }
         }
 
+        if (!ScrollMode2D)
+            getinput(myconnectindex);
 
-        getinput(myconnectindex);
         drawscreen(Player + screenpeek);
 
         if (QuitFlag)
@@ -3087,7 +3088,7 @@ void getinput(int const playerNum)
     // If in 2D follow mode, scroll around.
     if (ScrollMode2D && !Prediction)
     {
-        keymove = keymove / 6;
+        keymove = keymove / 2;
 
         if (M_Active())
             return;


### PR DESCRIPTION
- ScrollMode2D was running at the frame rate, turning off vsync made it unacceptable.