### PR TITLE
Game input tweaks

### DIFF
--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -4759,6 +4759,8 @@ static void P_DoJetpack(int const playerNum, int const playerBits, int const pla
     pPlayer->pycount        &= 2047;
     pPlayer->pyoff           = sintable[pPlayer->pycount] >> 7;
 
+    g_player[playerNum].horizSkew = 0;
+
     if (pPlayer->jetpack_on < 11)
     {
         pPlayer->jetpack_on++;

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -5703,7 +5703,10 @@ RECHECK:
 
     if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
         if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
+        {
             pPlayer->return_to_center = 9;
+            thisPlayer.horizRecenter  = true;
+        }
 
     if (TEST_SYNC_KEY(playerBits, SK_LOOK_UP))
     {

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -4901,11 +4901,11 @@ void P_ProcessInput(int playerNum)
 {
     auto &thisPlayer = g_player[playerNum];
 
-    thisPlayer.horizAngleAdjust = 0;
-    thisPlayer.horizSkew = 0;
-
     if (thisPlayer.playerquitflag == 0)
         return;
+
+    thisPlayer.horizAngleAdjust = 0;
+    thisPlayer.horizSkew = 0;
 
     auto const pPlayer = thisPlayer.ps;
     auto const pSprite = &sprite[pPlayer->i];

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -5301,7 +5301,6 @@ void P_ProcessInput(int playerNum)
                             A_PlaySound(DUKE_LAND, pPlayer->i);
 #endif
                     }
-                    pPlayer->on_ground = 1;
                 }
                 else
                     pPlayer->on_ground = 0;

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3322,6 +3322,21 @@ void P_GetInput(int const playerNum)
         }
     }
 
+    if (pPlayer->return_to_center > 0)
+        pPlayer->return_to_center--;
+
+    if (pPlayer->hard_landing)
+    {
+        pPlayer->return_to_center = 9;
+        thisPlayer.horizRecenter  = true;
+    }
+
+    if (pPlayer->hard_landing > 0)
+    {
+        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        pPlayer->hard_landing--;
+    }
+
     // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
 
     if (thisPlayer.horizAngleAdjust)
@@ -5697,10 +5712,7 @@ RECHECK:
             G_ActivateBySector(pPlayer->cursectnum, pPlayer->i);
     }
 
-    if (pPlayer->return_to_center > 0)
-        pPlayer->return_to_center--;
-
-    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
+    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW))
         if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
@@ -5743,12 +5755,6 @@ RECHECK:
             thisPlayer.horizAngleAdjust = -float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
             thisPlayer.horizRecenter    = false;
         }
-    }
-
-    if (pPlayer->hard_landing > 0)
-    {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
-        pPlayer->hard_landing--;
     }
 
     //Shooting code/changes

--- a/source/duke3d/src/premap.cpp
+++ b/source/duke3d/src/premap.cpp
@@ -777,6 +777,10 @@ void P_ResetPlayer(int playerNum)
                      ? PWEAPON(playerNum, p.curr_weapon, TotalTime)
                      : 0;
 
+    g_player[playerNum].horizRecenter    = 0;
+    g_player[playerNum].horizSkew        = 0;
+    g_player[playerNum].horizAngleAdjust = 0;
+
     P_UpdateScreenPal(&p);
     VM_OnEvent(EVENT_RESETPLAYER, p.i, playerNum);
 }

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -6941,9 +6941,6 @@ void P_ProcessInput(int playerNum)
 {
     auto &thisPlayer = g_player[playerNum];
 
-    thisPlayer.horizAngleAdjust = 0;
-    thisPlayer.horizSkew = 0;
-
     if (DEER)
     {
         P_DHProcessInput(playerNum);
@@ -6951,6 +6948,9 @@ void P_ProcessInput(int playerNum)
     }
     if (thisPlayer.playerquitflag == 0)
         return;
+
+    thisPlayer.horizAngleAdjust = 0;
+    thisPlayer.horizSkew = 0;
 
     auto const pPlayer = thisPlayer.ps;
     auto const pSprite = &sprite[pPlayer->i];
@@ -8872,11 +8872,11 @@ void P_DHProcessInput(int playerNum)
 {
     auto &thisPlayer = g_player[playerNum];
 
-    thisPlayer.horizAngleAdjust = 0;
-    thisPlayer.horizSkew = 0;
-
     if (thisPlayer.playerquitflag == 0)
         return;
+
+    thisPlayer.horizAngleAdjust = 0;
+    thisPlayer.horizSkew = 0;
 
     auto const pPlayer = thisPlayer.ps;
     auto const pSprite = &sprite[pPlayer->i];

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -8051,7 +8051,6 @@ check_enemy_sprite:
                             pPlayer->moto_turb = 12;
                         }
                     }
