### PR TITLE
SW: Fix broken interpolation pathway

### DIFF
--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -2012,13 +2012,13 @@ drawscreen(PLAYERp pp)
     if (/*PEDANTIC_MODE ||*/ pp->sop_control ||
         pp == Player+myconnectindex && TEST(pp->Flags, PF_DEAD))
     {
-        tq16ang = camerapp->q16ang;
-        tq16horiz = camerapp->q16horiz;
+        tq16ang = camerapp->oq16ang + mulscale16(((camerapp->q16ang + fix16_from_int(1024) - camerapp->oq16ang) & 0x7FFFFFF) - fix16_from_int(1024), smoothratio);
+        tq16horiz = camerapp->oq16horiz + mulscale16(camerapp->q16horiz - camerapp->oq16horiz, smoothratio);
     }
     else
     {
-        tq16ang = camerapp->oq16ang + mulscale16(((camerapp->q16ang + fix16_from_int(1024) - camerapp->oq16ang) & 0x7FFFFFF) - fix16_from_int(1024), smoothratio);
-        tq16horiz = camerapp->oq16horiz + mulscale16(camerapp->q16horiz - camerapp->oq16horiz, smoothratio);
+        tq16ang = camerapp->q16ang;
+        tq16horiz = camerapp->q16horiz;
     }
 
     tsectnum = camerapp->cursectnum;


### PR DESCRIPTION
What 43ec16eb5576124bed3699943bb70b9ea943bd93 intends to do was already done via 2d734664259e47b999fe989b924ecaa0a97bb109, however I applied the if statement in the opposite order so when it was cherry-picked again, the pathway was actually reversed - interpolating when alive and not when dead.

Rather than re-apply the opposite order, I've made the if statement match upstream for more consistency and to avoid further conflicts.