### PR TITLE
- allow game's clock to keep running while paused (restores interpolations/animations in menus).

### DIFF
--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -5911,7 +5911,7 @@ MAIN_LOOP_RESTART:
 
         if (M_Active() || GUICapture || ud.pause_on != 0)
         {
-            totalclock = ototalclock + TICSPERFRAME;
+            ototalclock = totalclock - TICSPERFRAME;
             buttonMap.ResetButtonStates();
         }
         else

--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -2339,7 +2339,7 @@ GAMELOOP:
 
             if (M_Active() || GUICapture || bPause)
             {
-                totalclock = tclocks + 4;
+                tclocks = totalclock - 4;
                 buttonMap.ResetButtonStates();
             }
             else

--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -7294,7 +7294,7 @@ MAIN_LOOP_RESTART:
 
         if (M_Active() || GUICapture || ud.pause_on != 0)
         {
-            totalclock = ototalclock + TICSPERFRAME;
+            ototalclock = totalclock - TICSPERFRAME;
             buttonMap.ResetButtonStates();
         }
         else

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -2528,7 +2528,7 @@ void RunLevel(void)
 
         if (M_Active() || GUICapture || GamePaused)
         {
-            totalclock = ototalclock + (120 / synctics);
+            ototalclock = (int)totalclock - (120 / synctics);
             buttonMap.ResetButtonStates();
         }
         else


### PR DESCRIPTION
Apologies, my fix worked a little too well. Noticed this morning that the spinning menu animations for Duke 3D/SW weren't spinning as intended.

This change still pauses the game cleanly when going into a GUI break (console, etc) but keeps the clock running so interpolations still work.