-                    pPlayer->on_ground = 1;
                 }
                 else
                     pPlayer->on_ground = 0;

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3164,7 +3164,6 @@ enddisplayweapon:
 #define MAXANGVEL     1024
 #define MAXHORIZVEL   256
 
-#define MOTOTURN      20
 #define MAXVELMOTO    120
 
 int32_t g_myAimStat = 0, g_oldAimStat = 0;
@@ -3664,22 +3663,18 @@ void P_GetInputMotorcycle(int playerNum)
     localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Strafe_Left) || (input.svel > 0)) << 2;
     localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Strafe_Right) || (input.svel < 0)) << 3;
 
-    int turnAmount;
     int const turn = input.q16avel / 32;
     int turnLeft = buttonMap.ButtonDown(gamefunc_Turn_Left) || buttonMap.ButtonDown(gamefunc_Strafe_Left);
     int turnRight = buttonMap.ButtonDown(gamefunc_Turn_Right) || buttonMap.ButtonDown(gamefunc_Strafe_Right);
     int avelScale = F16((turnLeft || turnRight) ? 1 : 0);
     if (turn)
     {
-        turnAmount = (MOTOTURN << 1);
         avelScale = fix16_max(avelScale, fix16_clamp(fix16_mul(turn, turn),0,F16(1)));
         if (turn < 0)
             turnLeft = 1;
         else if (turn > 0)
             turnRight = 1;
     }
-    else
-        turnAmount = MOTOTURN;
 
     input.svel = input.fvel = input.q16avel = 0;
 
@@ -3718,16 +3713,16 @@ void P_GetInputMotorcycle(int playerNum)
             if (turnHeldTime >= TURBOTURNTIME && pPlayer->moto_speed > 0)
             {
                 if (moveBack)
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount)));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 40 : 20)));
                 else
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount)));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 40 : 20)));
             }
             else
             {
                 if (moveBack)
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / (8 / 3))));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 20 : 6)));
                 else
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / (8 / 3))));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 20 : 6)));
             }
         }
         else if (turnRight || pPlayer->moto_drink > 0)
@@ -3739,16 +3734,16 @@ void P_GetInputMotorcycle(int playerNum)
             if (turnHeldTime >= TURBOTURNTIME && pPlayer->moto_speed > 0)
             {
                 if (moveBack)
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount)));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 40 : 20)));
                 else
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount)));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 40 : 20)));
             }
             else
             {
                 if (moveBack)
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / (8 / 3))));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 20 : 6)));
                 else
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / (8 / 3))));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 20 : 6)));
             }
         }
         else
@@ -3870,14 +3865,12 @@ void P_GetInputBoat(int playerNum)
     localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Strafe_Left) || (input.svel > 0)) << 2;
     localInput.extbits |= (buttonMap.ButtonDown(gamefunc_Strafe_Right) || (input.svel < 0)) << 3;
 
-    int turnAmount;
     int const turn = input.q16avel / 32;
     int turnLeft = buttonMap.ButtonDown(gamefunc_Turn_Left) || buttonMap.ButtonDown(gamefunc_Strafe_Left);
     int turnRight = buttonMap.ButtonDown(gamefunc_Turn_Right) || buttonMap.ButtonDown(gamefunc_Strafe_Right);
     int avelScale = F16((turnLeft || turnRight) ? 1 : 0);
     if (turn)
     {
-        turnAmount = (MOTOTURN << 1);
         avelScale = fix16_max(avelScale, fix16_clamp(fix16_mul(turn, turn),0,F16(1)));
         if (turn < 0)
             turnLeft = 1;
@@ -3885,7 +3878,6 @@ void P_GetInputBoat(int playerNum)
             turnRight = 1;
     }
     else
-        turnAmount = MOTOTURN;
 
     input.svel = input.fvel = input.q16avel = 0;
 
@@ -3911,15 +3903,15 @@ void P_GetInputBoat(int playerNum)
                 if (pPlayer->tilt_status < -10)
                     pPlayer->tilt_status = -10;
                 if (turnHeldTime >= TURBOTURNTIME)
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount)));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 40 : 20)));
                 else
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / (10 / 3))));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 12 : 6)));
             }
             else
                 if (turnHeldTime >= TURBOTURNTIME)
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / 3)));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 12 : 6)));
                 else
