### PR TITLE
- fix Windows compilation due to incomplete Vulkan backend code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,7 @@ include( TargetArch )
 #	set( HAVE_VM_JIT ON )
 #	option (HAVE_VULKAN "Enable Vulkan support" ON)
 #endif()
+set( HAVE_VULKAN FALSE )
 
 # no, we're not using external asmjit for now, we made too many modifications to our's.
 # if the asmjit author uses our changes then we'll update this.


### PR DESCRIPTION
I couldn't get a compile going on Windows without disabling some of the Vulkan stuff. Should be fine to do so for now until the new backend_unification branch is merged in.