### PR TITLE
SW: Allow sector object interpolations to be disabled for debugging.

### DIFF
--- a/source/core/gamecvars.cpp
+++ b/source/core/gamecvars.cpp
@@ -88,6 +88,7 @@ CVARD(Bool, cl_viewvbob, true, CVAR_ARCHIVE|CVAR_FRONTEND_BLOOD, "enable/disable
 CVARD(Bool, cl_interpolate, true, CVAR_ARCHIVE, "enable/disable view interpolation") // only implemented in Blood
 CVARD(Bool, cl_slopetilting, false, CVAR_ARCHIVE, "enable/disable slope tilting") // only implemented in Blood
 CVARD(Int, cl_showweapon, 1, CVAR_ARCHIVE, "enable/disable show weapons") // only implemented in Blood
+CVARD(Bool, cl_sointerpolation, true, CVAR_ARCHIVE, "enable/disable sector object interpolation") // only implemented in SW
 CUSTOM_CVARD(Int, cl_crosshairscale, 50, CVAR_ARCHIVE, "changes the size of the crosshair")
 {
 	if (self < 1) self = 1;

--- a/source/core/gamecvars.h
+++ b/source/core/gamecvars.h
@@ -23,6 +23,7 @@ EXTERN_CVAR(Bool, cl_slopetilting)
 EXTERN_CVAR(Int, cl_showweapon)
 EXTERN_CVAR(Int, cl_weaponswitch)
 EXTERN_CVAR(Int, cl_crosshairscale)
+EXTERN_CVAR(Bool, cl_sointerpolation)
 
 EXTERN_CVAR(Bool, demo_playloop)
 EXTERN_CVAR(Bool, demorec_seeds_cvar)

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -2034,7 +2034,7 @@ drawscreen(PLAYERp pp)
     {
         dointerpolations(smoothratio);                      // Stick at beginning of drawscreen
         short_dointerpolations(smoothratio);                      // Stick at beginning of drawscreen
-        if (gs.InterpolateSO)
+        if (cl_sointerpolation)
             so_dointerpolations(smoothratio);                           // Stick at beginning of drawscreen
     }
 
@@ -2053,7 +2053,7 @@ drawscreen(PLAYERp pp)
         tq16ang = camerapp->oq16ang + mulscale16(NORM_Q16ANGLE(camerapp->q16ang + fix16_from_int(1024) - camerapp->oq16ang) - fix16_from_int(1024), smoothratio);
         tq16horiz = camerapp->oq16horiz + mulscale16(camerapp->q16horiz - camerapp->oq16horiz, smoothratio);
     }
-    else if (gs.InterpolateSO && !CommEnabled)
+    else if (cl_sointerpolation && !CommEnabled)
     {
         tq16ang = camerapp->oq16ang + mulscale16(((pp->camq16ang + fix16_from_int(1024) - camerapp->oq16ang) & 0x7FFFFFF) - fix16_from_int(1024), smoothratio);
         tq16horiz = camerapp->oq16horiz + mulscale16(pp->camq16horiz - camerapp->oq16horiz, smoothratio);
@@ -2096,7 +2096,7 @@ drawscreen(PLAYERp pp)
     if (pp->sop_riding || pp->sop_control)
     {
         if (pp->sop_control &&
-            (!gs.InterpolateSO || (CommEnabled && !pp->sop_remote)))
+            (!cl_sointerpolation || (CommEnabled && !pp->sop_remote)))
         {
             tx = pp->posx;
             ty = pp->posy;
@@ -2324,7 +2324,7 @@ drawscreen(PLAYERp pp)
 
     restoreinterpolations();                 // Stick at end of drawscreen
     short_restoreinterpolations();                 // Stick at end of drawscreen
-    if (gs.InterpolateSO)
+    if (cl_sointerpolation)
         so_restoreinterpolations();                       // Stick at end of drawscreen
 
     PostDraw();

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -210,7 +210,6 @@ const GAME_SET gs_defaults =
 {
     2, // border
     0, // border tile
-	TRUE, // interpolate sector objects
 // Network game settings
     0, // GameType
     0, // Level

--- a/source/sw/src/interpso.cpp
+++ b/source/sw/src/interpso.cpp
@@ -183,7 +183,7 @@ void so_updateinterpolations(void) // Stick at beginning of domovethings
     SECTOR_OBJECTp sop;
     so_interp *interp;
     so_interp::interp_data *data;
-    SWBOOL interpolating = gs.InterpolateSO && !CommEnabled; // If changing from menu
+    SWBOOL interpolating = cl_sointerpolation && !CommEnabled; // If changing from menu
 
     for (sop = SectorObject, interp = so_interpdata;
          sop < &SectorObject[MAX_SECTOR_OBJECTS]; sop++, interp++)

--- a/source/sw/src/settings.h
+++ b/source/sw/src/settings.h
@@ -33,7 +33,6 @@ typedef struct
 {
     int8_t BorderNum;
     int8_t BorderTile;	// Network only - disabled
-    SWBOOL InterpolateSO;
 // Net Options from Menus
     uint8_t NetGameType;   // 0=DeathMatch [spawn], 1=Cooperative 2=DeathMatch [no spawn]
     uint8_t NetLevel;      // 1-28

--- a/source/sw/src/track.cpp
+++ b/source/sw/src/track.cpp
@@ -1636,7 +1636,7 @@ MovePlayer(PLAYERp pp, SECTOR_OBJECTp sop, int nx, int ny)
 
     if (TEST(sop->flags, SOBJ_DONT_ROTATE))
     {
-        if (!gs.InterpolateSO || CommEnabled)
+        if (!cl_sointerpolation || CommEnabled)
         {
             pp->oposx = pp->posx;
             pp->oposy = pp->posy;
@@ -1686,7 +1686,7 @@ MovePlayer(PLAYERp pp, SECTOR_OBJECTp sop, int nx, int ny)
     pp->camq16ang = NORM_Q16ANGLE(pp->camq16ang);
     pp->q16ang = NORM_Q16ANGLE(pp->RevolveQ16Ang + fix16_from_int(pp->RevolveDeltaAng));
 
-    if (!gs.InterpolateSO || CommEnabled)
+    if (!cl_sointerpolation || CommEnabled)
     {
         pp->oq16ang = pp->q16ang;
         pp->oposx = pp->posx;
@@ -1946,7 +1946,7 @@ PlayerPart:
                     pp->SpriteP->z = pp->loz;
                 }
             }
-            if (!gs.InterpolateSO || CommEnabled)
+            if (!cl_sointerpolation || CommEnabled)
                 pp->oposz = pp->posz;
         }
         else


### PR DESCRIPTION
New code is causing some issues that are being worked on, particularly a secret in $bullet/Level 1: Seppuku Station and the drill in $dozer/Level 2: Zilla Construction.

Upstream do expose this as a menu toggle, but I feel it's more for debugging than anything else. Can expose through the menu similar to `cl_slopetilting` if desired.