### PR TITLE
SW/Blood: Workaround for map view showing 1px of non-border at the bottom.

### DIFF
--- a/source/blood/src/map2d.cpp
+++ b/source/blood/src/map2d.cpp
@@ -194,7 +194,7 @@ void CViewMap::sub_25C74(void)
         tm = 1;
     }
     // only clear the actual window.
-    twod->AddColorOnlyQuad(windowxy1.x, windowxy1.y, windowxy2.x - windowxy1.x + 1, windowxy2.y - windowxy1.y - 1, 0xff000000);
+    twod->AddColorOnlyQuad(windowxy1.x, windowxy1.y, (windowxy2.x + 1) - windowxy1.x, (windowxy2.y + 1) - windowxy1.y, 0xff000000);
     renderDrawMapView(x,y,nZoom>>2,angle);
     sub_2541C(x,y,nZoom>>2,angle);
     const char *pTitle = levelGetTitle();

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -2205,7 +2205,7 @@ drawscreen(PLAYERp pp)
         if (dimensionmode == 6)
         {
             // only clear the actual window.
-            twod->AddColorOnlyQuad(windowxy1.x, windowxy1.y, windowxy2.x - windowxy1.x, windowxy2.y - windowxy1.y, 0xff000000);
+            twod->AddColorOnlyQuad(windowxy1.x, windowxy1.y, (windowxy2.x + 1) - windowxy1.x, (windowxy2.y + 1) - windowxy1.y, 0xff000000);
             renderDrawMapView(tx, ty, zoom, fix16_to_int(tq16ang));
         }
 


### PR DESCRIPTION
This is to work around [this reported issue](https://forum.zdoom.org/viewtopic.php?f=356&t=67744).

For SW, there's so many janky examples of this throughout the game's code. I thought best to remove the subtractions done in [BorderSetView()](https://github.com/coelckers/Raze/blob/6589d316785c20c940d8d11f2be2608cdf92fc8e/source/sw/src/border.cpp#L401) but I've decided to go the safe route due to comments [like this](https://github.com/coelckers/Raze/blob/6589d316785c20c940d8d11f2be2608cdf92fc8e/source/sw/src/border.cpp#L281).

EDIT: Pushed same fix for Blood.