### PR TITLE
More misc input improvements

### DIFF
--- a/source/core/version.h
+++ b/source/core/version.h
@@ -68,13 +68,13 @@ const char *GetVersionString();
 
 #define MINSAVEVER_DN3D 7
 #define MINSAVEVER_BLD 6
-#define MINSAVEVER_RR 6
+#define MINSAVEVER_RR 7
 #define MINSAVEVER_SW 6
 #define MINSAVEVER_PS 6
 
 #define SAVEVER_DN3D 7
 #define SAVEVER_BLD 6
-#define SAVEVER_RR 6
+#define SAVEVER_RR 7
 #define SAVEVER_SW 6
 #define SAVEVER_PS 6
 

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3322,21 +3322,6 @@ void P_GetInput(int const playerNum)
         }
     }
 
-    if (pPlayer->return_to_center > 0)
-        pPlayer->return_to_center--;
-
-    if (pPlayer->hard_landing)
-    {
-        pPlayer->return_to_center = 9;
-        thisPlayer.horizRecenter  = true;
-    }
-
-    if (pPlayer->hard_landing > 0)
-    {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
-        pPlayer->hard_landing--;
-    }
-
     // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
 
     if (thisPlayer.horizAngleAdjust)
@@ -5712,7 +5697,10 @@ RECHECK:
             G_ActivateBySector(pPlayer->cursectnum, pPlayer->i);
     }
 
-    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW))
+    if (pPlayer->return_to_center > 0)
+        pPlayer->return_to_center--;
+
+    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
         if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
@@ -5755,6 +5743,12 @@ RECHECK:
             thisPlayer.horizAngleAdjust = -float(6 << (int)(TEST_SYNC_KEY(playerBits, SK_RUN)));
             thisPlayer.horizRecenter    = false;
         }
+    }
+
+    if (pPlayer->hard_landing > 0)
+    {
+        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        pPlayer->hard_landing--;
     }
 
     //Shooting code/changes

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3374,7 +3374,7 @@ void P_GetInput(int const playerNum)
     }
 
     if (thisPlayer.horizSkew)
-        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(thisPlayer.horizSkew))));
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(thisPlayer.horizSkew)));
 
     pPlayer->q16horiz = fix16_clamp(pPlayer->q16horiz, F16(HORIZ_MIN), F16(HORIZ_MAX));
 }
@@ -5747,7 +5747,7 @@ RECHECK:
 
     if (pPlayer->hard_landing > 0)
     {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        thisPlayer.horizSkew = -(pPlayer->hard_landing << 4);
         pPlayer->hard_landing--;
     }
 
@@ -5776,7 +5776,7 @@ RECHECK:
 #ifndef EDUKE32_STANDALONE
     if (!FURY && pPlayer->knee_incs > 0)
     {
-        thisPlayer.horizSkew = F16(-48);
+        thisPlayer.horizSkew = -48;
         thisPlayer.horizRecenter = true;
         pPlayer->return_to_center = 9;
 

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3043,13 +3043,17 @@ enum inputlock_t
 
 static int P_CheckLockedMovement(int const playerNum)
 {
-    auto const pPlayer = g_player[playerNum].ps;
+    auto      &thisPlayer = g_player[playerNum];
+    auto const pPlayer    = thisPlayer.ps;
 
     if (pPlayer->on_crane >= 0)
         return IL_NOMOVE|IL_NOANGLE;
 
     if (pPlayer->newowner != -1)
         return IL_NOANGLE|IL_NOHORIZ;
+
+    if (pPlayer->return_to_center > 0 || thisPlayer.horizRecenter)
+        return IL_NOHORIZ;
 
     if (pPlayer->dead_flag || pPlayer->fist_incs || pPlayer->transporter_hold > 2 || pPlayer->hard_landing || pPlayer->access_incs > 0
         || pPlayer->knee_incs > 0
@@ -3332,15 +3336,16 @@ void P_GetInput(int const playerNum)
     }
     else if (pPlayer->return_to_center > 0 || thisPlayer.horizRecenter)
     {
-        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(fix16_from_dbl(200 / 3) - fix16_sdiv(pPlayer->q16horiz, F16(1.5))))));
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(fix16_from_dbl(66.535) - fix16_sdiv(pPlayer->q16horiz, fix16_from_dbl(1.505))))));
 
-        if ((!pPlayer->return_to_center && thisPlayer.horizRecenter) || (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1)))
+        if (pPlayer->q16horiz >= F16(99) && pPlayer->q16horiz <= F16(101))
         {
             pPlayer->q16horiz = F16(100);
+            pPlayer->return_to_center = 0;
             thisPlayer.horizRecenter = false;
         }
 