-                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval((turnAmount / (10 / 3)) / 3)));
+                    input.q16avel = fix16_ssub(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 4 : 2)));
         }
         else if (turnRight || pPlayer->moto_drink > 0)
         {
@@ -3930,15 +3922,15 @@ void P_GetInputBoat(int playerNum)
                 if (pPlayer->tilt_status > 10)
                     pPlayer->tilt_status = 10;
                 if (turnHeldTime >= TURBOTURNTIME)
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount)));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 40 : 20)));
                 else
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / (10 / 3))));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 12 : 6)));
             }
             else
                 if (turnHeldTime >= TURBOTURNTIME)
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turnAmount / 3)));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 12 : 6)));
                 else
-                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval((turnAmount / (10 / 3)) / 3)));
+                    input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(turn ? 4 : 2)));
         }
         else if (!pPlayer->not_on_water)
         {

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -8710,7 +8710,10 @@ HORIZONLY:;
 
     if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
         if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
+        {
             pPlayer->return_to_center = 9;
+            thisPlayer.horizRecenter  = true;
+        }
 
     if (TEST_SYNC_KEY(playerBits, SK_LOOK_UP))
     {
@@ -9359,7 +9362,10 @@ void P_DHProcessInput(int playerNum)
         pPlayer->return_to_center--;
 
     if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
+    {
         pPlayer->return_to_center = 9;
+        thisPlayer.horizRecenter  = true;
+    }
 
     if (TEST_SYNC_KEY(playerBits, SK_LOOK_UP))
     {

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3902,7 +3902,6 @@ void P_GetInputBoat(int playerNum)
         else if (turn > 0)
             turnRight = 1;
     }
-    else
 
     input.svel = input.fvel = input.q16avel = 0;
 

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -6844,6 +6844,8 @@ static void P_DoJetpack(int const playerNum, int const playerBits, int const pla
     pPlayer->pycount        &= 2047;
     pPlayer->pyoff           = sintable[pPlayer->pycount] >> 7;
 
+    g_player[playerNum].horizSkew = 0;
+
     if (pPlayer->jetpack_on < 11)
     {
         pPlayer->jetpack_on++;

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3506,6 +3506,21 @@ void P_GetInput(int const playerNum)
         }
     }
 
+    if (pPlayer->return_to_center > 0)
+        pPlayer->return_to_center--;
+
+    if (pPlayer->hard_landing)
+    {
+        pPlayer->return_to_center = 9;
+        thisPlayer.horizRecenter  = true;
+    }
+
+    if (pPlayer->hard_landing > 0)
+    {
+        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        pPlayer->hard_landing--;
+    }
+
     // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
 
     if (thisPlayer.horizAngleAdjust)
@@ -4125,6 +4140,21 @@ void P_DHGetInput(int const playerNum)
 
     if (pPlayer->cursectnum >= 0 && sector[pPlayer->cursectnum].hitag == 2003)
         input.fvel >>= 1;
+
+    if (pPlayer->return_to_center > 0)
+        pPlayer->return_to_center--;
+
+    if (pPlayer->hard_landing)
+    {
+        pPlayer->return_to_center = 9;
+        thisPlayer.horizRecenter  = true;
+    }
+
+    if (pPlayer->hard_landing > 0)
+    {
+        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        pPlayer->hard_landing--;
+    }
 
     // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
 
@@ -8704,10 +8734,7 @@ HORIZONLY:;
         }
     }
 
-    if (pPlayer->return_to_center > 0)
-        pPlayer->return_to_center--;
-
-    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
+    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW))
         if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
@@ -8754,12 +8781,6 @@ HORIZONLY:;
         if (!delta) delta++;
         pPlayer->recoil -= delta;
         pPlayer->q16horiz -= F16(delta);
-    }
-
-    if (pPlayer->hard_landing > 0)
-    {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
-        pPlayer->hard_landing--;
     }
 
     //Shooting code/changes
@@ -9357,10 +9378,7 @@ void P_DHProcessInput(int playerNum)
                                  A_GetFurthestAngle(pPlayer->i, 8) < 512);
     }
 
-    if (pPlayer->return_to_center > 0)
-        pPlayer->return_to_center--;
-
-    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
+    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW))
     {
         pPlayer->return_to_center = 9;
         thisPlayer.horizRecenter  = true;
@@ -9394,12 +9412,6 @@ void P_DHProcessInput(int playerNum)
         if (!delta) delta++;
         pPlayer->recoil -= delta;
         pPlayer->q16horiz -= F16(delta);
-    }
-
-    if (pPlayer->hard_landing > 0)
-    {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
-        pPlayer->hard_landing--;
     }
 
     if (TEST_SYNC_KEY(playerBits, SK_FIRE))

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3768,10 +3768,35 @@ void P_GetInputMotorcycle(int playerNum)
         localInput.bits |= buttonMap.ButtonDown(gamefunc_Run) << SK_CROUCH;
     }
 
