### PR TITLE
Game pause fixes

### DIFF
--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -5912,6 +5912,7 @@ MAIN_LOOP_RESTART:
         if (M_Active() || GUICapture || ud.pause_on != 0)
         {
             totalclock = ototalclock + TICSPERFRAME;
+            buttonMap.ResetButtonStates();
         }
         else
         {

--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -2337,7 +2337,7 @@ GAMELOOP:
         {
             bInMove = kTrue;
 
-            if (GUICapture || bPause)
+            if (M_Active() || GUICapture || bPause)
             {
                 totalclock = tclocks + 4;
             }

--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -2340,6 +2340,7 @@ GAMELOOP:
             if (M_Active() || GUICapture || bPause)
             {
                 totalclock = tclocks + 4;
+                buttonMap.ResetButtonStates();
             }
             else
             {

--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -7291,48 +7291,55 @@ MAIN_LOOP_RESTART:
 
         char gameUpdate = false;
         double const gameUpdateStartTime = timerGetHiTicks();
-        
-        while (((g_netClient || g_netServer) || !(g_player[myconnectindex].ps->gm & (MODE_MENU|MODE_DEMO))) && (int)(totalclock - ototalclock) >= TICSPERFRAME)
+
+        if (M_Active() || GUICapture || ud.pause_on != 0)
         {
-            ototalclock += TICSPERFRAME;
-
-            if (RRRA && g_player[myconnectindex].ps->on_motorcycle)
-                P_GetInputMotorcycle(myconnectindex);
-            else if (RRRA && g_player[myconnectindex].ps->on_boat)
-                P_GetInputBoat(myconnectindex);
-            else
-                P_GetInput(myconnectindex);
-
-            // this is where we fill the input_t struct that is actually processed by P_ProcessInput()
-            auto const pPlayer = g_player[myconnectindex].ps;
-            auto const q16ang  = fix16_to_int(pPlayer->q16ang);
-            auto &     input   = inputfifo[g_player[myconnectindex].movefifoend&(MOVEFIFOSIZ-1)][myconnectindex];
-
-            input = localInput;
-            input.fvel = mulscale9(localInput.fvel, sintable[(q16ang + 2560) & 2047]) +
-                         mulscale9(localInput.svel, sintable[(q16ang + 2048) & 2047]) +
-                         pPlayer->fric.x;
-            input.svel = mulscale9(localInput.fvel, sintable[(q16ang + 2048) & 2047]) +
-                         mulscale9(localInput.svel, sintable[(q16ang + 1536) & 2047]) +
-                         pPlayer->fric.y;
-            localInput = {};
-
-            g_player[myconnectindex].movefifoend++;
-
-            if (((!GUICapture && (g_player[myconnectindex].ps->gm&MODE_MENU) != MODE_MENU) || ud.recstat == 2 || (g_netServer || ud.multimode > 1)) &&
-                    (g_player[myconnectindex].ps->gm&MODE_GAME))
-            {
-                G_MoveLoop();
-            }
+            totalclock = ototalclock + TICSPERFRAME;
         }
+        else
+        {
+            while (((g_netClient || g_netServer) || !(g_player[myconnectindex].ps->gm & (MODE_MENU|MODE_DEMO))) && (int)(totalclock - ototalclock) >= TICSPERFRAME)
+            {
+                ototalclock += TICSPERFRAME;
 
-        gameUpdate = true;
-        g_gameUpdateTime = timerGetHiTicks()-gameUpdateStartTime;
-        if (g_gameUpdateAvgTime < 0.f)
-            g_gameUpdateAvgTime = g_gameUpdateTime;
-        g_gameUpdateAvgTime = ((GAMEUPDATEAVGTIMENUMSAMPLES-1.f)*g_gameUpdateAvgTime+g_gameUpdateTime)/((float) GAMEUPDATEAVGTIMENUMSAMPLES);
+                if (RRRA && g_player[myconnectindex].ps->on_motorcycle)
+                    P_GetInputMotorcycle(myconnectindex);
+                else if (RRRA && g_player[myconnectindex].ps->on_boat)
+                    P_GetInputBoat(myconnectindex);
+                else
+                    P_GetInput(myconnectindex);
 
-        G_DoCheats();
+                // this is where we fill the input_t struct that is actually processed by P_ProcessInput()
+                auto const pPlayer = g_player[myconnectindex].ps;
+                auto const q16ang  = fix16_to_int(pPlayer->q16ang);
+                auto &     input   = inputfifo[g_player[myconnectindex].movefifoend&(MOVEFIFOSIZ-1)][myconnectindex];
+
+                input = localInput;
+                input.fvel = mulscale9(localInput.fvel, sintable[(q16ang + 2560) & 2047]) +
+                             mulscale9(localInput.svel, sintable[(q16ang + 2048) & 2047]) +
+                             pPlayer->fric.x;
+                input.svel = mulscale9(localInput.fvel, sintable[(q16ang + 2048) & 2047]) +
+                             mulscale9(localInput.svel, sintable[(q16ang + 1536) & 2047]) +
+                             pPlayer->fric.y;
+                localInput = {};
+
+                g_player[myconnectindex].movefifoend++;
+
+                if (((g_player[myconnectindex].ps->gm&MODE_MENU) != MODE_MENU || ud.recstat == 2 || (g_netServer || ud.multimode > 1)) &&
+                        (g_player[myconnectindex].ps->gm&MODE_GAME))
+                {
+                    G_MoveLoop();
+                }
+            }
+
+            gameUpdate = true;
+            g_gameUpdateTime = timerGetHiTicks()-gameUpdateStartTime;
+            if (g_gameUpdateAvgTime < 0.f)
+                g_gameUpdateAvgTime = g_gameUpdateTime;
+            g_gameUpdateAvgTime = ((GAMEUPDATEAVGTIMENUMSAMPLES-1.f)*g_gameUpdateAvgTime+g_gameUpdateTime)/((float) GAMEUPDATEAVGTIMENUMSAMPLES);
+
+            G_DoCheats();
+        }
 
         if (g_player[myconnectindex].ps->gm & (MODE_EOL|MODE_RESTART))
         {

--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -7295,6 +7295,7 @@ MAIN_LOOP_RESTART:
         if (M_Active() || GUICapture || ud.pause_on != 0)
         {
             totalclock = ototalclock + TICSPERFRAME;
+            buttonMap.ResetButtonStates();
         }
         else
         {

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -2526,9 +2526,9 @@ void RunLevel(void)
             return; // Stop the game loop if a savegame was loaded from the menu.
         }
 
-        if (M_Active())
+        if (M_Active() || GUICapture || GamePaused)
         {
-            ototalclock = (int)totalclock;
+            totalclock = ototalclock + (120 / synctics);
         }
         else
         {

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -2529,6 +2529,7 @@ void RunLevel(void)
         if (M_Active() || GUICapture || GamePaused)
         {
             totalclock = ototalclock + (120 / synctics);
+            buttonMap.ResetButtonStates();
         }
         else
         {


### PR DESCRIPTION
This is to work around the issues reported [here](https://forum.zdoom.org/viewtopic.php?f=340&t=68226) and [here](https://forum.zdoom.org/viewtopic.php?f=345&t=67733).

Because the issue keeps getting 'razed' :wink:, I thought perhaps something could be done to address them. These changes are effectively duplicates of what was done while repairing the main game loop for Exhumed. 

I've also added commits to reset the buttonMap after returning from pause. Currently if you're holding down any key, that key remains stuck down until you press it again (walking, strafing, etc). I think it's desirable to reset that state and not be locked in, but have done as separate commits so that they can be excluded if desired.