-        if (pPlayer->q16horizoff >= F16(-0.1) && pPlayer->q16horizoff <= F16(0.1))
+        if (pPlayer->q16horizoff >= F16(-1) && pPlayer->q16horizoff <= F16(1))
             pPlayer->q16horizoff = 0;
     }
 

--- a/source/duke3d/src/player.h
+++ b/source/duke3d/src/player.h
@@ -230,7 +230,7 @@ typedef struct
 
     bool    horizRecenter;
     float   horizAngleAdjust;
-    fix16_t horizSkew;
+    int8_t  horizSkew;
 
     int32_t netsynctime;
     int16_t ping, filler;

--- a/source/exhumed/src/player.cpp
+++ b/source/exhumed/src/player.cpp
@@ -191,7 +191,7 @@ void PlayerInterruptKeys()
     else
     {
         input.nAngle = fix16_sadd(input.nAngle, fix16_sdiv(fix16_from_int(info.mousex), fix16_from_int(32)));
-        input.nAngle = fix16_sadd(input.nAngle, fix16_from_int(info.dyaw / analogExtent * (analogTurnAmount << 1)));
+        input.nAngle = fix16_sadd(input.nAngle, fix16_from_int(info.dyaw * analogTurnAmount / (analogExtent >> 1)));
     }
 
     g_MyAimMode = in_mousemode || buttonMap.ButtonDown(gamefunc_Mouse_Aiming);

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3505,21 +3505,6 @@ void P_GetInput(int const playerNum)
         }
     }
 
-    if (pPlayer->return_to_center > 0)
-        pPlayer->return_to_center--;
-
-    if (pPlayer->hard_landing)
-    {
-        pPlayer->return_to_center = 9;
-        thisPlayer.horizRecenter  = true;
-    }
-
-    if (pPlayer->hard_landing > 0)
-    {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
-        pPlayer->hard_landing--;
-    }
-
     // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
 
     if (thisPlayer.horizAngleAdjust)
@@ -4181,21 +4166,6 @@ void P_DHGetInput(int const playerNum)
 
     if (pPlayer->cursectnum >= 0 && sector[pPlayer->cursectnum].hitag == 2003)
         input.fvel >>= 1;
-
-    if (pPlayer->return_to_center > 0)
-        pPlayer->return_to_center--;
-
-    if (pPlayer->hard_landing)
-    {
-        pPlayer->return_to_center = 9;
-        thisPlayer.horizRecenter  = true;
-    }
-
-    if (pPlayer->hard_landing > 0)
-    {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
-        pPlayer->hard_landing--;
-    }
 
     // A horiz diff of 128 equal 45 degrees, so we convert horiz to 1024 angle units
 
@@ -8775,7 +8745,10 @@ HORIZONLY:;
         }
     }
 
-    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW))
+    if (pPlayer->return_to_center > 0)
+        pPlayer->return_to_center--;
+
+    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
         if (VM_OnEvent(EVENT_RETURNTOCENTER, pPlayer->i,playerNum) == 0)
         {
             pPlayer->return_to_center = 9;
@@ -8822,6 +8795,12 @@ HORIZONLY:;
         if (!delta) delta++;
         pPlayer->recoil -= delta;
         pPlayer->q16horiz -= F16(delta);
+    }
+
+    if (pPlayer->hard_landing > 0)
+    {
+        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        pPlayer->hard_landing--;
     }
 
     //Shooting code/changes
@@ -9419,7 +9398,10 @@ void P_DHProcessInput(int playerNum)
                                  A_GetFurthestAngle(pPlayer->i, 8) < 512);
     }
 
-    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW))
+    if (pPlayer->return_to_center > 0)
+        pPlayer->return_to_center--;
+
+    if (TEST_SYNC_KEY(playerBits, SK_CENTER_VIEW) || pPlayer->hard_landing)
     {
         pPlayer->return_to_center = 9;
         thisPlayer.horizRecenter  = true;
@@ -9453,6 +9435,12 @@ void P_DHProcessInput(int playerNum)
         if (!delta) delta++;
         pPlayer->recoil -= delta;
         pPlayer->q16horiz -= F16(delta);
+    }
+
+    if (pPlayer->hard_landing > 0)
+    {
+        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        pPlayer->hard_landing--;
     }
 
     if (TEST_SYNC_KEY(playerBits, SK_FIRE))

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3557,7 +3557,7 @@ void P_GetInput(int const playerNum)
     }
  
     if (thisPlayer.horizSkew)
