### PR TITLE
SW minor input refinements

### DIFF
--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -1642,9 +1642,7 @@ void CameraView(PLAYERp pp, int *tx, int *ty, int *tz, short *tsectnum, fix16_t 
                         zvect = 0;
 
                     // new horiz to player
-                    *tq16horiz = fix16_from_int(100 - (zvect/256));
-                    *tq16horiz = fix16_max(*tq16horiz, fix16_from_int(PLAYER_HORIZ_MIN));
-                    *tq16horiz = fix16_min(*tq16horiz, fix16_from_int(PLAYER_HORIZ_MAX));
+                    *tq16horiz = fix16_clamp(fix16_from_int(100 - (zvect/256)), fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
 
                     //DSPRINTF(ds,"xvect %d,yvect %d,zvect %d,tq16horiz %d",xvect,yvect,zvect,*tq16horiz);
                     MONO_PRINT(ds);
@@ -2104,10 +2102,8 @@ drawscreen(PLAYERp pp)
         tz += camerapp->bob_z;
 
         // recoil only when not in camera
-        //tq16horiz = tq16horiz + fix16_from_int(camerapp->recoil_horizoff);
-        tq16horiz = tq16horiz + fix16_from_int(pp->recoil_horizoff);
-        tq16horiz = fix16_max(tq16horiz, fix16_from_int(PLAYER_HORIZ_MIN));
-        tq16horiz = fix16_min(tq16horiz, fix16_from_int(PLAYER_HORIZ_MAX));
+        //tq16horiz = fix16_clamp(fix16_sadd(tq16horiz, fix16_from_int(camerapp->recoil_horizoff)), fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
+        tq16horiz = fix16_clamp(fix16_sadd(tq16horiz, fix16_from_int(pp->recoil_horizoff)), fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
     }
 
     if (r_usenewaspect)

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -2011,8 +2011,18 @@ drawscreen(PLAYERp pp)
     tx = camerapp->oposx + mulscale16(camerapp->posx - camerapp->oposx, smoothratio);
     ty = camerapp->oposy + mulscale16(camerapp->posy - camerapp->oposy, smoothratio);
     tz = camerapp->oposz + mulscale16(camerapp->posz - camerapp->oposz, smoothratio);
-    tq16ang = camerapp->q16ang;
-    tq16horiz = camerapp->q16horiz;
+
+    if (!TEST(pp->Flags, PF_DEAD))
+    {
+        tq16ang = camerapp->q16ang;
+        tq16horiz = camerapp->q16horiz;
+    }
+    else
+    {
+        tq16ang = camerapp->oq16ang + mulscale16(((camerapp->q16ang + fix16_from_int(1024) - camerapp->oq16ang) & 0x7FFFFFF) - fix16_from_int(1024), smoothratio);
+        tq16horiz = camerapp->oq16horiz + mulscale16(camerapp->q16horiz - camerapp->oq16horiz, smoothratio);
+    }
+
     tsectnum = camerapp->cursectnum;
 
     //ASSERT(tsectnum >= 0 && tsectnum <= MAXSECTORS);

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -2979,7 +2979,7 @@ void getinput(int const playerNum)
 #define MAXANGVEL    1024
 #define MAXHORIZVEL  256
 #define HORIZ_SPEED  (16)
-#define TURN_SHIFT   2
+#define TURN_SHIFT   4
 #define SET_LOC_KEY(bits, sync_num, key_test) SET(bits, ((!!(key_test)) << (sync_num)))
 
     static int32_t turnheldtime;
@@ -3255,17 +3255,17 @@ void getinput(int const playerNum)
         {
             if (FLAG_KEY_PRESSED(pp, SK_TURN_180))
             {
-                short delta_ang;
+                fix16_t delta_q16ang;
 
                 FLAG_KEY_RELEASE(pp, SK_TURN_180);
 
-                pp->turn180_target = NORM_ANGLE(fix16_to_int(pp->q16ang) + 1024);
+                pp->turn180_target = fix16_sadd(pp->q16ang, fix16_from_int(1024)) & 0x7FFFFFF;
 
                 // make the first turn in the clockwise direction
                 // the rest will follow
-                delta_ang = GetDeltaAngle(pp->turn180_target, fix16_to_int(pp->q16ang));
+                delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
 
-                pp->q16ang = fix16_sadd(pp->q16ang, fix16_from_float(scaleAdjustmentToInterval(labs(delta_ang) >> TURN_SHIFT))) & 0x7FFFFFF;
+                pp->q16ang = fix16_sadd(pp->q16ang, fix16_max(fix16_one,fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT))))))) & 0x7FFFFFF;
 
                 SET(pp->Flags, PF_TURN_180);
             }