-    input.q16avel      = fix16_mul(input.q16avel, avelScale);
-    localInput.q16avel = fix16_sadd(localInput.q16avel, input.q16avel);
-    pPlayer->q16ang    = fix16_sadd(pPlayer->q16ang, input.q16avel) & 0x7FFFFFF;
-    localInput.fvel    = clamp((input.fvel += pPlayer->moto_speed), -(MAXVELMOTO / 8), MAXVELMOTO);
+    input.fvel += pPlayer->moto_speed;
+    input.q16avel = fix16_mul(input.q16avel, avelScale);
+
+    int const movementLocked = P_CheckLockedMovement(playerNum);
+
+    if ((ud.scrollmode && ud.overhead_on) || (movementLocked & IL_NOTHING) == IL_NOTHING)
+    {
+        if (ud.scrollmode && ud.overhead_on)
+        {
+            ud.folfvel = input.fvel;
+            ud.folavel = fix16_to_int(input.q16avel);
+        }
+
+        localInput.fvel = localInput.svel = 0;
+        localInput.q16avel = localInput.q16horz = 0;
+    }
+    else
+    {
+        if (!(movementLocked & IL_NOMOVE))
+        {
+            localInput.fvel = clamp(input.fvel, -(MAXVELMOTO / 8), MAXVELMOTO);
+        }
+
+        if (!(movementLocked & IL_NOANGLE))
+        {
+            localInput.q16avel = fix16_sadd(localInput.q16avel, input.q16avel);
+            pPlayer->q16ang    = fix16_sadd(pPlayer->q16ang, input.q16avel) & 0x7FFFFFF;
+        }
+    }
 
     if (TEST_SYNC_KEY(localInput.bits, SK_JUMP))
     {
@@ -3952,10 +3977,35 @@ void P_GetInputBoat(int playerNum)
             pPlayer->tilt_status++;
     }
 
-    input.q16avel      = fix16_mul(input.q16avel, avelScale);
-    localInput.q16avel = fix16_sadd(localInput.q16avel, input.q16avel);
-    pPlayer->q16ang    = fix16_sadd(pPlayer->q16ang, input.q16avel) & 0x7FFFFFF;
-    localInput.fvel    = clamp((input.fvel += pPlayer->moto_speed), -(MAXVELMOTO / 8), MAXVELMOTO);
+    input.fvel += pPlayer->moto_speed;
+    input.q16avel = fix16_mul(input.q16avel, avelScale);
+
+    int const movementLocked = P_CheckLockedMovement(playerNum);
+
+    if ((ud.scrollmode && ud.overhead_on) || (movementLocked & IL_NOTHING) == IL_NOTHING)
+    {
+        if (ud.scrollmode && ud.overhead_on)
+        {
+            ud.folfvel = input.fvel;
+            ud.folavel = fix16_to_int(input.q16avel);
+        }
+
+        localInput.fvel = localInput.svel = 0;
+        localInput.q16avel = localInput.q16horz = 0;
+    }
+    else
+    {
+        if (!(movementLocked & IL_NOMOVE))
+        {
+            localInput.fvel = clamp(input.fvel, -(MAXVELMOTO / 8), MAXVELMOTO);
+        }
+
+        if (!(movementLocked & IL_NOANGLE))
+        {
+            localInput.q16avel = fix16_sadd(localInput.q16avel, input.q16avel);
+            pPlayer->q16ang    = fix16_sadd(pPlayer->q16ang, input.q16avel) & 0x7FFFFFF;
+        }
+    }
 }
 
 int dword_A99D4, dword_A99D8, dword_A99DC, dword_A99E0;

--- a/source/rr/src/premap.cpp
+++ b/source/rr/src/premap.cpp
@@ -936,6 +936,10 @@ void P_ResetStatus(int playerNum)
     pPlayer->movement_lock      = 0;
     pPlayer->frag_ps            = playerNum;
 
