### PR TITLE
SW input improvements

### DIFF
--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -2009,8 +2009,7 @@ drawscreen(PLAYERp pp)
     tx = camerapp->oposx + mulscale16(camerapp->posx - camerapp->oposx, smoothratio);
     ty = camerapp->oposy + mulscale16(camerapp->posy - camerapp->oposy, smoothratio);
     tz = camerapp->oposz + mulscale16(camerapp->posz - camerapp->oposz, smoothratio);
-    if (/*PEDANTIC_MODE ||*/ pp->sop_control ||
-        pp == Player+myconnectindex && TEST(pp->Flags, PF_DEAD))
+    if (pp == Player+myconnectindex && (pp->on_vehicle || pp->sop_control || TEST(pp->Flags, PF_DEAD)))
     {
         tq16ang = camerapp->oq16ang + mulscale16(((camerapp->q16ang + fix16_from_int(1024) - camerapp->oq16ang) & 0x7FFFFFF) - fix16_from_int(1024), smoothratio);
         tq16horiz = camerapp->oq16horiz + mulscale16(camerapp->q16horiz - camerapp->oq16horiz, smoothratio);

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -1054,11 +1054,9 @@ ResizeView(PLAYERp pp)
 
         if (inputState.GetKeyStatus(KEYSC_ESC))
         {
-            extern SWBOOL ScrollMode2D;
-
 			inputState.ClearKeyStatus(sc_Escape);
             dimensionmode = 3;
-            ScrollMode2D = FALSE;
+            pp->ScrollMode2D = FALSE;
             SetRedrawScreen(pp);
         }
     }
@@ -2189,9 +2187,7 @@ drawscreen(PLAYERp pp)
 
     if ((dimensionmode == 5 || dimensionmode == 6) && pp == Player+myconnectindex)
     {
-        extern SWBOOL ScrollMode2D;
-
-        if (ScrollMode2D)
+        if (pp->ScrollMode2D)
         {
             tx = pp->mfposx;
             ty = pp->mfposy;
@@ -2218,7 +2214,7 @@ drawscreen(PLAYERp pp)
         }
 
         // Draw the line map on top of texture 2d map or just stand alone
-        drawoverheadmap(tx, ty, zoom, fix16_to_int(tq16ang));
+        drawoverheadmap(tx, ty, zoom, fix16_to_int(tq16ang), pp->ScrollMode2D);
     }
 
     for (j = 0; j < MAXSPRITES; j++)

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -188,7 +188,6 @@ SWBOOL FirstTimeIntoGame;
 SWBOOL BorderAdjust = FALSE;
 SWBOOL InterpolateSectObj;
 SWBOOL LocationInfo = 0;
-void drawoverheadmap(int cposx, int cposy, int czoom, short cang);
 int DispFrameRate = FALSE;
 int DispMono = TRUE;
 int Fog = FALSE;
@@ -229,7 +228,6 @@ SWBOOL PauseMode = FALSE;
 SWBOOL PauseKeySet = FALSE;
 SWBOOL SlowMode = FALSE;
 SWBOOL FrameAdvanceTics = 3;
-SWBOOL ScrollMode2D = FALSE;
 
 SWBOOL DebugSO = FALSE;
 SWBOOL DebugPanel = FALSE;
@@ -2556,7 +2554,7 @@ void RunLevel(void)
                 domovethings();
             }
 
-            if (!ScrollMode2D && !pp->on_vehicle)
+            if (!pp->ScrollMode2D && !pp->on_vehicle)
                 getinput(myconnectindex);
         }
 
@@ -3118,7 +3116,7 @@ void getinput(int const playerNum)
             MirrorDelay = 1;
             dimensionmode = 3;
             SetFragBar(pp);
-            ScrollMode2D = FALSE;
+            pp->ScrollMode2D = FALSE;
             SetRedrawScreen(pp);
         }
     }
@@ -3129,14 +3127,14 @@ void getinput(int const playerNum)
         if (buttonMap.ButtonDown(gamefunc_Map_Follow_Mode))
         {
 			buttonMap.ClearButton(gamefunc_Map_Follow_Mode);
-            ScrollMode2D = !ScrollMode2D;
+            pp->ScrollMode2D = !pp->ScrollMode2D;
             pp->mfposx = pp->posx;
             pp->mfposy = pp->posy;
         }
     }
 
     // If in 2D follow mode, scroll around.