@@ -3278,10 +3278,10 @@ void getinput(int const playerNum)
 
     if (TEST(pp->Flags, PF_TURN_180))
     {
-        short delta_ang;
+        fix16_t delta_q16ang;
 
-        delta_ang = GetDeltaAngle(pp->turn180_target, fix16_to_int(pp->q16ang));
-        pp->q16ang = fix16_sadd(pp->q16ang, fix16_from_float(scaleAdjustmentToInterval(delta_ang >> TURN_SHIFT))) & 0x7FFFFFF;
+        delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
+        pp->q16ang = fix16_sadd(pp->q16ang, fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT)))))) & 0x7FFFFFF;
 
         sprite[pp->PlayerSprite].ang = fix16_to_int(pp->q16ang);
         if (!Prediction)
@@ -3291,11 +3291,11 @@ void getinput(int const playerNum)
         }
 
         // get new delta to see how close we are
-        delta_ang = GetDeltaAngle(pp->turn180_target, fix16_to_int(pp->q16ang));
+        delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
 
-        if (labs(delta_ang) < (3<<TURN_SHIFT))
+        if (fix16_abs(delta_q16ang) < fix16_from_int(3 * TURN_SHIFT))
         {
-            pp->q16ang = fix16_from_int(pp->turn180_target);
+            pp->q16ang = pp->turn180_target;
             RESET(pp->Flags, PF_TURN_180);
         }
         else
@@ -3304,7 +3304,7 @@ void getinput(int const playerNum)
 
     if (input.q16avel != 0)
     {
-       pp->q16ang   = fix16_sadd(pp->q16ang, input.q16avel) & 0x7FFFFFF;
+       pp->q16ang = fix16_sadd(pp->q16ang, input.q16avel) & 0x7FFFFFF;
 
         // update players sprite angle
         // NOTE: It's also updated in UpdatePlayerSprite, but needs to be

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -3269,7 +3269,7 @@ void getinput(int const playerNum)
                         // the rest will follow
                         delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
 
-                        pp->q16ang = fix16_sadd(pp->q16ang, fix16_max(fix16_one,fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT))))))) & 0x7FFFFFF;
+                        pp->q16ang = fix16_sadd(pp->q16ang, fix16_max(fix16_one, fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT))))))) & 0x7FFFFFF;
 
                         SET(pp->Flags, PF_TURN_180);
                     }
@@ -3297,7 +3297,7 @@ void getinput(int const playerNum)
                 // get new delta to see how close we are
                 delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
 
-                if (fix16_abs(delta_q16ang) < fix16_from_int(3 * TURN_SHIFT))
+                if (fix16_abs(delta_q16ang) < (fix16_one << 1))
                 {
                     pp->q16ang = pp->turn180_target;
                     RESET(pp->Flags, PF_TURN_180);
@@ -3451,8 +3451,7 @@ void getinput(int const playerNum)
         }
 
         // bound the base