+    g_player[playerNum].horizRecenter    = 0;
+    g_player[playerNum].horizSkew        = 0;
+    g_player[playerNum].horizAngleAdjust = 0;
+
     P_UpdateScreenPal(pPlayer);
 
     if (RR)

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -3294,6 +3294,17 @@ void getinput(int const playerNum)
     localInput.q16avel = fix16_clamp(fix16_sadd(localInput.q16avel, input.q16avel), fix16_from_int(-MAXANGVEL), fix16_from_int(MAXANGVEL));
     localInput.q16horz = fix16_clamp(fix16_sadd(localInput.q16horz, input.q16horz), fix16_from_int(-MAXHORIZVEL), fix16_from_int(MAXHORIZVEL));
 
+    // actually snap
+    SET_LOC_KEY(localInput.bits, SK_SNAP_UP, buttonMap.ButtonDown(gamefunc_Aim_Up));
+    SET_LOC_KEY(localInput.bits, SK_SNAP_DOWN, buttonMap.ButtonDown(gamefunc_Aim_Down));
+
+    // actually just look
+    SET_LOC_KEY(localInput.bits, SK_LOOK_UP, buttonMap.ButtonDown(gamefunc_Look_Up));
+    SET_LOC_KEY(localInput.bits, SK_LOOK_DOWN, buttonMap.ButtonDown(gamefunc_Look_Down));
+
+    SET_LOC_KEY(localInput.bits, SK_CENTER_VIEW, buttonMap.ButtonDown(gamefunc_Center_View));
+    SET_LOC_KEY(localInput.bits, SK_TURN_180, buttonMap.ButtonDown(gamefunc_TurnAround));
+
     if (!TEST(pp->Flags, PF_DEAD))
     {
         if (!TEST(pp->Flags, PF_CLIMBING))
@@ -3524,18 +3535,8 @@ void getinput(int const playerNum)
 		inputState.ClearKeyStatus(sc_Pause);
 	}
 
-    SET_LOC_KEY(localInput.bits, SK_CENTER_VIEW, buttonMap.ButtonDown(gamefunc_Center_View));
-
     SET_LOC_KEY(localInput.bits, SK_RUN, buttonMap.ButtonDown(gamefunc_Run));
     SET_LOC_KEY(localInput.bits, SK_SHOOT, buttonMap.ButtonDown(gamefunc_Fire));
-
-    // actually snap
-    SET_LOC_KEY(localInput.bits, SK_SNAP_UP, buttonMap.ButtonDown(gamefunc_Aim_Up));
-    SET_LOC_KEY(localInput.bits, SK_SNAP_DOWN, buttonMap.ButtonDown(gamefunc_Aim_Down));
-
-    // actually just look
-    SET_LOC_KEY(localInput.bits, SK_LOOK_UP, buttonMap.ButtonDown(gamefunc_Look_Up));
-    SET_LOC_KEY(localInput.bits, SK_LOOK_DOWN, buttonMap.ButtonDown(gamefunc_Look_Down));
 
     for (i = 0; i < MAX_WEAPONS_KEYS; i++)
     {
@@ -3653,8 +3654,6 @@ void getinput(int const playerNum)
     SET_LOC_KEY(localInput.bits, SK_OPERATE, buttonMap.ButtonDown(gamefunc_Open));
     SET_LOC_KEY(localInput.bits, SK_JUMP, buttonMap.ButtonDown(gamefunc_Jump));
     SET_LOC_KEY(localInput.bits, SK_CRAWL, buttonMap.ButtonDown(gamefunc_Crouch));
-
-    SET_LOC_KEY(localInput.bits, SK_TURN_180, buttonMap.ButtonDown(gamefunc_TurnAround));
 
     SET_LOC_KEY(localInput.bits, SK_INV_LEFT, buttonMap.ButtonDown(gamefunc_Inventory_Left));
     SET_LOC_KEY(localInput.bits, SK_INV_RIGHT, buttonMap.ButtonDown(gamefunc_Inventory_Right));


### PR DESCRIPTION
A few things going on here.

SW: The bits that set whether the player is aiming up/down, etc was being set after the code to perform the action. Setting prior allows the action to be performed within that iteration of the function and not the next frame.

Duke3D & RR: With both games while cherry-picking the input changes that do mouse input at the frame-rate, a deletion was missed that was causing the player not to return to centre upon a hard landing. This is original behaviour so it should be restored.

Following the repair, I note that when re-centering from a hard landing, the player cannot look up/down until `thisPlayer.horizRecenter` is `false`. Because this was being done within the game's clock in `P_ProcessInput()`, it was slow and gave this jarring effect of not being able to aim properly.

Moving this code to `P_GetInput()` where it's processed at the frame-rate is much nicer and I'm going to propose it upsteam as well.

Lastly for both games, I've included some cherry-picks from upstream and have applied them to RR as well for consistency, and preserving author credits.