### PR TITLE
Death cam fixes

### DIFF
--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -726,9 +726,21 @@ void G_DrawRooms(int32_t playerNum, int32_t smoothRatio)
                                      pPlayer->opos.y + mulscale16(pPlayer->pos.y - pPlayer->opos.y, smoothRatio),
                                      pPlayer->opos.z + mulscale16(pPlayer->pos.z - pPlayer->opos.z, smoothRatio) };
 
-            CAMERA(pos)      = camVect;
-            CAMERA(q16ang)   = pPlayer->q16ang + fix16_from_int(pPlayer->look_ang);
-            CAMERA(q16horiz) = pPlayer->q16horiz + pPlayer->q16horizoff;
+            CAMERA(pos)          = camVect;
+
+            if (pPlayer->wackedbyactor >= 0)
+            {
+                CAMERA(q16ang)   = pPlayer->oq16ang
+                                 + mulscale16(((pPlayer->q16ang + F16(1024) - pPlayer->oq16ang) & 0x7FFFFFF) - F16(1024), smoothRatio)
+                                 + fix16_from_int(pPlayer->look_ang);
+                CAMERA(q16horiz) = pPlayer->oq16horiz + pPlayer->oq16horizoff
+                                 + mulscale16((pPlayer->q16horiz + pPlayer->q16horizoff - pPlayer->oq16horiz - pPlayer->oq16horizoff), smoothRatio);
+            }
+            else
+            {
+                CAMERA(q16ang)   = pPlayer->q16ang + fix16_from_int(pPlayer->look_ang);
+                CAMERA(q16horiz) = pPlayer->q16horiz + pPlayer->q16horizoff;
+            }
 
             if (cl_viewbob)
             {

--- a/source/rr/src/actors.cpp
+++ b/source/rr/src/actors.cpp
@@ -1228,7 +1228,7 @@ ACTOR_STATIC void G_MovePlayers(void)
 
                     if (pPlayer->wackedbyactor >= 0 && sprite[pPlayer->wackedbyactor].statnum < MAXSTATUS)
                     {
-                        pPlayer->q16ang += fix16_to_int(G_GetAngleDelta(pPlayer->q16ang,
+                        pPlayer->q16ang += fix16_from_int(G_GetAngleDelta(fix16_to_int(pPlayer->q16ang),
                                                                       getangle(sprite[pPlayer->wackedbyactor].x - pPlayer->pos.x,
                                                                                sprite[pPlayer->wackedbyactor].y - pPlayer->pos.y))
                                                       >> 1);

--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -1024,9 +1024,21 @@ void G_DrawRooms(int32_t playerNum, int32_t smoothRatio)
                                          pPlayer->opos.y + mulscale16(pPlayer->pos.y - pPlayer->opos.y, smoothRatio),
                                          pPlayer->opos.z + mulscale16(pPlayer->pos.z - pPlayer->opos.z, smoothRatio) };
 
-                CAMERA(pos)      = camVect;
-                CAMERA(q16ang)   = pPlayer->q16ang + fix16_from_int(pPlayer->look_ang);
-                CAMERA(q16horiz) = pPlayer->q16horiz + pPlayer->q16horizoff;
+                CAMERA(pos)          = camVect;
+
+                if (pPlayer->wackedbyactor >= 0)
+                {
+                    CAMERA(q16ang)   = pPlayer->oq16ang
+                                     + mulscale16(((pPlayer->q16ang + F16(1024) - pPlayer->oq16ang) & 0x7FFFFFF) - F16(1024), smoothRatio)
+                                     + fix16_from_int(pPlayer->look_ang);
+                    CAMERA(q16horiz) = pPlayer->oq16horiz + pPlayer->oq16horizoff
+                                     + mulscale16((pPlayer->q16horiz + pPlayer->q16horizoff - pPlayer->oq16horiz - pPlayer->oq16horizoff), smoothRatio);
+                }
+                else
+                {
+                    CAMERA(q16ang)   = pPlayer->q16ang + fix16_from_int(pPlayer->look_ang);
+                    CAMERA(q16horiz) = pPlayer->q16horiz + pPlayer->q16horizoff;
+                }
             }
 
             if (cl_viewbob)


### PR DESCRIPTION
Backport of an EDuke32 fix as well as the new implementations. Makes the camera smooth when chasing the actor who whacked you, which is done at ticrate and not frame rate.