### PR TITLE
Duke3D and RR: Move lastInputTicks to a different struct.

### DIFF
--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3135,9 +3135,9 @@ void P_GetInput(int const playerNum)
     input.fvel -= info.dz * keyMove / analogExtent;
 
     auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - pPlayer->lastInputTicks;
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
 
-    pPlayer->lastInputTicks = currentHiTicks;
+    thisPlayer.lastInputTicks = currentHiTicks;
 
     if (elapsedInputTicks == currentHiTicks)
         return;

--- a/source/duke3d/src/player.h
+++ b/source/duke3d/src/player.h
@@ -213,8 +213,6 @@ typedef struct {
 
     int8_t last_used_weapon;
 
-    double lastInputTicks;
-
 #ifdef LUNATIC
     int8_t palsfadespeed, palsfadenext, palsfadeprio, padding2_;
 
@@ -224,7 +222,7 @@ typedef struct {
 #endif
 
     int8_t crouch_toggle;
-    int8_t padding_[5];
+    int8_t padding_[1];
 } DukePlayer_t;
 
 // KEEPINSYNC lunatic/_defs_game.lua
@@ -238,6 +236,7 @@ typedef struct
     int8_t  horizSkew;
     bool    lookLeft;
     bool    lookRight;
+    double  lastInputTicks;
 
     int32_t netsynctime;
     int16_t ping, filler;

--- a/source/duke3d/src/premap.cpp
+++ b/source/duke3d/src/premap.cpp
@@ -719,7 +719,6 @@ void P_ResetPlayer(int playerNum)
     p.jumping_toggle     = 0;
     p.knee_incs          = 0;
     p.knuckle_incs       = 1;
-    p.lastInputTicks     = 0;
     p.last_full_weapon   = 0;
     p.last_pissed_time   = 0;
     p.loogcnt            = 0;
@@ -781,6 +780,7 @@ void P_ResetPlayer(int playerNum)
     g_player[playerNum].horizRecenter    = 0;
     g_player[playerNum].horizSkew        = 0;
     g_player[playerNum].horizAngleAdjust = 0;
+    g_player[playerNum].lastInputTicks   = 0;
 
     P_UpdateScreenPal(&p);
     VM_OnEvent(EVENT_RESETPLAYER, p.i, playerNum);

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3273,9 +3273,9 @@ void P_GetInput(int const playerNum)
     input.fvel -= info.dz * keyMove / analogExtent;
 
     auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - pPlayer->lastInputTicks;
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
 
-    pPlayer->lastInputTicks = currentHiTicks;
+    thisPlayer.lastInputTicks = currentHiTicks;
 
     if (elapsedInputTicks == currentHiTicks)
         return;
@@ -3671,9 +3671,9 @@ void P_GetInputMotorcycle(int playerNum)
     input.fvel -= info.dz * keyMove / analogExtent;
 
     auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - pPlayer->lastInputTicks;
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
 
-    pPlayer->lastInputTicks = currentHiTicks;
+    thisPlayer.lastInputTicks = currentHiTicks;
 
     if (elapsedInputTicks == currentHiTicks)
         return;
@@ -3925,9 +3925,9 @@ void P_GetInputBoat(int playerNum)
     input.fvel -= info.dz * keyMove / analogExtent;
 
     auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - pPlayer->lastInputTicks;
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
 
-    pPlayer->lastInputTicks = currentHiTicks;
+    thisPlayer.lastInputTicks = currentHiTicks;
 
     if (elapsedInputTicks == currentHiTicks)
         return;
@@ -4190,9 +4190,9 @@ void P_DHGetInput(int const playerNum)
     input.fvel -= info.dz * keyMove / analogExtent;
 
     auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - pPlayer->lastInputTicks;
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
 
-    pPlayer->lastInputTicks = currentHiTicks;
+    thisPlayer.lastInputTicks = currentHiTicks;
 
     if (elapsedInputTicks == currentHiTicks)
         return;

--- a/source/rr/src/player.h
+++ b/source/rr/src/player.h
@@ -223,7 +223,7 @@ typedef struct {
     int32_t drug_timer;
     int32_t sea_sick;
     uint8_t hurt_delay2, nocheat;
-    double  tilt_status, lastInputTicks;
+    double  tilt_status;
 
     int32_t dhat60f, dhat613, dhat617, dhat61b, dhat61f;
 
@@ -242,6 +242,7 @@ typedef struct
     int8_t  horizSkew;
     bool    lookLeft;
     bool    lookRight;
+    double  lastInputTicks;
 
     int32_t movefifoend, syncvalhead, myminlag;
     int32_t pcolor, pteam;

--- a/source/rr/src/premap.cpp
+++ b/source/rr/src/premap.cpp
@@ -2471,7 +2471,7 @@ int G_EnterLevel(int gameMode)
     renderFlushPerms();
 
     // reset lastInputTicks.
-    g_player[myconnectindex].ps->lastInputTicks = 0;
+    g_player[myconnectindex].lastInputTicks = 0;
 
     everyothertime = 0;
     g_globalRandom = 0;


### PR DESCRIPTION
Best that this data not be in the DukePlayer_t struct since it's data that never needs to be sent to other clients in a multiplayer situation.

Having this in the playerdata_t struct is also in line with where all the new properties concerning input being tied to frame-rate are kept.