### PR TITLE
Bump save versions for Duke3D following changes to DukePlayer_t struct.

### DIFF
--- a/source/core/version.h
+++ b/source/core/version.h
@@ -66,13 +66,13 @@ const char *GetVersionString();
 #define SAVESIG_SW GAMENAME ".ShadowWarrior"
 #define SAVESIG_PS GAMENAME ".Exhumed"
 
-#define MINSAVEVER_DN3D 7
+#define MINSAVEVER_DN3D 8
 #define MINSAVEVER_BLD 6
 #define MINSAVEVER_RR 7
 #define MINSAVEVER_SW 6
 #define MINSAVEVER_PS 6
 
-#define SAVEVER_DN3D 7
+#define SAVEVER_DN3D 8
 #define SAVEVER_BLD 6
 #define SAVEVER_RR 7
 #define SAVEVER_SW 6


### PR DESCRIPTION
Forgot about this in my previous PR. Previous saves are inoperable with the changes that have been made.

I bumped the save game ver for RR in a previous commit for the same reason. Since the changes are all within a release cycle, I won't bump it again.