-        pp->q16horizbase = fix16_max(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MIN));
-        pp->q16horizbase = fix16_min(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MAX));
+        pp->q16horizbase = fix16_clamp(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
 
         // bound adjust q16horizoff
         if (pp->q16horizbase + pp->q16horizoff < fix16_from_int(PLAYER_HORIZ_MIN))

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -3249,214 +3249,220 @@ void getinput(int const playerNum)
     localInput.q16avel = fix16_clamp(fix16_sadd(localInput.q16avel, input.q16avel), fix16_from_int(-MAXANGVEL), fix16_from_int(MAXANGVEL));
     localInput.q16horz = fix16_clamp(fix16_sadd(localInput.q16horz, input.q16horz), fix16_from_int(-MAXHORIZVEL), fix16_from_int(MAXHORIZVEL));
 
-    if (!TEST(pp->Flags, PF_TURN_180))
+    if (!TEST(pp->Flags, PF_DEAD))
     {
-        if (TEST_SYNC_KEY(pp, SK_TURN_180))
+        if (!TEST(pp->Flags, PF_CLIMBING))
         {
-            if (FLAG_KEY_PRESSED(pp, SK_TURN_180))
+            if (!TEST(pp->Flags, PF_TURN_180))
+            {
+                if (TEST_SYNC_KEY(pp, SK_TURN_180))
+                {
+                    if (FLAG_KEY_PRESSED(pp, SK_TURN_180))
+                    {
+                        fix16_t delta_q16ang;
+
+                        FLAG_KEY_RELEASE(pp, SK_TURN_180);
+
+                        pp->turn180_target = fix16_sadd(pp->q16ang, fix16_from_int(1024)) & 0x7FFFFFF;
+
+                        // make the first turn in the clockwise direction
+                        // the rest will follow
+                        delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
+
+                        pp->q16ang = fix16_sadd(pp->q16ang, fix16_max(fix16_one,fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT))))))) & 0x7FFFFFF;
+
+                        SET(pp->Flags, PF_TURN_180);
+                    }
+                }
+                else
+                {
+                    FLAG_KEY_RESET(pp, SK_TURN_180);
+                }
+            }
+
+            if (TEST(pp->Flags, PF_TURN_180))
             {
                 fix16_t delta_q16ang;
 
-                FLAG_KEY_RELEASE(pp, SK_TURN_180);
+                delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
+                pp->q16ang = fix16_sadd(pp->q16ang, fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT)))))) & 0x7FFFFFF;
 
-                pp->turn180_target = fix16_sadd(pp->q16ang, fix16_from_int(1024)) & 0x7FFFFFF;
+                sprite[pp->PlayerSprite].ang = fix16_to_int(pp->q16ang);
+                if (!Prediction)
+                {
+                    if (pp->PlayerUnderSprite >= 0)
+                        sprite[pp->PlayerUnderSprite].ang = fix16_to_int(pp->q16ang);
+                }
 
-                // make the first turn in the clockwise direction
-                // the rest will follow
+                // get new delta to see how close we are
                 delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
 
-                pp->q16ang = fix16_sadd(pp->q16ang, fix16_max(fix16_one,fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT))))))) & 0x7FFFFFF;
+                if (fix16_abs(delta_q16ang) < fix16_from_int(3 * TURN_SHIFT))
+                {
+                    pp->q16ang = pp->turn180_target;
+                    RESET(pp->Flags, PF_TURN_180);
+                }
+                else
+                    return;
+            }
 
-                SET(pp->Flags, PF_TURN_180);
+            if (input.q16avel != 0)
+            {
+               pp->q16ang = fix16_sadd(pp->q16ang, input.q16avel) & 0x7FFFFFF;
+
+                // update players sprite angle
+                // NOTE: It's also updated in UpdatePlayerSprite, but needs to be
+                // here to cover
+                // all cases.
+                sprite[pp->PlayerSprite].ang = fix16_to_int(pp->q16ang);
+                if (!Prediction)
+                {
+                    if (pp->PlayerUnderSprite >= 0)
+                        sprite[pp->PlayerUnderSprite].ang = fix16_to_int(pp->q16ang);
+                }
             }
         }
-        else
+
+        // Fixme: This should probably be made optional.
+        if (cl_slopetilting)
         {
-            FLAG_KEY_RESET(pp, SK_TURN_180);
-        }
-    }
+            int x,y,k,j;
+            short tempsect;
 