-    if (ScrollMode2D && !Prediction)
+    if (pp->ScrollMode2D && !Prediction)
     {
         keymove = keymove / 2;
 
@@ -3154,7 +3152,7 @@ void getinput(int const playerNum)
         if (buttonMap.ButtonDown(gamefunc_Map_Follow_Mode))
         {
             buttonMap.ClearButton(gamefunc_Map_Follow_Mode);
-            ScrollMode2D = !ScrollMode2D;
+            pp->ScrollMode2D = !pp->ScrollMode2D;
             // Reset coords
             pp->mfposx = pp->posx;
             pp->mfposy = pp->posy;
@@ -3208,7 +3206,7 @@ void getinput(int const playerNum)
     }
 
     // !JIM! Added M_Active() so that you don't move at all while using menus
-    if (M_Active() || ScrollMode2D || InputMode)
+    if (M_Active() || pp->ScrollMode2D || InputMode)
         return;
 
     SET_LOC_KEY(localInput.bits, SK_SPACE_BAR, ((!!inputState.GetKeyStatus(KEYSC_SPACE)) | buttonMap.ButtonDown(gamefunc_Open)));
@@ -3585,7 +3583,7 @@ void getinput(int const playerNum)
 
 #define MAP_BLOCK_SPRITE    (DK_BLUE + 6)
 
-void drawoverheadmap(int cposx, int cposy, int czoom, short cang)
+void drawoverheadmap(int cposx, int cposy, int czoom, short cang, SWBOOL ScrollMode2D)
 {
     int i, j, k, l, x1, y1, x2, y2, x3, y3, x4, y4, ox, oy, xoff, yoff;
     int dax, day, cosang, sinang, xspan, yspan, sprx, spry;

--- a/source/sw/src/game.h
+++ b/source/sw/src/game.h
@@ -1283,7 +1283,7 @@ struct PLAYERstruct
     short Heads;                    // Number of Accursed Heads orbiting player
     int PlayerVersion;
 
-    SWBOOL on_vehicle;
+    SWBOOL on_vehicle, ScrollMode2D;
 };
 
 extern PLAYER Player[MAX_SW_PLAYERS_REG+1];
@@ -2402,7 +2402,7 @@ int DoSkullBeginDeath(int16_t SpriteNum); // skull.c
 void AnimateCacheCursor(void);  // game.c
 void TerminateGame(void);   // game.c
 void TerminateLevel(void);  // game.c
-void drawoverheadmap(int cposx,int cposy,int czoom,short cang); // game.c
+void drawoverheadmap(int cposx,int cposy,int czoom,short cang, SWBOOL ScrollMode2D); // game.c
 void DrawMenuLevelScreen(void); // game.c
 void DebugWriteString(char *string);    // game.c
 void ManualPlayerInsert(PLAYERp pp);    // game.c

--- a/source/sw/src/game.h
+++ b/source/sw/src/game.h
@@ -1282,6 +1282,8 @@ struct PLAYERstruct
     short Reverb;                   // Player's current reverb setting
     short Heads;                    // Number of Accursed Heads orbiting player
     int PlayerVersion;
+
+    SWBOOL on_vehicle;
 };
 
 extern PLAYER Player[MAX_SW_PLAYERS_REG+1];

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -1583,7 +1583,7 @@ DoPlayerTurnBoat(PLAYERp pp)
     }
     else
     {
-        angvel = fix16_smul(pp->input.q16avel, fix16_from_float(PLAYER_TURN_SCALE));
+        angvel = fix16_smul(pp->input.q16avel, fix16_from_int(PLAYER_TURN_SCALE));
         angvel = fix16_sadd(angvel, fix16_ssub(angvel, fix16_sdiv(angvel, fix16_from_int(4))));
         angvel = fix16_sdiv(fix16_smul(angvel, fix16_from_int(synctics)), fix16_from_int(32));
     }

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -1188,6 +1188,16 @@ SWBOOL
 FAFcansee(int32_t xs, int32_t ys, int32_t zs, int16_t sects,
           int32_t xe, int32_t ye, int32_t ze, int16_t secte);
 