-        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(thisPlayer.horizSkew))));
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(thisPlayer.horizSkew)));
  
     pPlayer->q16horiz = fix16_clamp(pPlayer->q16horiz, F16(HORIZ_MIN), F16(HORIZ_MAX));
 }
@@ -4201,7 +4201,7 @@ void P_DHGetInput(int const playerNum)
     }
  
     if (thisPlayer.horizSkew)
-        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(thisPlayer.horizSkew))));
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(thisPlayer.horizSkew)));
  
     pPlayer->q16horiz = fix16_clamp(pPlayer->q16horiz, F16(HORIZ_MIN), F16(HORIZ_MAX));
  
@@ -8799,7 +8799,7 @@ HORIZONLY:;
 
     if (pPlayer->hard_landing > 0)
     {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        thisPlayer.horizSkew = -(pPlayer->hard_landing << 4);
         pPlayer->hard_landing--;
     }
 
@@ -8829,7 +8829,7 @@ HORIZONLY:;
 
     if (pPlayer->knee_incs > 0)
     {
-        thisPlayer.horizSkew = F16(-48);
+        thisPlayer.horizSkew = -48;
         thisPlayer.horizRecenter = true;
         pPlayer->return_to_center = 9;
 
@@ -9439,7 +9439,7 @@ void P_DHProcessInput(int playerNum)
 
     if (pPlayer->hard_landing > 0)
     {
-        thisPlayer.horizSkew = fix16_from_int(-(pPlayer->hard_landing << 4));
+        thisPlayer.horizSkew = -(pPlayer->hard_landing << 4);
         pPlayer->hard_landing--;
     }
 

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3180,13 +3180,17 @@ enum inputlock_t
 
 static int P_CheckLockedMovement(int const playerNum)
 {
-    auto const pPlayer = g_player[playerNum].ps;
+    auto      &thisPlayer = g_player[playerNum];
+    auto const pPlayer    = thisPlayer.ps;
 
     if (pPlayer->on_crane >= 0)
         return IL_NOMOVE|IL_NOANGLE;
 
     if (pPlayer->newowner != -1)
         return IL_NOANGLE|IL_NOHORIZ;
+
+    if (pPlayer->return_to_center > 0 || thisPlayer.horizRecenter)
+        return IL_NOHORIZ;
 
     if (pPlayer->dead_flag || pPlayer->fist_incs || pPlayer->transporter_hold > 2 || pPlayer->hard_landing || pPlayer->access_incs > 0
         || pPlayer->knee_incs > 0
@@ -3515,15 +3519,16 @@ void P_GetInput(int const playerNum)
     }
     else if (pPlayer->return_to_center > 0 || thisPlayer.horizRecenter)
     {
-        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(fix16_from_dbl(200 / 3) - fix16_sdiv(pPlayer->q16horiz, F16(1.5))))));
+        pPlayer->q16horiz = fix16_sadd(pPlayer->q16horiz, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(fix16_from_dbl(66.535) - fix16_sdiv(pPlayer->q16horiz, fix16_from_dbl(1.505))))));
 
-        if ((!pPlayer->return_to_center && thisPlayer.horizRecenter) || (pPlayer->q16horiz >= F16(99.9) && pPlayer->q16horiz <= F16(100.1)))
+        if (pPlayer->q16horiz >= F16(99) && pPlayer->q16horiz <= F16(101))
         {
             pPlayer->q16horiz = F16(100);
+            pPlayer->return_to_center = 0;
             thisPlayer.horizRecenter = false;
         }
 