-    if (TEST(pp->Flags, PF_TURN_180))
-    {
-        fix16_t delta_q16ang;
-
-        delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
-        pp->q16ang = fix16_sadd(pp->q16ang, fix16_from_float(scaleAdjustmentToInterval(fix16_to_int(fix16_sdiv(fix16_abs(delta_q16ang), fix16_from_int(TURN_SHIFT)))))) & 0x7FFFFFF;
-
-        sprite[pp->PlayerSprite].ang = fix16_to_int(pp->q16ang);
-        if (!Prediction)
-        {
-            if (pp->PlayerUnderSprite >= 0)
-                sprite[pp->PlayerUnderSprite].ang = fix16_to_int(pp->q16ang);
-        }
-
-        // get new delta to see how close we are
-        delta_q16ang = GetDeltaAngleQ16(pp->turn180_target, pp->q16ang);
-
-        if (fix16_abs(delta_q16ang) < fix16_from_int(3 * TURN_SHIFT))
-        {
-            pp->q16ang = pp->turn180_target;
-            RESET(pp->Flags, PF_TURN_180);
-        }
-        else
-            return;
-    }
-
-    if (input.q16avel != 0)
-    {
-       pp->q16ang = fix16_sadd(pp->q16ang, input.q16avel) & 0x7FFFFFF;
-
-        // update players sprite angle
-        // NOTE: It's also updated in UpdatePlayerSprite, but needs to be
-        // here to cover
-        // all cases.
-        sprite[pp->PlayerSprite].ang = fix16_to_int(pp->q16ang);
-        if (!Prediction)
-        {
-            if (pp->PlayerUnderSprite >= 0)
-                sprite[pp->PlayerUnderSprite].ang = fix16_to_int(pp->q16ang);
-        }
-    }
-
-    // Fixme: This should probably be made optional.
-    if (cl_slopetilting)
-    {
-        int x,y,k,j;
-        short tempsect;
-
-        if (!TEST(pp->Flags, PF_FLYING|PF_SWIMMING|PF_DIVING|PF_CLIMBING|PF_JUMPING|PF_FALLING))
-        {
-            if (!TEST(pp->Flags, PF_MOUSE_AIMING_ON) && TEST(sector[pp->cursectnum].floorstat, FLOOR_STAT_SLOPE)) // If the floor is sloped
+            if (!TEST(pp->Flags, PF_FLYING|PF_SWIMMING|PF_DIVING|PF_CLIMBING|PF_JUMPING|PF_FALLING))
             {
-                // Get a point, 512 units ahead of player's position
-                x = pp->posx + (sintable[(fix16_to_int(pp->q16ang) + 512) & 2047] >> 5);
-                y = pp->posy + (sintable[fix16_to_int(pp->q16ang) & 2047] >> 5);
-                tempsect = pp->cursectnum;
-                COVERupdatesector(x, y, &tempsect);
-
-                if (tempsect >= 0)              // If the new point is inside a valid
-                // sector...
+                if (!TEST(pp->Flags, PF_MOUSE_AIMING_ON) && TEST(sector[pp->cursectnum].floorstat, FLOOR_STAT_SLOPE)) // If the floor is sloped
                 {
-                    // Get the floorz as if the new (x,y) point was still in
-                    // your sector
-                    j = getflorzofslope(pp->cursectnum, pp->posx, pp->posy);
-                    k = getflorzofslope(pp->cursectnum, x, y);
+                    // Get a point, 512 units ahead of player's position
+                    x = pp->posx + (sintable[(fix16_to_int(pp->q16ang) + 512) & 2047] >> 5);
+                    y = pp->posy + (sintable[fix16_to_int(pp->q16ang) & 2047] >> 5);
+                    tempsect = pp->cursectnum;
+                    COVERupdatesector(x, y, &tempsect);
 
-                    // If extended point is in same sector as you or the slopes
-                    // of the sector of the extended point and your sector match
-                    // closely (to avoid accidently looking straight out when
-                    // you're at the edge of a sector line) then adjust horizon
-                    // accordingly
-                    if ((pp->cursectnum == tempsect) ||
-                        (klabs(getflorzofslope(tempsect, x, y) - k) <= (4 << 8)))
+                    if (tempsect >= 0)              // If the new point is inside a valid
+                    // sector...
                     {
-                        pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(mulscale16((j - k), 160))));
+                        // Get the floorz as if the new (x,y) point was still in
+                        // your sector
+                        j = getflorzofslope(pp->cursectnum, pp->posx, pp->posy);
+                        k = getflorzofslope(pp->cursectnum, x, y);
+
+                        // If extended point is in same sector as you or the slopes
+                        // of the sector of the extended point and your sector match
+                        // closely (to avoid accidently looking straight out when
+                        // you're at the edge of a sector line) then adjust horizon
+                        // accordingly
+                        if ((pp->cursectnum == tempsect) ||
+                            (klabs(getflorzofslope(tempsect, x, y) - k) <= (4 << 8)))
+                        {
+                            pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(mulscale16((j - k), 160))));
+                        }
                     }
                 }
             }