+SWBOOL
+P_CheckOperatingVehicle(PLAYERp pp)
+{
+    SWBOOL on_vehicle = pp->DoPlayerAction == DoPlayerOperateBoat ||
+                        pp->DoPlayerAction == DoPlayerOperateTank ||
+                        pp->DoPlayerAction == DoPlayerOperateTurret;
+
+    return on_vehicle;
+}
+
 int
 DoPickTarget(SPRITEp sp, uint32_t max_delta_ang, SWBOOL skip_targets)
 {
@@ -1732,6 +1742,229 @@ void SlipSlope(PLAYERp pp)
 }
 
 extern int PlaxCeilGlobZadjust, PlaxFloorGlobZadjust;
+
+double scaleAdjustmentToInterval(double x);
+
+void
+DoPlayerHorizon(PLAYERp pp, fix16_t *q16horz)
+{
+#define HORIZ_SPEED  (16)
+
+    // Fixme: This should probably be made optional.
+    if (cl_slopetilting)
+    {
+        int x,y,k,j;
+        short tempsect;
+
+        if (!TEST(pp->Flags, PF_FLYING|PF_SWIMMING|PF_DIVING|PF_CLIMBING|PF_JUMPING|PF_FALLING))
+        {
+            if (!TEST(pp->Flags, PF_MOUSE_AIMING_ON) && TEST(sector[pp->cursectnum].floorstat, FLOOR_STAT_SLOPE)) // If the floor is sloped
+            {
+                // Get a point, 512 units ahead of player's position
+                x = pp->posx + (sintable[(fix16_to_int(pp->q16ang) + 512) & 2047] >> 5);
+                y = pp->posy + (sintable[fix16_to_int(pp->q16ang) & 2047] >> 5);
+                tempsect = pp->cursectnum;
+                COVERupdatesector(x, y, &tempsect);
+
+                if (tempsect >= 0) // If the new point is inside a valid sector...
+                {
+                    // Get the floorz as if the new (x,y) point was still in
+                    // your sector
+                    j = getflorzofslope(pp->cursectnum, pp->posx, pp->posy);
+                    k = getflorzofslope(pp->cursectnum, x, y);
+
+                    // If extended point is in same sector as you or the slopes
+                    // of the sector of the extended point and your sector match
+                    // closely (to avoid accidently looking straight out when
+                    // you're at the edge of a sector line) then adjust horizon
+                    // accordingly
+                    if ((pp->cursectnum == tempsect) || (klabs(getflorzofslope(tempsect, x, y) - k) <= (4 << 8)))
+                    {
+                        if (!pp->on_vehicle)
+                        {
+                            pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_dbl(scaleAdjustmentToInterval(mulscale16((j - k), 160))));
+                        }
+                        else
+                        {
+                            pp->q16horizoff += fix16_from_int((((j - k) * 160) >> 16));
+                        }
+                    }
+                }
+            }
+        }
+
+        if (TEST(pp->Flags, PF_CLIMBING))
+        {
+            // tilt when climbing but you can't even really tell it
+            if (pp->q16horizoff < fix16_from_int(100))
+            {
+                if (!pp->on_vehicle)
+                {
+                    pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(((fix16_from_int(100) - pp->q16horizoff) >> 3) + fix16_one))));
+                }
+                else
+                {
+                    pp->q16horizoff += fix16_from_int((((100 - fix16_to_int(pp->q16horizoff)) >> 3) + 1));
+                }
+            }
+        }
+        else
+        {
+            // Make q16horizoff grow towards 0 since q16horizoff is not modified when
+            // you're not on a slope
+            if (pp->q16horizoff > 0)
+            {
+                if (!pp->on_vehicle)
+                {
+                    pp->q16horizoff = fix16_ssub(pp->q16horizoff, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl((pp->q16horizoff >> 3) + fix16_one))));
+                    pp->q16horizoff = fix16_max(pp->q16horizoff, 0);
+                }
+                else
+                {
+                    pp->q16horizoff -= fix16_from_int(((fix16_to_int(pp->q16horizoff) >> 3) + 1));
+                }
+            }
+            else if (pp->q16horizoff < 0)
+            {
+                if (!pp->on_vehicle)
+                {
+                    pp->q16horizoff = fix16_sadd(pp->q16horizoff, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl((-pp->q16horizoff >> 3) + fix16_one))));
+                    pp->q16horizoff = fix16_min(pp->q16horizoff, 0);
+                }
+                else
+                {
+                    pp->q16horizoff += fix16_from_int((((fix16_to_int(-pp->q16horizoff)) >> 3) + 1));
+                }
+            }
+        }
+    }
+
+    if (*q16horz)
+    {
+        if (!pp->on_vehicle)
+        {
+            pp->q16horizbase = fix16_sadd(pp->q16horizbase, *q16horz);
+        }
+        else
+        {
+            pp->q16horizbase += *q16horz;
+        }
+        SET(pp->Flags, PF_LOCK_HORIZ | PF_LOOKING);
+    }
+
+    // this is the locked type
+    if (TEST_SYNC_KEY(pp, SK_SNAP_UP) || TEST_SYNC_KEY(pp, SK_SNAP_DOWN))
+    {
+        // set looking because player is manually looking
+        SET(pp->Flags, PF_LOCK_HORIZ | PF_LOOKING);
+
+        // adjust pp->q16horiz negative
+        if (TEST_SYNC_KEY(pp, SK_SNAP_DOWN))
+        {
+            if (!pp->on_vehicle)
+            {
+                pp->q16horizbase = fix16_ssub(pp->q16horizbase, fix16_from_dbl(scaleAdjustmentToInterval(HORIZ_SPEED / 2)));
+            }
+            else
+            {
+                pp->q16horizbase -= fix16_from_int((HORIZ_SPEED/2));
+            }
+        }
+
+        // adjust pp->q16horiz positive
+        if (TEST_SYNC_KEY(pp, SK_SNAP_UP))
+        {
+            if (!pp->on_vehicle)
+            {
+                pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_dbl(scaleAdjustmentToInterval(HORIZ_SPEED / 2)));
+            }
+            else
+            {
+                pp->q16horizbase += fix16_from_int((HORIZ_SPEED/2));
+            }
+        }
+    }
+
+    // this is the unlocked type
+    if (TEST_SYNC_KEY(pp, SK_LOOK_UP) || TEST_SYNC_KEY(pp, SK_LOOK_DOWN) || TEST_SYNC_KEY(pp, SK_CENTER_VIEW))
+    {
+        RESET(pp->Flags, PF_LOCK_HORIZ);
+        SET(pp->Flags, PF_LOOKING);
+
+        // adjust pp->q16horiz negative
+        if (TEST_SYNC_KEY(pp, SK_LOOK_DOWN))
+        {
+            if (!pp->on_vehicle)
+            {
+                pp->q16horizbase = fix16_ssub(pp->q16horizbase, fix16_from_dbl(scaleAdjustmentToInterval(HORIZ_SPEED)));
+            }
+            else
+            {
+                pp->q16horizbase -= fix16_from_int(HORIZ_SPEED);
+            }
+        }
+
+        // adjust pp->q16horiz positive
+        if (TEST_SYNC_KEY(pp, SK_LOOK_UP))
+        {
+            if (!pp->on_vehicle)
+            {
+                pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_dbl(scaleAdjustmentToInterval(HORIZ_SPEED)));
+            }
+            else
+            {
+                pp->q16horizbase += fix16_from_int(HORIZ_SPEED);
+            }
+        }
+
+        // reset pp->q16horizoff when resetting to center.
+        if (TEST_SYNC_KEY(pp, SK_CENTER_VIEW))
+            pp->q16horizoff = 0;
+    }
+
+    if (!TEST(pp->Flags, PF_LOCK_HORIZ))
+    {
+        if (!(TEST_SYNC_KEY(pp, SK_LOOK_UP) || TEST_SYNC_KEY(pp, SK_LOOK_DOWN)))
+        {
+            // not pressing the pp->q16horiz keys
+            if (pp->q16horizbase != fix16_from_int(100))
+            {
+                int i;
+
+                // move pp->q16horiz back to 100
+                for (i = 1; i; i--)
+                {
+                    // this formula does not work for pp->q16horiz = 101-103
+                    if (!pp->on_vehicle)
+                    {
+                        pp->q16horizbase = fix16_sadd(pp->q16horizbase, fix16_from_dbl(scaleAdjustmentToInterval(fix16_to_dbl(fix16_ssub(fix16_from_int(25), fix16_sdiv(pp->q16horizbase, fix16_from_int(4)))))));
+                    }
+                    else
+                    {
+                        pp->q16horizbase += fix16_from_int(25 - (fix16_to_int(pp->q16horizbase) >> 2));
+                    }
+                }
+            }
+            else
+            {
+                // not looking anymore because pp->q16horiz is back at 100
+                RESET(pp->Flags, PF_LOOKING);
+            }
+        }
+    }
+
+    // bound the base
+    pp->q16horizbase = fix16_clamp(pp->q16horizbase, fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
+
+    // bound adjust q16horizoff
+    if (pp->q16horizbase + pp->q16horizoff < fix16_from_int(PLAYER_HORIZ_MIN))
+        pp->q16horizoff = fix16_ssub(fix16_from_int(PLAYER_HORIZ_MIN), pp->q16horizbase);
+    else if (pp->q16horizbase + pp->q16horizoff > fix16_from_int(PLAYER_HORIZ_MAX))
+        pp->q16horizoff = fix16_ssub(fix16_from_int(PLAYER_HORIZ_MAX), pp->q16horizbase);
+
+    // add base and offsets
+    pp->q16horiz = fix16_clamp((pp->q16horizbase + pp->q16horizoff), fix16_from_int(PLAYER_HORIZ_MIN), fix16_from_int(PLAYER_HORIZ_MAX));
+}
 
 void
 DoPlayerBob(PLAYERp pp)