-        if (pPlayer->q16horizoff >= F16(-0.1) && pPlayer->q16horizoff <= F16(0.1))
+        if (pPlayer->q16horizoff >= F16(-1) && pPlayer->q16horizoff <= F16(1))
             pPlayer->q16horizoff = 0;
     }
  

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3681,13 +3681,13 @@ void P_GetInputMotorcycle(int playerNum)
     {
         if (turnLeft)
         {
-            pPlayer->tilt_status--;
+            pPlayer->tilt_status -= scaleAdjustmentToInterval(1);
             if (pPlayer->tilt_status < -10)
                 pPlayer->tilt_status = -10;
         }
         else if (turnRight)
         {
-            pPlayer->tilt_status++;
+            pPlayer->tilt_status += scaleAdjustmentToInterval(1);
             if (pPlayer->tilt_status > 10)
                 pPlayer->tilt_status = 10;
         }
@@ -3697,7 +3697,7 @@ void P_GetInputMotorcycle(int playerNum)
         if (turnLeft || pPlayer->moto_drink < 0)
         {
             turnHeldTime += elapsedTics;
-            pPlayer->tilt_status--;
+            pPlayer->tilt_status -= scaleAdjustmentToInterval(1);
             if (pPlayer->tilt_status < -10)
                 pPlayer->tilt_status = -10;
             if (turnHeldTime >= TURBOTURNTIME && pPlayer->moto_speed > 0)
@@ -3718,7 +3718,7 @@ void P_GetInputMotorcycle(int playerNum)
         else if (turnRight || pPlayer->moto_drink > 0)
         {
             turnHeldTime += elapsedTics;
-            pPlayer->tilt_status++;
+            pPlayer->tilt_status += scaleAdjustmentToInterval(1);
             if (pPlayer->tilt_status > 10)
                 pPlayer->tilt_status = 10;
             if (turnHeldTime >= TURBOTURNTIME && pPlayer->moto_speed > 0)
@@ -3741,11 +3741,14 @@ void P_GetInputMotorcycle(int playerNum)
             turnHeldTime = 0;
 
             if (pPlayer->tilt_status > 0)
-                pPlayer->tilt_status--;
+                pPlayer->tilt_status -= scaleAdjustmentToInterval(1);
             else if (pPlayer->tilt_status < 0)
-                pPlayer->tilt_status++;
+                pPlayer->tilt_status += scaleAdjustmentToInterval(1);
         }
     }
+
+    if (pPlayer->tilt_status > -0.025 && pPlayer->tilt_status < 0.025)
+        pPlayer->tilt_status = 0;
 
     if (pPlayer->moto_underwater)
     {
@@ -3913,7 +3916,7 @@ void P_GetInputBoat(int playerNum)
             turnHeldTime += elapsedTics;
             if (!pPlayer->not_on_water)
             {
-                pPlayer->tilt_status--;
+                pPlayer->tilt_status -= scaleAdjustmentToInterval(1);
                 if (pPlayer->tilt_status < -10)
                     pPlayer->tilt_status = -10;
                 if (turnHeldTime >= TURBOTURNTIME)
@@ -3932,7 +3935,7 @@ void P_GetInputBoat(int playerNum)
             turnHeldTime += elapsedTics;
             if (!pPlayer->not_on_water)
             {
-                pPlayer->tilt_status++;
+                pPlayer->tilt_status += scaleAdjustmentToInterval(1);
                 if (pPlayer->tilt_status > 10)
                     pPlayer->tilt_status = 10;
                 if (turnHeldTime >= TURBOTURNTIME)
@@ -3951,9 +3954,9 @@ void P_GetInputBoat(int playerNum)
             turnHeldTime = 0;
 
             if (pPlayer->tilt_status > 0)
-                pPlayer->tilt_status--;
+                pPlayer->tilt_status -= scaleAdjustmentToInterval(1);
             else if (pPlayer->tilt_status < 0)
-                pPlayer->tilt_status++;
+                pPlayer->tilt_status += scaleAdjustmentToInterval(1);
         }
     }
     else if (!pPlayer->not_on_water)
@@ -3961,10 +3964,13 @@ void P_GetInputBoat(int playerNum)
         turnHeldTime = 0;
 
         if (pPlayer->tilt_status > 0)
-            pPlayer->tilt_status--;
+            pPlayer->tilt_status -= scaleAdjustmentToInterval(1);
         else if (pPlayer->tilt_status < 0)
-            pPlayer->tilt_status++;
+            pPlayer->tilt_status += scaleAdjustmentToInterval(1);
     }
+
+    if (pPlayer->tilt_status > -0.025 && pPlayer->tilt_status < 0.025)
+        pPlayer->tilt_status = 0;
 
     input.fvel += pPlayer->moto_speed;
     input.q16avel = fix16_mul(input.q16avel, avelScale);
@@ -8574,9 +8580,10 @@ HORIZONLY:;
                         {
                             if (numplayers == 1)
                             {
+                                int tilt_status = pPlayer->tilt_status;
                                 vec3_t const vect = {
-                                    sintable[(pPlayer->tilt_status*20+fix16_to_int(pPlayer->q16ang)+512)&2047]>>8,
-                                    sintable[(pPlayer->tilt_status*20+fix16_to_int(pPlayer->q16ang))&2047]>>8,sprite[spriteNum].zvel
+                                    sintable[(tilt_status*20+fix16_to_int(pPlayer->q16ang)+512)&2047]>>8,
+                                    sintable[(tilt_status*20+fix16_to_int(pPlayer->q16ang))&2047]>>8,sprite[spriteNum].zvel
                                 };
 
                                 A_MoveSprite(spriteNum,&vect,CLIPMASK0);
@@ -8627,9 +8634,10 @@ HORIZONLY:;
                         {
                             if (numplayers == 1)
                             {
+                                int tilt_status = pPlayer->tilt_status;
                                 vec3_t const vect = {
-                                    sintable[(pPlayer->tilt_status*20+fix16_to_int(pPlayer->q16ang)+512)&2047]>>9,
-                                    sintable[(pPlayer->tilt_status*20+fix16_to_int(pPlayer->q16ang))&2047]>>9,sprite[spriteNum].zvel
+                                    sintable[(tilt_status*20+fix16_to_int(pPlayer->q16ang)+512)&2047]>>9,
+                                    sintable[(tilt_status*20+fix16_to_int(pPlayer->q16ang))&2047]>>9,sprite[spriteNum].zvel
                                 };
 
                                 A_MoveSprite(spriteNum,&vect,CLIPMASK0);

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3256,7 +3256,7 @@ void P_GetInput(int const playerNum)
     else
     {
         input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
-        input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw / analogExtent * (analogTurnAmount << 1)));
+        input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw * analogTurnAmount / (analogExtent >> 1)));
     }
 
     if (mouseaim)
@@ -3607,7 +3607,7 @@ void P_GetInputMotorcycle(int playerNum)
     input_t input {};
 
     input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
-    input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw / analogExtent * (analogTurnAmount << 1)));
+    input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw * analogTurnAmount / (analogExtent >> 1)));
 
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;
@@ -3837,7 +3837,7 @@ void P_GetInputBoat(int playerNum)
     input_t input {};
 
     input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