-        }
 
-        if (TEST(pp->Flags, PF_CLIMBING))
-        {
-            // tilt when climbing but you can't even really tell it
-            if (pp->q16horizoff < fix16_from_int(100))
-                pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(((fix16_from_int(100) - pp->q16horizoff) >> 3) + fix16_one))));
-        }
-        else
-        {
-            // Make q16horizoff grow towards 0 since q16horizoff is not modified when
-            // you're not on a slope
-            if (pp->q16horizoff > 0)
+            if (TEST(pp->Flags, PF_CLIMBING))
             {
-                pp->q16horizoff = fix16_ssub(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((pp->q16horizoff >> 3) + fix16_one))));
-                pp->q16horizoff = fix16_max(pp->q16horizoff, 0);
-            }
-            else if (pp->q16horizoff < 0)
-            {
-                pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((-pp->q16horizoff >> 3) + fix16_one))));
-                pp->q16horizoff = fix16_min(pp->q16horizoff, 0);
-            }
-        }
-    }
-
-    if (input.q16horz)
-    {
-        pp->q16horizbase = fix16_sadd(pp->q16horizbase, input.q16horz);
-        SET(pp->Flags, PF_LOCK_HORIZ | PF_LOOKING);
-    }
-
-    if (TEST_SYNC_KEY(pp, SK_CENTER_VIEW))
-    {
-        pp->q16horiz = pp->q16horizbase = fix16_from_int(100);
-        pp->q16horizoff = 0;
-    }
-
-    // this is the locked type
-    if (TEST_SYNC_KEY(pp, SK_SNAP_UP) || TEST_SYNC_KEY(pp, SK_SNAP_DOWN))
-    {
-        // set looking because player is manually looking
-        SET(pp->Flags, PF_LOCK_HORIZ | PF_LOOKING);
-
-        // adjust pp->q16horiz negative
-        if (TEST_SYNC_KEY(pp, SK_SNAP_DOWN))
-            pp->q16horizbase = fix16_ssub(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval((HORIZ_SPEED/2))));
-
-        // adjust pp->q16horiz positive
-        if (TEST_SYNC_KEY(pp, SK_SNAP_UP))
-            pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval((HORIZ_SPEED/2))));
-    }
-
-    // this is the unlocked type
-    if (TEST_SYNC_KEY(pp, SK_LOOK_UP) || TEST_SYNC_KEY(pp, SK_LOOK_DOWN))
-    {
-        RESET(pp->Flags, PF_LOCK_HORIZ);
-        SET(pp->Flags, PF_LOOKING);
-
-        // adjust pp->q16horiz negative
-        if (TEST_SYNC_KEY(pp, SK_LOOK_DOWN))
-            pp->q16horizbase = fix16_ssub(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval(HORIZ_SPEED)));
-
-        // adjust pp->q16horiz positive
-        if (TEST_SYNC_KEY(pp, SK_LOOK_UP))
-            pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval(HORIZ_SPEED)));
-    }
-
-    if (!TEST(pp->Flags, PF_LOCK_HORIZ))
-    {
-        if (!(TEST_SYNC_KEY(pp, SK_LOOK_UP) || TEST_SYNC_KEY(pp, SK_LOOK_DOWN)))
-        {
-            // not pressing the pp->q16horiz keys
-            if (pp->q16horizbase != fix16_from_int(100))
-            {
-                int i;
-
-                // move pp->q16horiz back to 100
-                for (i = 1; i; i--)
-                {
-                    // this formula does not work for pp->q16horiz = 101-103
-                    pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(fix16_ssub(fix16_from_int(25), fix16_sdiv(pp->q16horizbase, fix16_from_int(4)))))));
-                }
+                // tilt when climbing but you can't even really tell it
+                if (pp->q16horizoff < fix16_from_int(100))
+                    pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(((fix16_from_int(100) - pp->q16horizoff) >> 3) + fix16_one))));
             }
             else
             {
-                // not looking anymore because pp->q16horiz is back at 100
-                RESET(pp->Flags, PF_LOOKING);
+                // Make q16horizoff grow towards 0 since q16horizoff is not modified when
+                // you're not on a slope
+                if (pp->q16horizoff > 0)
+                {
+                    pp->q16horizoff = fix16_ssub(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((pp->q16horizoff >> 3) + fix16_one))));
+                    pp->q16horizoff = fix16_max(pp->q16horizoff, 0);
+                }
+                else if (pp->q16horizoff < 0)
+                {
+                    pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float((-pp->q16horizoff >> 3) + fix16_one))));
+                    pp->q16horizoff = fix16_min(pp->q16horizoff, 0);
+                }
             }
         }