@@ -2496,6 +2729,8 @@ DoPlayerMoveBoat(PLAYERp pp)
 
     OperateSectorObject(pp->sop, fix16_to_int(pp->q16ang), pp->posx, pp->posy);
     pp->cursectnum = save_sectnum; // for speed
+
+    DoPlayerHorizon(pp, &pp->input.q16horz);
 }
 
 #if 0
@@ -3006,6 +3241,8 @@ DoPlayerMoveTank(PLAYERp pp)
     OperateSectorObject(pp->sop, fix16_to_int(pp->q16ang), pp->posx, pp->posy);
     pp->cursectnum = save_sectnum; // for speed
 
+    DoPlayerHorizon(pp, &pp->input.q16horz);
+
     DoTankTreads(pp);
 }
 
@@ -3020,6 +3257,8 @@ DoPlayerMoveTurret(PLAYERp pp)
         SET(pp->Flags, PF_PLAYER_MOVED);
 
     OperateSectorObject(pp->sop, fix16_to_int(pp->q16ang), pp->sop->xmid, pp->sop->ymid);
+
+    DoPlayerHorizon(pp, &pp->input.q16horz);
 }
 
 void

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -7794,8 +7794,7 @@ domovethings(void)
         DoPlayerSectorUpdatePreMove(pp);
         ChopsCheck(pp);
 
-//        extern SWBOOL ScrollMode2D;
-        //if (!ScrollMode2D)
+        //if (!pp->ScrollMode2D)
         if (pp->DoPlayerAction) pp->DoPlayerAction(pp);
 
         UpdatePlayerSprite(pp);

--- a/source/sw/src/player.h
+++ b/source/sw/src/player.h
@@ -143,6 +143,8 @@ void PlaySOsound(short sectnum,short sound_num);
 void DoSpawnTeleporterEffectPlace(SPRITEp sp);
 void FindMainSector(SECTOR_OBJECTp sop);
 
+SWBOOL P_CheckOperatingVehicle(PLAYERp pp);
+
 END_SW_NS
 
 #endif


### PR DESCRIPTION
When making the player's input change at frame-rate, the code for `DoPlayerTurn()` and `DoPlayerHorizon()` were moved into `getinput()` as required. However, this caused some issues when operating vehicles as you'd have the vehicle code updating angle as well as `getinput()`.

These changes make the vehicles operate nicely, nicer than they do before this PR and nicer than they did in 0.5.1. In saying that, input for these is processed with the game's tic-rate. They're too complicated to move, it's more accurate to just do those corner cases at tic-rate.