### PR TITLE
- Repair compiling on Arch Linux with GCC 9.3.0.

### DIFF
--- a/source/platform/posix/unix/gtk_dialogs.cpp
+++ b/source/platform/posix/unix/gtk_dialogs.cpp
@@ -59,6 +59,7 @@ typedef enum
 #include "i_system.h"
 #include "version.h"
 #include "gamecontrol.h"
+#include "cmdlib.h"
 
 EXTERN_CVAR (Bool, queryiwad);
 


### PR DESCRIPTION
'countof()' was not available.

While it compiles, still having issues running after compile. I trigger I_FatalError in FScanner::CheckOpen(). Will try to work out what's going on and either raise a PR for it or put in a ticket on the forums.