+
+        if (input.q16horz)
+        {
+            pp->q16horizbase = fix16_sadd(pp->q16horizbase, input.q16horz);
+            SET(pp->Flags, PF_LOCK_HORIZ | PF_LOOKING);
+        }
+
+        if (TEST_SYNC_KEY(pp, SK_CENTER_VIEW))
+        {
+            pp->q16horiz = pp->q16horizbase = fix16_from_int(100);
+            pp->q16horizoff = 0;
+        }
+
+        // this is the locked type
+        if (TEST_SYNC_KEY(pp, SK_SNAP_UP) || TEST_SYNC_KEY(pp, SK_SNAP_DOWN))
+        {
+            // set looking because player is manually looking
+            SET(pp->Flags, PF_LOCK_HORIZ | PF_LOOKING);
+
+            // adjust pp->q16horiz negative
+            if (TEST_SYNC_KEY(pp, SK_SNAP_DOWN))
+                pp->q16horizbase = fix16_ssub(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval((HORIZ_SPEED/2))));
+
+            // adjust pp->q16horiz positive
+            if (TEST_SYNC_KEY(pp, SK_SNAP_UP))
+                pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval((HORIZ_SPEED/2))));
+        }
+
+        // this is the unlocked type
+        if (TEST_SYNC_KEY(pp, SK_LOOK_UP) || TEST_SYNC_KEY(pp, SK_LOOK_DOWN))
+        {
+            RESET(pp->Flags, PF_LOCK_HORIZ);
+            SET(pp->Flags, PF_LOOKING);
+
+            // adjust pp->q16horiz negative
+            if (TEST_SYNC_KEY(pp, SK_LOOK_DOWN))
+                pp->q16horizbase = fix16_ssub(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval(HORIZ_SPEED)));
+
+            // adjust pp->q16horiz positive
+            if (TEST_SYNC_KEY(pp, SK_LOOK_UP))
+                pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval(HORIZ_SPEED)));
+        }
+
+        if (!TEST(pp->Flags, PF_LOCK_HORIZ))
+        {
+            if (!(TEST_SYNC_KEY(pp, SK_LOOK_UP) || TEST_SYNC_KEY(pp, SK_LOOK_DOWN)))
+            {
+                // not pressing the pp->q16horiz keys
+                if (pp->q16horizbase != fix16_from_int(100))
+                {
+                    int i;
+
+                    // move pp->q16horiz back to 100
+                    for (i = 1; i; i--)
+                    {
+                        // this formula does not work for pp->q16horiz = 101-103
+                        pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_float(scaleAdjustmentToInterval(fix16_to_float(fix16_ssub(fix16_from_int(25), fix16_sdiv(pp->q16horizbase, fix16_from_int(4)))))));
+                    }
+                }
+                else
+                {
+                    // not looking anymore because pp->q16horiz is back at 100
+                    RESET(pp->Flags, PF_LOOKING);
+                }
+            }
+        }
+
+        // bound the base
+        pp->q16horizbase = fix16_max(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MIN));
+        pp->q16horizbase = fix16_min(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MAX));
+
+        // bound adjust q16horizoff
+        if (pp->q16horizbase + pp->q16horizoff < fix16_from_int(PLAYER_HORIZ_MIN))
+            pp->q16horizoff = fix16_ssub(fix16_from_float(scaleAdjustmentToInterval(PLAYER_HORIZ_MIN)), pp->q16horizbase);
+        else if (pp->q16horizbase + pp->q16horizoff > fix16_from_int(PLAYER_HORIZ_MAX))
+            pp->q16horizoff = fix16_ssub(fix16_from_float(scaleAdjustmentToInterval(PLAYER_HORIZ_MAX)), pp->q16horizbase);
+
+        // add base and offsets
+        pp->q16horiz = fix16_clamp((pp->q16horizbase + pp->q16horizoff), fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
     }