-    input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw / analogExtent * (analogTurnAmount << 1)));
+    input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw * analogTurnAmount / (analogExtent >> 1)));
 
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;

--- a/source/rr/src/player.h
+++ b/source/rr/src/player.h
@@ -235,7 +235,7 @@ typedef struct
 
     bool    horizRecenter;
     float   horizAngleAdjust;
-    fix16_t horizSkew;
+    int8_t  horizSkew;
 
     int32_t movefifoend, syncvalhead, myminlag;
     int32_t pcolor, pteam;

--- a/source/rr/src/player.h
+++ b/source/rr/src/player.h
@@ -210,7 +210,7 @@ typedef struct {
     int16_t drink_amt, eat_amt, drink_ang, eat_ang;
     int32_t drink_timer, eat_timer;
     int16_t level_end_timer;
-    int16_t moto_speed, tilt_status, moto_drink;
+    int16_t moto_speed, moto_drink;
     uint8_t on_motorcycle, on_boat, moto_underwater, not_on_water, moto_on_ground;
     uint8_t moto_do_bump, moto_bump_fast, moto_on_oil, moto_on_mud;
     int16_t moto_bump, moto_bump_target, moto_turb;
@@ -220,11 +220,12 @@ typedef struct {
     int32_t drug_timer;
     int32_t sea_sick;
     uint8_t hurt_delay2, nocheat;
+    double  tilt_status;
 
     int32_t dhat60f, dhat613, dhat617, dhat61b, dhat61f;
 
     int8_t crouch_toggle;
-    int8_t padding_[3];
+    int8_t padding_[1];
 } DukePlayer_t;
 
 // KEEPINSYNC lunatic/_defs_game.lua

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -3219,7 +3219,7 @@ void getinput(int const playerNum)
     else
     {
         input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), fix16_from_int(32)));
-        input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw / analogExtent * (analogTurnAmount << 1)));
+        input.q16avel = fix16_sadd(input.q16avel, fix16_from_int(info.dyaw * analogTurnAmount / (analogExtent >> 1)));
     }
 
     if (mouseaim)


### PR DESCRIPTION
Reverted some previous commits regarding better handling of returning to centre for Duke 3D and RR. Previous attempt wasn't the best as return to centre speed fluctuated with frame-rate, etc. What's here feels much more consistent and is very nice from a game-play point of view.

Other fixes are properly scaling the tilt angle for the motorbike and hovercraft in RRRA. Previously the tilt speed increased as the frame-rate did. Also backported some EDuke32 input improvements to the other games.