-
-    // bound the base
-    pp->q16horizbase = fix16_max(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MIN));
-    pp->q16horizbase = fix16_min(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MAX));
-
-    // bound adjust q16horizoff
-    if (pp->q16horizbase + pp->q16horizoff < fix16_from_int(PLAYER_HORIZ_MIN))
-        pp->q16horizoff = fix16_ssub(fix16_from_float(scaleAdjustmentToInterval(PLAYER_HORIZ_MIN)), pp->q16horizbase);
-    else if (pp->q16horizbase + pp->q16horizoff > fix16_from_int(PLAYER_HORIZ_MAX))
-        pp->q16horizoff = fix16_ssub(fix16_from_float(scaleAdjustmentToInterval(PLAYER_HORIZ_MAX)), pp->q16horizbase);
-
-    // add base and offsets
-    pp->q16horiz = fix16_clamp((pp->q16horizbase + pp->q16horizoff), fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
 
     if (!CommEnabled)
     {

--- a/source/sw/src/game.h
+++ b/source/sw/src/game.h
@@ -1075,7 +1075,7 @@ struct PLAYERstruct
     short camera_check_time_delay;
 
     short cursectnum,lastcursectnum;
-    short turn180_target; // 180 degree turn
+    fix16_t turn180_target; // 180 degree turn
 
     // variables that do not fit into sprite structure
     int hvel,tilt,tilt_dest;
@@ -2060,6 +2060,7 @@ void SetBorder(PLAYERp pp, int);
 void SetFragBar(PLAYERp pp);
 int Distance(int x1, int y1, int x2, int y2);
 short GetDeltaAngle(short, short);
+fix16_t GetDeltaAngleQ16(fix16_t, fix16_t);
 
 int SetActorRotation(short SpriteNum,int,int);
 int NewStateGroup(short SpriteNum, STATEp SpriteGroup[]);

--- a/source/sw/src/game.h
+++ b/source/sw/src/game.h
@@ -1029,6 +1029,7 @@ struct PLAYERstruct
     // interpolation
     int
         oposx, oposy, oposz;
+    fix16_t oq16horiz, oq16ang;
 
     // Map follow mode pos values.
     int32_t mfposx, mfposy;

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -1352,7 +1352,7 @@ DoPlayerTeleportPause(PLAYERp pp)
 void
 DoPlayerTeleportToSprite(PLAYERp pp, SPRITEp sp)
 {
-    pp->q16ang = fix16_from_int(sp->ang);
+    pp->q16ang = pp->oq16ang = fix16_from_int(sp->ang);
     pp->posx = pp->oposx = pp->oldposx = sp->x;
     pp->posy = pp->oposy = pp->oldposy = sp->y;
 
@@ -5649,9 +5649,9 @@ DoPlayerStopOperate(PLAYERp pp)
     if (pp->sop_remote)
     {
         if (TEST_BOOL1(pp->remote_sprite))
-            pp->q16ang = fix16_from_int(pp->remote_sprite->ang);
+            pp->q16ang = pp->oq16ang = fix16_from_int(pp->remote_sprite->ang);
         else
-            pp->q16ang = fix16_from_int(getangle(pp->sop_remote->xmid - pp->posx, pp->sop_remote->ymid - pp->posy));
+            pp->q16ang = pp->oq16ang = fix16_from_int(getangle(pp->sop_remote->xmid - pp->posx, pp->sop_remote->ymid - pp->posy));
     }
 
     if (pp->sop_control)
@@ -7078,6 +7078,8 @@ MoveSkipSavePos(void)
         pp->oposx = pp->posx;
         pp->oposy = pp->posy;
         pp->oposz = pp->posz;
+        pp->oq16ang = pp->q16ang;
+        pp->oq16horiz = pp->q16horiz;
     }
 
     // save off stats for skip4
@@ -7626,8 +7628,8 @@ InitAllPlayers(void)
         pp->posx = pp->oposx = pfirst->posx;
         pp->posy = pp->oposy = pfirst->posy;
         pp->posz = pp->oposz = pfirst->posz;
-        pp->q16ang = pfirst->q16ang;
-        pp->q16horiz = pfirst->q16horiz;
+        pp->q16ang = pp->oq16ang = pfirst->q16ang;
+        pp->q16horiz = pp->oq16horiz = pfirst->q16horiz;
         pp->cursectnum = pfirst->cursectnum;
         // set like this so that player can trigger something on start of the level
         pp->lastcursectnum = pfirst->cursectnum+1;
@@ -7778,7 +7780,7 @@ PlayerSpawnPosition(PLAYERp pp)
     pp->posx = pp->oposx = sp->x;
     pp->posy = pp->oposy = sp->y;
     pp->posz = pp->oposz = sp->z;
-    pp->q16ang = fix16_from_int(sp->ang);
+    pp->q16ang = pp->oq16ang = fix16_from_int(sp->ang);
     pp->cursectnum = sp->sectnum;
 
     getzsofslope(pp->cursectnum, pp->posx, pp->posy, &cz, &fz);

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -1153,6 +1153,26 @@ GetDeltaAngle(short ang1, short ang2)
 
 }
 
+fix16_t
+GetDeltaAngleQ16(fix16_t ang1, fix16_t ang2)
+{
+    // Look at the smaller angle if > 1024 (180 degrees)
+    if (fix16_abs(fix16_sub(ang1, ang2)) > fix16_from_int(1024))
+    {
+        if (ang1 <= fix16_from_int(1024))
+            ang1 = fix16_add(ang1, fix16_from_int(2048));
+
+        if (ang2 <= fix16_from_int(1024))
+            ang2 = fix16_add(ang2, fix16_from_int(2048));
+    }
+
+    //if (ang1 - ang2 == -fix16_from_int(1024))
+    //    return(fix16_from_int(1024));
+
+    return fix16_sub(ang1, ang2);
+
+}
+
 TARGET_SORT TargetSort[MAX_TARGET_SORT];
 unsigned TargetSortCount;
 
@@ -6309,15 +6329,13 @@ void DoPlayerDeathFollowKiller(PLAYERp pp)
     if (pp->Killer > -1)
     {
         SPRITEp kp = &sprite[pp->Killer];
-        short ang2,delta_ang;
+        fix16_t delta_q16ang;
 
         if (FAFcansee(kp->x, kp->y, SPRITEp_TOS(kp), kp->sectnum,
                       pp->posx, pp->posy, pp->posz, pp->cursectnum))
         {
-            ang2 = getangle(kp->x - pp->posx, kp->y - pp->posy);
-
-            delta_ang = GetDeltaAngle(ang2, fix16_to_int(pp->q16ang));
-            pp->q16ang = fix16_sadd(pp->q16ang, fix16_from_int((delta_ang >> 4))) & 0x7FFFFFF;
+            delta_q16ang = GetDeltaAngleQ16(fix16_from_int(getangle(kp->x - pp->posx, kp->y - pp->posy)), pp->q16ang);
+            pp->q16ang = fix16_sadd(pp->q16ang, fix16_sdiv(delta_q16ang, fix16_from_int(16))) & 0x7FFFFFF;
         }
     }
 }

--- a/source/sw/src/predict.cpp
+++ b/source/sw/src/predict.cpp
@@ -157,9 +157,11 @@ DoPrediction(PLAYERp ppp)
     u = User[ppp->PlayerSprite];
     User[ppp->PlayerSprite] = &PredictUser;
 
+    ppp->oq16ang = ppp->q16ang;
     ppp->oposx = ppp->posx;
     ppp->oposy = ppp->posy;
     ppp->oposz = ppp->posz;
+    ppp->oq16horiz = ppp->q16horiz;
 
 #if PREDICT_DEBUG
     PredictDebug(ppp);


### PR DESCRIPTION
Just some minor changes and restoration of some old behaviour.

- Define new function GetDeltaAngleQ16() and use it appropriately.
- Smooth out 180 degree turning.
- Ensure 180 degree turning is always clockwise (thanks NY00123).
- Lock player turning and horizon when dead (thanks NY00123).
- Restore old interpolation when the camera pans while dead (this function runs at the game's ticrate and not frame rate) (thanks NY00123).