### PR TITLE
Uplift of pausing code for all games.

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -104,7 +104,6 @@ double g_gameUpdateAvgTime = 0.001;
 
 bool gQuitGame;
 int gQuitRequest;
-bool gPaused;
 
 enum gametokens
 {
@@ -663,7 +662,7 @@ void StartLevel(GAMEOPTIONS *gameOptions)
         gGameMessageMgr.SetCoordinates(gViewX0S+1,gViewY0S+15);
     netWaitForEveryone(0);
     totalclock = 0;
-    gPaused = 0;
+    paused = 0;
     gGameStarted = 1;
     ready2send = 1;
 }
@@ -823,8 +822,7 @@ void ProcessFrame(void)
         if (gPlayer[i].input.keyFlags.pause)
         {
             gPlayer[i].input.keyFlags.pause = 0;
-            gPaused = !gPaused;
-            if (gPaused && gGameOptions.nGameType > 0 && numplayers > 1)
+            if (paused && gGameOptions.nGameType > 0 && numplayers > 1)
             {
                 sprintf(buffer,"%s paused the game",gProfile[i].name);
                 viewSetMessage(buffer);
@@ -834,7 +832,7 @@ void ProcessFrame(void)
     viewClearInterpolations();
     if (!gDemo.at1)
     {
-        if (gPaused || gEndGameMgr.at0 || (gGameOptions.nGameType == 0 && M_Active()))
+        if (paused || gEndGameMgr.at0 || (gGameOptions.nGameType == 0 && M_Active()))
             return;
         if (gDemo.at0)
             gDemo.Write(gFifoInput[(gNetFifoTail-1)&255]);
@@ -1214,7 +1212,7 @@ RESTART:
         {
             char gameUpdate = false;
             double const gameUpdateStartTime = timerGetHiTicks();
-            while (gPredictTail < gNetFifoHead[myconnectindex] && !gPaused)
+            while (gPredictTail < gNetFifoHead[myconnectindex] && !paused)
             {
                 viewUpdatePrediction(&gFifoInput[gPredictTail&255][myconnectindex]);
             }

--- a/source/blood/src/blood.h
+++ b/source/blood/src/blood.h
@@ -121,7 +121,6 @@ extern double g_gameUpdateTime, g_gameUpdateAndDrawTime;
 extern double g_gameUpdateAvgTime;
 extern int blood_globalflags;
 
-extern bool gPaused;
 extern bool gSavingGame;
 extern bool gQuitGame;
 extern int gQuitRequest;

--- a/source/blood/src/loadsave.cpp
+++ b/source/blood/src/loadsave.cpp
@@ -561,7 +561,7 @@ bool GameInterface::LoadGame(FSaveGameNode* node)
     gFrame = 0;
     gFrameRate = 0;
     totalclock = 0;
-    gPaused = 0;
+    paused = 0;
     gGameStarted = 1;
     bVanilla = false;
     
@@ -662,7 +662,7 @@ void MyLoadSave::Load(void)
     Read(&totalclock, sizeof(totalclock));
     totalclock = nGameClock;
     Read(&gLevelTime, sizeof(gLevelTime));
-    Read(&gPaused, sizeof(gPaused));
+    Read(&paused, sizeof(paused));
     Read(baseWall, sizeof(baseWall[0])*numwalls);
     Read(baseSprite, sizeof(baseSprite[0])*nNumSprites);
     Read(baseFloor, sizeof(baseFloor[0])*numsectors);
@@ -755,7 +755,7 @@ void MyLoadSave::Save(void)
     ClockTicks nGameClock = totalclock;
     Write(&nGameClock, sizeof(nGameClock));
     Write(&gLevelTime, sizeof(gLevelTime));
-    Write(&gPaused, sizeof(gPaused));
+    Write(&paused, sizeof(paused));
     Write(baseWall, sizeof(baseWall[0])*numwalls);
     Write(baseSprite, sizeof(baseSprite[0])*nNumSprites);
     Write(baseFloor, sizeof(baseFloor[0])*numsectors);

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3088,7 +3088,7 @@ void viewDrawScreen(bool sceneonly)
     if (delta < 0)
         delta = 0;
     lastUpdate = totalclock;
-    if (!gPaused && (!M_Active() || gGameOptions.nGameType != 0))
+    if (!paused && (!M_Active() || gGameOptions.nGameType != 0))
     {
         gInterpolate = ((totalclock-gNetFifoClock)+4).toScale16()/4;
     }
@@ -3558,7 +3558,7 @@ void viewDrawScreen(bool sceneonly)
 
     viewDrawMapTitle();
     viewDrawAimedPlayerName();
-    if (gPaused)
+    if (paused)
     {
         viewDrawText(1, GStrings("TXTB_PAUSED"), 160, 10, 0, 0, 1, 0);
     }

--- a/source/common/audio/music/music.cpp
+++ b/source/common/audio/music/music.cpp
@@ -682,5 +682,3 @@ CCMD(currentmusic)
 		Printf("Currently no music playing\n");
 	}
 }
-
-extern int paused;

--- a/source/common/audio/music/music.cpp
+++ b/source/common/audio/music/music.cpp
@@ -167,9 +167,9 @@ static bool S_StartMusicPlaying(ZMusic_MusicStream song, bool loop, float rel_vo
 
 //==========================================================================
 //
-// S_PauseSound
+// S_PauseMusic
 //
-// Stop music and sound effects, during game PAUSE.
+// Stop music, during game PAUSE.
 //==========================================================================
 
 void S_PauseMusic ()
@@ -184,9 +184,9 @@ void S_PauseMusic ()
 
 //==========================================================================
 //
-// S_ResumeSound
+// S_ResumeMusic
 //
-// Resume music and sound effects, after game PAUSE.
+// Resume music, after game PAUSE.
 //==========================================================================
 
 void S_ResumeMusic ()
@@ -682,3 +682,5 @@ CCMD(currentmusic)
 		Printf("Currently no music playing\n");
 	}
 }
+
+extern int paused;

--- a/source/core/gamecontrol.cpp
+++ b/source/core/gamecontrol.cpp
@@ -114,6 +114,9 @@ CVAR(Bool, disableautoload, false, CVAR_ARCHIVE | CVAR_NOINITCALL | CVAR_GLOBALC
 
 extern int hud_size_max;
 
+int paused;
+bool pausedWithKey;
+
 CUSTOM_CVAR(Int, cl_gender, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 {
 	if (self < 0 || self > 3) self = 0;
@@ -828,6 +831,45 @@ CCMD(snd_reset)
 
 //==========================================================================
 //
+// S_PauseSound
+//
+// Stop music and sound effects, during game PAUSE.
+//
+//==========================================================================
+
+void S_PauseSound (bool notmusic, bool notsfx)
+{
+	if (!notmusic)
+	{
+		S_PauseMusic();
+	}
+	if (!notsfx)
+	{
+		soundEngine->SetPaused(true);
+		GSnd->SetSfxPaused (true, 0);
+	}
+}
+
+//==========================================================================
+//
+// S_ResumeSound
+//
+// Resume music and sound effects, after game PAUSE.
+//
+//==========================================================================
+
+void S_ResumeSound (bool notsfx)
+{
+	S_ResumeMusic();
+	if (!notsfx)
+	{
+		soundEngine->SetPaused(false);
+		GSnd->SetSfxPaused (false, 0);
+	}
+}
+
+//==========================================================================
+//
 // S_SetSoundPaused
 //
 // Called with state non-zero when the app is active, zero when it isn't.
@@ -836,7 +878,6 @@ CCMD(snd_reset)
 
 void S_SetSoundPaused(int state)
 {
-#if 0
 	if (state)
 	{
 		if (paused == 0)
@@ -855,21 +896,10 @@ void S_SetSoundPaused(int state)
 			S_PauseSound(false, true);
 			if (GSnd != nullptr)
 			{
-				GSnd->SetInactive(gamestate == GS_LEVEL || gamestate == GS_TITLELEVEL ?
-					SoundRenderer::INACTIVE_Complete :
-					SoundRenderer::INACTIVE_Mute);
+				GSnd->SetInactive(SoundRenderer::INACTIVE_Complete);
 			}
 		}
 	}
-	if (!netgame
-#ifdef _DEBUG
-		&& !demoplayback
-#endif
-		)
-	{
-		pauseext = !state;
-	}
-#endif
 }
 
 int CalcSmoothRatio(const ClockTicks &totalclk, const ClockTicks &ototalclk, int realgameticspersec)
@@ -940,3 +970,31 @@ bool CheckCheatmode(bool printmsg)
 	return false;
 }
 
+void updatePauseStatus()
+{
+    if (M_Active() || GUICapture)
+    {
+        paused = 1;
+    }
+    else if ((!M_Active() || !GUICapture) && !pausedWithKey)
+    {
+        paused = 0;
+    }
+
+    if (inputState.GetKeyStatus(sc_Pause))
+    {
+        inputState.ClearKeyStatus(sc_Pause);
+        paused = !paused;
+
+        if (paused)
+        {
+            S_PauseSound(!paused, !paused);
+        }
+        else
+        {
+            S_ResumeSound(paused);
+        }
+
+        pausedWithKey = paused;
+    }
+}

--- a/source/core/gamecontrol.h
+++ b/source/core/gamecontrol.h
@@ -154,6 +154,8 @@ const char* G_DefaultConFile(void);
 const char* G_ConFile(void);
 
 TArray<GrpEntry> GrpScan();
+void S_PauseSound(bool notmusic, bool notsfx);
+void S_ResumeSound(bool notsfx);
 void S_SetSoundPaused(int state);
 
 void G_FatalEngineError(void);
@@ -182,3 +184,5 @@ enum
 	PAUSESFX_CONSOLE = 2
 };
 
+void updatePauseStatus();
+extern int paused;

--- a/source/duke3d/src/d_menu.cpp
+++ b/source/duke3d/src/d_menu.cpp
@@ -425,7 +425,7 @@ void GameInterface::DrawNativeMenuText(int fontnum, int state, double xpos, doub
 
 void GameInterface::MenuOpened()
 {
-	S_PauseSounds(true);
+	S_PauseSound(true, false);
 	if ((!g_netServer && ud.multimode < 2))
 	{
 		ready2send = 0;
@@ -491,7 +491,7 @@ void GameInterface::MenuClosed()
 		}
 
 		G_UpdateScreenArea();
-		S_PauseSounds(false);
+		S_ResumeSound(false);
 	}
 }
 

--- a/source/duke3d/src/demo.cpp
+++ b/source/duke3d/src/demo.cpp
@@ -117,7 +117,7 @@ static int32_t G_OpenDemoRead(int32_t g_whichDemo) // 0 = mine
     ud.reccnt = 0;
 
     ud.god = ud.cashman = ud.eog = gFullMap = 0;
-    ud.noclip = ud.scrollmode = ud.overhead_on = 0; //= ud.pause_on = 0;
+    ud.noclip = ud.scrollmode = ud.overhead_on = 0; //= paused = 0;
 
     totalclock = ototalclock = lockclock = 0;
 
@@ -588,7 +588,7 @@ RECHECK:
                 Demo_FinishProfile();
 
             while (totalclock >= (lockclock+TICSPERFRAME)
-                //                   || (ud.reccnt > REALGAMETICSPERSEC*2 && ud.pause_on)
+                //                   || (ud.reccnt > REALGAMETICSPERSEC*2 && paused)
                 || (g_demo_goalCnt>0 && g_demo_cnt<g_demo_goalCnt))
             {
                 if (ud.reccnt<=0)

--- a/source/duke3d/src/game.h
+++ b/source/duke3d/src/game.h
@@ -317,7 +317,7 @@ static inline int32_t calc_smoothratio(ClockTicks totalclk, ClockTicks ototalclk
     if (!(((!g_netServer && ud.multimode < 2) && ((g_player[myconnectindex].ps->gm & MODE_MENU) == 0)) ||
           (g_netServer || ud.multimode > 1) ||
           ud.recstat == 2) ||
-        ud.pause_on)
+        paused)
     {
         return 65536;
     }

--- a/source/duke3d/src/gamestructures.cpp
+++ b/source/duke3d/src/gamestructures.cpp
@@ -1394,7 +1394,7 @@ int32_t __fastcall VM_GetUserdef(int32_t labelNum, int const lParm2)
         case USERDEFS_OVERHEAD_ON:            labelNum = ud.overhead_on;                  break;
         case USERDEFS_LAST_OVERHEAD:          labelNum = ud.last_overhead;                break;
         case USERDEFS_SHOWWEAPONS:            labelNum = ud.showweapons;                  break;
-        case USERDEFS_PAUSE_ON:               labelNum = ud.pause_on;                     break;
+        case USERDEFS_PAUSE_ON:               labelNum = paused;                          break;
         case USERDEFS_FROM_BONUS:             labelNum = ud.from_bonus;                   break;
         case USERDEFS_CAMERASPRITE:           labelNum = ud.camerasprite;                 break;
         case USERDEFS_LAST_CAMSPRITE:         labelNum = ud.last_camsprite;               break;
@@ -1582,7 +1582,7 @@ void __fastcall VM_SetUserdef(int const labelNum, int const lParm2, int32_t cons
         case USERDEFS_OVERHEAD_ON:                  ud.overhead_on                   = iSet; break;
         case USERDEFS_LAST_OVERHEAD:                ud.last_overhead                 = iSet; break;
         case USERDEFS_SHOWWEAPONS:                  ud.showweapons                   = iSet; break;
-        case USERDEFS_PAUSE_ON:                     ud.pause_on                      = iSet; break;
+        case USERDEFS_PAUSE_ON:                     paused                           = iSet; break;
         case USERDEFS_FROM_BONUS:                   ud.from_bonus                    = iSet; break;
         case USERDEFS_CAMERASPRITE:                 ud.camerasprite                  = iSet; break;
         case USERDEFS_LAST_CAMSPRITE:               ud.last_camsprite                = iSet; break;

--- a/source/duke3d/src/network.cpp
+++ b/source/duke3d/src/network.cpp
@@ -2275,7 +2275,7 @@ static void Net_ReceiveServerUpdate(ENetEvent *event)
     Bmemcpy(&serverupdate, updatebuf, sizeof(serverupdate_t));
     updatebuf += sizeof(serverupdate_t);
     inputfifo[0][0] = serverupdate.nsyn;
-    ud.pause_on     = serverupdate.pause_on;
+    paused          = serverupdate.pause_on;
 
     ticrandomseed = serverupdate.seed;
 
@@ -4945,7 +4945,7 @@ void Net_SendServerUpdates(void)
     serverupdate.header   = PACKET_MASTER_TO_SLAVE;
     serverupdate.seed     = ticrandomseed;
     serverupdate.nsyn     = *nsyn;
-    serverupdate.pause_on = ud.pause_on;
+    serverupdate.pause_on = paused;
 
     serverupdate.numplayers = 0;
     updatebuf               = tempnetbuf.Data() + sizeof(serverupdate_t);

--- a/source/duke3d/src/premap.cpp
+++ b/source/duke3d/src/premap.cpp
@@ -871,7 +871,7 @@ static void P_PrepForNewLevel(int playerNum, int gameMode)
 
     ud.camerasprite = -1;
     ud.eog          = 0;
-    ud.pause_on     = 0;
+    paused          = 0;
 
     if (((gameMode & MODE_EOL) != MODE_EOL && numplayers < 2 && !g_netServer)
         || (!(g_gametypeFlags[ud.coop] & GAMETYPE_PRESERVEINVENTORYDEATH) && numplayers > 1))
@@ -1728,7 +1728,7 @@ int G_EnterLevel(int gameMode)
 
     if (g_networkMode != NET_DEDICATED_SERVER)
     {
-        S_PauseSounds(false);
+        S_ResumeSound(false);
         FX_StopAllSounds();
         S_ClearSoundLocks();
         FX_SetReverb(0);

--- a/source/duke3d/src/savegame.cpp
+++ b/source/duke3d/src/savegame.cpp
@@ -1093,7 +1093,7 @@ static const dataspec_t svgm_udnetw[] =
     { DS_NOCHK, &ud.ffire, sizeof(ud.ffire), 1 },
     { DS_NOCHK, &ud.noexits, sizeof(ud.noexits), 1 },
     { DS_NOCHK, &ud.playerai, sizeof(ud.playerai), 1 },
-    { 0, &ud.pause_on, sizeof(ud.pause_on), 1 },
+    { 0, &paused, sizeof(paused), 1 },
     { 0, connectpoint2, sizeof(connectpoint2), 1 },
     { 0, &randomseed, sizeof(randomseed), 1 },
     { 0, &g_globalRandom, sizeof(g_globalRandom), 1 },

--- a/source/duke3d/src/screens.cpp
+++ b/source/duke3d/src/screens.cpp
@@ -784,7 +784,7 @@ void G_DisplayRest(int32_t smoothratio)
 
             if (ud.scrollmode == 0)
             {
-                if (pp->newowner == -1 && !ud.pause_on)
+                if (pp->newowner == -1 && !paused)
                 {
                     cposx = pp->opos.x + mulscale16(pp->pos.x-pp->opos.x, smoothratio);
                     cposy = pp->opos.y + mulscale16(pp->pos.y-pp->opos.y, smoothratio);
@@ -799,7 +799,7 @@ void G_DisplayRest(int32_t smoothratio)
             }
             else
             {
-                if (!ud.pause_on)
+                if (!paused)
                 {
                     ud.fola += ud.folavel>>3;
                     ud.folx += (ud.folfvel*sintable[(512+2048-ud.fola)&2047])>>14;
@@ -898,10 +898,10 @@ void G_DisplayRest(int32_t smoothratio)
         renderSetAspect(vr, asp);
     }
 
-    if (ud.pause_on==1 && (g_player[myconnectindex].ps->gm&MODE_MENU) == 0)
+    if (paused==1 && (g_player[myconnectindex].ps->gm&MODE_MENU) == 0)
         menutext_center(100, GStrings("Game Paused"));
 
-    mdpause = (ud.pause_on || (ud.recstat==2 && (g_demo_paused && g_demo_goalCnt==0)) || (g_player[myconnectindex].ps->gm&MODE_MENU && numplayers < 2));
+    mdpause = (paused || (ud.recstat==2 && (g_demo_paused && g_demo_goalCnt==0)) || (g_player[myconnectindex].ps->gm&MODE_MENU && numplayers < 2));
 
     // JBF 20040124: display level stats in screen corner
     if (ud.overhead_on != 2 && hud_stats && VM_OnEvent(EVENT_DISPLAYLEVELSTATS, g_player[screenpeek].ps->i, screenpeek) == 0)

--- a/source/duke3d/src/sector.cpp
+++ b/source/duke3d/src/sector.cpp
@@ -2628,28 +2628,7 @@ void P_HandleSharedKeys(int playerNum)
 
     if (playerBits && TEST_SYNC_KEY(playerBits, SK_MULTIFLAG) == 0)
     {
-        if (TEST_SYNC_KEY(playerBits, SK_PAUSE))
-        {
-            inputState.ClearKeyStatus(sc_Pause);
-            if (ud.pause_on)
-                ud.pause_on = 0;
-            else ud.pause_on = 1+SHIFTS_IS_PRESSED;
-            if (ud.pause_on)
-            {
-                Mus_SetPaused(true);
-                S_PauseSounds(true);
-            }
-            else
-            {
-                Mus_SetPaused(false);
-                S_PauseSounds(false);
-
-                pub = NUMPAGES;
-                pus = NUMPAGES;
-            }
-        }
-
-        if (ud.pause_on) return;
+        if (paused) return;
 
         if (sprite[pPlayer->i].extra <= 0) return;		// if dead...
 

--- a/source/duke3d/src/sounds.cpp
+++ b/source/duke3d/src/sounds.cpp
@@ -80,17 +80,6 @@ TArray<uint8_t> DukeSoundEngine::ReadSound(int lumpnum)
 //
 //==========================================================================
 
-void S_PauseSounds(bool paused)
-{
-    soundEngine->SetPaused(paused);
-}
-
-//==========================================================================
-//
-// 
-//
-//==========================================================================
-
 void cacheAllSounds(void)
 {
     auto& sfx = soundEngine->GetSounds();

--- a/source/duke3d/src/sounds.h
+++ b/source/duke3d/src/sounds.h
@@ -58,7 +58,6 @@ inline void S_ClearSoundLocks(void) {}
 void cacheAllSounds(void);
 void S_MenuSound(void);
 void S_PauseMusic(bool paused);
-void S_PauseSounds(bool paused);
 void S_PlayLevelMusicOrNothing(unsigned int);
 int S_TryPlaySpecialMusic(unsigned int);
 void S_PlaySpecialMusicOrNothing(unsigned int);

--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -730,7 +730,6 @@ short screensize;
 short bSnakeCam = kFalse;
 short bRecord = kFalse;
 short bPlayback = kFalse;
-short bPause = kFalse;
 short bInDemo = kFalse;
 short bSlipMode = kFalse;
 short bDoFlashes = kTrue;
@@ -1012,26 +1011,8 @@ void CheckKeys()
 		return;
     }
 
-    if (inputState.GetKeyStatus(sc_Pause))
+    if (paused)
     {
-        if (!nNetPlayerCount)
-        {
-            if (bPause)
-            {
-                ototalclock = totalclock = tclocks;
-                bPause = kFalse;
-            }
-            else
-            {
-                bPause = kTrue;
-                // NoClip();
-                // int nLen = MyGetStringWidth("PAUSED");
-                // myprintext((320 - nLen) / 2, 100, "PAUSED", 0);
-                // Clip();
-                // videoNextPage();
-            }
-			inputState.ClearKeyStatus(sc_Pause);
-        }
         return;
     }
 
@@ -1463,7 +1444,7 @@ void G_Polymer_UnInit(void) { }
 
 static inline int32_t calc_smoothratio(ClockTicks totalclk, ClockTicks ototalclk)
 {
-    if (bRecord || bPlayback || nFreeze != 0 || bCamera || bPause)
+    if (bRecord || bPlayback || nFreeze != 0 || bCamera || paused)
         return 65536;
 
     return CalcSmoothRatio(totalclk, ototalclk, 30);
@@ -1525,7 +1506,7 @@ static void GameDisplay(void)
 
     DrawView(smoothRatio);
 
-    if (bPause)
+    if (paused && !M_Active())
     {
         int nLen = MyGetStringWidth("PAUSED");
         myprintext((320 - nLen) / 2, 100, "PAUSED", 0);
@@ -2214,6 +2195,7 @@ GAMELOOP:
         }
 
 // TODO		CONTROL_GetButtonInput();
+        updatePauseStatus();
         CheckKeys();
 
         if (bRecord || bPlayback)
@@ -2279,12 +2261,12 @@ GAMELOOP:
             else
             {
                 // loc_11FBC:
-                while (bPause)
+                while (paused)
                 {
                     inputState.ClearAllInput();
                     if (WaitAnyKey(-1) != sc_Pause)
                     {
-                        bPause = kFalse;
+                        paused = kFalse;
                     }
                 }
             }
@@ -2332,7 +2314,7 @@ GAMELOOP:
         {
             bInMove = kTrue;
 
-            if (M_Active() || GUICapture || bPause)
+            if (paused)
             {
                 tclocks = totalclock - 4;
                 buttonMap.ResetButtonStates();
@@ -3267,7 +3249,7 @@ int DoSpiritHead()
 
 bool GameInterface::CanSave()
 {
-    return !bRecord && !bPlayback && !bPause && !bInDemo && nTotalPlayers == 1;
+    return !bRecord && !bPlayback && !paused && !bInDemo && nTotalPlayers == 1;
 }
 
 void GameInterface::UpdateScreenSize()

--- a/source/exhumed/src/player.cpp
+++ b/source/exhumed/src/player.cpp
@@ -159,6 +159,18 @@ void PlayerInterruptKeys()
     ControlInfo info;
 	memset(&info, 0, sizeof(ControlInfo)); // this is done within CONTROL_GetInput() anyway
     CONTROL_GetInput(&info);
+
+    static double lastInputTicks;
+    auto const    currentHiTicks    = timerGetHiTicks();
+    double const  elapsedInputTicks = currentHiTicks - lastInputTicks;
+
+    lastInputTicks = currentHiTicks;
+
+    auto scaleAdjustmentToInterval = [=](double x) { return x * (120 / 4) / (1000.0 / elapsedInputTicks); };
+
+    if (paused)
+        return;
+
 	D_ProcessEvents();
 
     localInput = {};
@@ -206,14 +218,6 @@ void PlayerInterruptKeys()
     input.horizon = fix16_ssub(input.horizon, fix16_from_int(info.dpitch * analogTurnAmount / analogExtent));
     input.xVel -= info.dx * keyMove / analogExtent;
     input.yVel -= info.dz * keyMove / analogExtent;
-
-    static double lastInputTicks;
-    auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - lastInputTicks;
-
-    lastInputTicks = currentHiTicks;
-
-    auto scaleAdjustmentToInterval = [=](double x) { return x * (120 / 4) / (1000.0 / elapsedInputTicks); };
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {

--- a/source/rr/src/d_menu.cpp
+++ b/source/rr/src/d_menu.cpp
@@ -580,7 +580,7 @@ void GameInterface::DrawNativeMenuText(int fontnum, int state, double xpos, doub
 
 void GameInterface::MenuOpened()
 {
-	S_PauseSounds(true);
+	S_PauseSound(true, false);
 	if ((!g_netServer && ud.multimode < 2))
 	{
 		ready2send = 0;
@@ -646,7 +646,7 @@ void GameInterface::MenuClosed()
 		}
 
 		G_UpdateScreenArea();
-		S_PauseSounds(false);
+		S_ResumeSound(false);
 	}
 }
 

--- a/source/rr/src/demo.cpp
+++ b/source/rr/src/demo.cpp
@@ -120,7 +120,7 @@ static int32_t G_OpenDemoRead(int32_t g_whichDemo) // 0 = mine
 
     gFullMap = false;
     ud.god = ud.cashman = ud.eog = 0;
-    ud.noclip = ud.scrollmode = ud.overhead_on = 0; //= ud.pause_on = 0;
+    ud.noclip = ud.scrollmode = ud.overhead_on = 0; //= paused = 0;
 
     totalclock = ototalclock = lockclock = 0;
 
@@ -591,7 +591,7 @@ RECHECK:
                 Demo_FinishProfile();
 
             while (totalclock >= (lockclock+TICSPERFRAME)
-                //                   || (ud.reccnt > REALGAMETICSPERSEC*2 && ud.pause_on)
+                //                   || (ud.reccnt > REALGAMETICSPERSEC*2 && paused)
                 || (g_demo_goalCnt>0 && g_demo_cnt<g_demo_goalCnt))
             {
                 if (ud.reccnt<=0)

--- a/source/rr/src/game.h
+++ b/source/rr/src/game.h
@@ -314,7 +314,7 @@ static inline int32_t calc_smoothratio(ClockTicks totalclk, ClockTicks ototalclk
     if (!(((!g_netServer && ud.multimode < 2) && ((g_player[myconnectindex].ps->gm & MODE_MENU) == 0)) ||
           (g_netServer || ud.multimode > 1) ||
           ud.recstat == 2) ||
-        ud.pause_on)
+        paused)
     {
         return 65536;
     }

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -2093,7 +2093,7 @@ void P_DisplayWeapon(void)
         if (!RR && currentWeapon == KNEE_WEAPON && *weaponFrame == 0)
             goto enddisplayweapon;
 
-        int const doAnim      = !(sprite[pPlayer->i].pal == 1 || ud.pause_on || g_player[myconnectindex].ps->gm & MODE_MENU);
+        int const doAnim      = !(sprite[pPlayer->i].pal == 1 || paused || g_player[myconnectindex].ps->gm & MODE_MENU);
         int const halfLookAng = fix16_to_int(pPlayer->q16look_ang) >> 1;
 
         int const weaponPal = P_GetHudPal(pPlayer);
@@ -3209,7 +3209,15 @@ void P_GetInput(int const playerNum)
     auto const pSprite    = &sprite[pPlayer->i];
     ControlInfo info;
 
-    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || (ud.pause_on && !inputState.GetKeyStatus(sc_Pause)))
+    auto const    currentHiTicks    = timerGetHiTicks();
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
+
+    thisPlayer.lastInputTicks = currentHiTicks;
+
+    if (elapsedInputTicks == currentHiTicks)
+        return;
+
+    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || paused)
     {
         if (!(pPlayer->gm&MODE_MENU))
             CONTROL_GetInput(&info);
@@ -3271,14 +3279,6 @@ void P_GetInput(int const playerNum)
     input.q16horz = fix16_ssub(input.q16horz, fix16_from_int(info.dpitch * analogTurnAmount / analogExtent));
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;
-
-    auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
-
-    thisPlayer.lastInputTicks = currentHiTicks;
-
-    if (elapsedInputTicks == currentHiTicks)
-        return;
 
     auto scaleAdjustmentToInterval = [=](double x) { return x * REALGAMETICSPERSEC / (1000.0 / elapsedInputTicks); };
 
@@ -3631,7 +3631,15 @@ void P_GetInputMotorcycle(int playerNum)
     auto const pSprite    = &sprite[pPlayer->i];
     ControlInfo info;
 
-    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || (ud.pause_on && !inputState.GetKeyStatus(sc_Pause)))
+    auto const    currentHiTicks    = timerGetHiTicks();
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
+
+    thisPlayer.lastInputTicks = currentHiTicks;
+
+    if (elapsedInputTicks == currentHiTicks)
+        return;
+
+    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || paused)
     {
         if (!(pPlayer->gm&MODE_MENU))
             CONTROL_GetInput(&info);
@@ -3669,14 +3677,6 @@ void P_GetInputMotorcycle(int playerNum)
 
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;
-
-    auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
-
-    thisPlayer.lastInputTicks = currentHiTicks;
-
-    if (elapsedInputTicks == currentHiTicks)
-        return;
 
     auto scaleAdjustmentToInterval = [=](double x) { return x * REALGAMETICSPERSEC / (1000.0 / elapsedInputTicks); };
 
@@ -3885,7 +3885,15 @@ void P_GetInputBoat(int playerNum)
     auto const pSprite    = &sprite[pPlayer->i];
     ControlInfo info;
 
-    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || (ud.pause_on && !inputState.GetKeyStatus(sc_Pause)))
+    auto const    currentHiTicks    = timerGetHiTicks();
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
+
+    thisPlayer.lastInputTicks = currentHiTicks;
+
+    if (elapsedInputTicks == currentHiTicks)
+        return;
+
+    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || paused)
     {
         if (!(pPlayer->gm&MODE_MENU))
             CONTROL_GetInput(&info);
@@ -3923,14 +3931,6 @@ void P_GetInputBoat(int playerNum)
 
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;
-
-    auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
-
-    thisPlayer.lastInputTicks = currentHiTicks;
-
-    if (elapsedInputTicks == currentHiTicks)
-        return;
 
     auto scaleAdjustmentToInterval = [=](double x) { return x * REALGAMETICSPERSEC / (1000.0 / elapsedInputTicks); };
 
@@ -4134,7 +4134,15 @@ void P_DHGetInput(int const playerNum)
     auto const pSprite    = &sprite[pPlayer->i];
     ControlInfo info;
 
-    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || (ud.pause_on && !inputState.GetKeyStatus(sc_Pause)))
+    auto const    currentHiTicks    = timerGetHiTicks();
+    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
+
+    thisPlayer.lastInputTicks = currentHiTicks;
+
+    if (elapsedInputTicks == currentHiTicks)
+        return;
+
+    if ((pPlayer->gm & (MODE_MENU|MODE_TYPE)) || paused)
     {
         if (!(pPlayer->gm&MODE_MENU))
             CONTROL_GetInput(&info);
@@ -4188,14 +4196,6 @@ void P_DHGetInput(int const playerNum)
     input.q16horz = fix16_ssub(input.q16horz, fix16_from_int(info.dpitch * analogTurnAmount / analogExtent));
     input.svel -= info.dx * keyMove / analogExtent;
     input.fvel -= info.dz * keyMove / analogExtent;
-
-    auto const    currentHiTicks    = timerGetHiTicks();
-    double const  elapsedInputTicks = currentHiTicks - thisPlayer.lastInputTicks;
-
-    thisPlayer.lastInputTicks = currentHiTicks;
-
-    if (elapsedInputTicks == currentHiTicks)
-        return;
 
     auto scaleAdjustmentToInterval = [=](double x) { return x * REALGAMETICSPERSEC / (1000.0 / elapsedInputTicks); };
 

--- a/source/rr/src/premap.cpp
+++ b/source/rr/src/premap.cpp
@@ -1154,7 +1154,7 @@ static void resetprestat(int playerNum, int gameMode)
     g_animateCnt       = 0;
     parallaxtype       = 0;
     randomseed         = 17;
-    ud.pause_on        = 0;
+    paused             = 0;
     ud.camerasprite    = -1;
     ud.eog             = 0;
     tempwallptr        = 0;
@@ -2293,7 +2293,7 @@ int G_EnterLevel(int gameMode)
 
     //if (g_networkMode != NET_DEDICATED_SERVER)
     {
-        S_PauseSounds(false);
+        S_ResumeSound(false);
         FX_StopAllSounds();
         S_ClearSoundLocks();
         FX_SetReverb(0);

--- a/source/rr/src/savegame.cpp
+++ b/source/rr/src/savegame.cpp
@@ -183,7 +183,7 @@ int32_t G_LoadPlayer(const char *path)
 
     // some setup first
     ud.multimode = h.numplayers;
-	S_PauseSounds(true);
+    S_PauseSound(true, false);
 
     if (numplayers > 1)
     {
@@ -834,7 +834,7 @@ static const dataspec_t svgm_udnetw[] =
     { DS_NOCHK, &ud.ffire, sizeof(ud.ffire), 1 },
     { DS_NOCHK, &ud.noexits, sizeof(ud.noexits), 1 },
     { DS_NOCHK, &ud.playerai, sizeof(ud.playerai), 1 },
-    { 0, &ud.pause_on, sizeof(ud.pause_on), 1 },
+    { 0, &paused, sizeof(paused), 1 },
     { 0, connectpoint2, sizeof(connectpoint2), 1 },
     { 0, &randomseed, sizeof(randomseed), 1 },
     { 0, &g_globalRandom, sizeof(g_globalRandom), 1 },

--- a/source/rr/src/screens.cpp
+++ b/source/rr/src/screens.cpp
@@ -765,7 +765,7 @@ void G_DisplayRest(int32_t smoothratio)
 
             if (ud.scrollmode == 0)
             {
-                if (pp->newowner == -1 && !ud.pause_on)
+                if (pp->newowner == -1 && !paused)
                 {
                     if (screenpeek == myconnectindex && numplayers > 1)
                     {
@@ -789,7 +789,7 @@ void G_DisplayRest(int32_t smoothratio)
             }
             else
             {
-                if (!ud.pause_on)
+                if (!paused)
                 {
                     ud.fola += ud.folavel>>3;
                     ud.folx += (ud.folfvel*sintable[(512+2048-ud.fola)&2047])>>14;
@@ -869,10 +869,10 @@ void G_DisplayRest(int32_t smoothratio)
     }
 	*/
 
-    if (ud.pause_on==1 && (g_player[myconnectindex].ps->gm&MODE_MENU) == 0)
+    if (paused==1 && (g_player[myconnectindex].ps->gm&MODE_MENU) == 0)
         menutext_center(100, GStrings("Game Paused"));
 
-    mdpause = (ud.pause_on || (ud.recstat==2 && (g_demo_paused && g_demo_goalCnt==0)) || (g_player[myconnectindex].ps->gm&MODE_MENU && numplayers < 2));
+    mdpause = (paused || (ud.recstat==2 && (g_demo_paused && g_demo_goalCnt==0)) || (g_player[myconnectindex].ps->gm&MODE_MENU && numplayers < 2));
 
     // JBF 20040124: display level stats in screen corner
     if (ud.overhead_on != 2 && hud_stats) // && VM_OnEvent(EVENT_DISPLAYLEVELSTATS, g_player[screenpeek].ps->i, screenpeek) == 0)

--- a/source/rr/src/sector.cpp
+++ b/source/rr/src/sector.cpp
@@ -3648,29 +3648,7 @@ void P_HandleSharedKeys(int playerNum)
     {
         pPlayer->interface_toggle_flag = 1;
 
-        if (TEST_SYNC_KEY(playerBits, SK_PAUSE))
-        {
-            inputState.ClearKeyStatus(sc_Pause);
-            if (ud.pause_on)
-                ud.pause_on = 0;
-            else ud.pause_on = 1+SHIFTS_IS_PRESSED;
-            if (ud.pause_on)
-            {
-                Mus_SetPaused(true);
-                S_PauseSounds(true);
-            }
-            else
-            {
-                Mus_SetPaused(false);
-
-                S_PauseSounds(false);
-
-                pub = NUMPAGES;
-                pus = NUMPAGES;
-            }
-        }
-
-        if (ud.pause_on) return;
+        if (paused) return;
 
         if (sprite[pPlayer->i].extra <= 0) return;		// if dead...
 

--- a/source/rr/src/sounds.cpp
+++ b/source/rr/src/sounds.cpp
@@ -79,17 +79,6 @@ TArray<uint8_t> DukeSoundEngine::ReadSound(int lumpnum)
 //
 //==========================================================================
 
-void S_PauseSounds(bool paused)
-{
-    soundEngine->SetPaused(paused);
-}
-
-//==========================================================================
-//
-// 
-//
-//==========================================================================
-
 void cacheAllSounds(void)
 {
     auto& sfx = soundEngine->GetSounds();

--- a/source/rr/src/sounds.h
+++ b/source/rr/src/sounds.h
@@ -57,8 +57,6 @@ inline int S_CheckSoundPlaying(int sprnum, int soundNum) { return S_CheckSoundPl
 inline void S_ClearSoundLocks(void) {}
 void cacheAllSounds(void);
 void S_MenuSound(void);
-void S_PauseMusic(bool paused);
-void S_PauseSounds(bool paused);
 void S_PlayLevelMusicOrNothing(unsigned int);
 int S_TryPlaySpecialMusic(unsigned int);
 void S_PlaySpecialMusicOrNothing(unsigned int);

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -64,7 +64,7 @@ Prepared for public release: 03/28/2005 - Charlie Wiederhold, 3D Realms
 BEGIN_SW_NS
 
 static int OverlapDraw = FALSE;
-extern SWBOOL QuitFlag, LocationInfo, ConPanel, SpriteInfo, PauseKeySet;
+extern SWBOOL QuitFlag, LocationInfo, ConPanel, SpriteInfo;
 extern SWBOOL Voxel;
 extern char buffer[];
 SWBOOL DrawScreen;
@@ -1071,7 +1071,7 @@ static ClockTicks mapzoomclock;
 void
 ResizeView(PLAYERp pp)
 {
-    if (M_Active() || PauseKeySet)
+    if (M_Active() || paused)
         return;
 
     if (dimensionmode == 2 || dimensionmode == 5 || dimensionmode == 6)
@@ -2027,7 +2027,7 @@ drawscreen(PLAYERp pp)
 
 
     smoothratio = CalcSmoothRatio(totalclock, ototalclock, 120 / synctics);
-    if (GamePaused && !ReloadPrompt) // The checks were brought over from domovethings
+    if (paused && !ReloadPrompt) // The checks were brought over from domovethings
         smoothratio = 65536;
 
     if (!ScreenSavePic)
@@ -2326,6 +2326,26 @@ drawscreen(PLAYERp pp)
     short_restoreinterpolations();                 // Stick at end of drawscreen
     if (cl_sointerpolation)
         so_restoreinterpolations();                       // Stick at end of drawscreen
+
+    if (paused && !M_Active())
+    {
+        short w,h;
+#define MSG_GAME_PAUSED "Game Paused"
+        MNU_MeasureString(MSG_GAME_PAUSED, &w, &h);
+        PutStringTimer(pp, TEXT_TEST_COL(w), 100, MSG_GAME_PAUSED, 999);
+    }
+    else
+    {
+        pClearTextLine(pp, 100);
+    }
+
+    if (!CommEnabled && TEST(pp->Flags, PF_DEAD))
+    {
+        if (ReloadPrompt)
+        {
+            ReloadPrompt = FALSE;
+        }
+    }
 
     PostDraw();
     DrawScreen = FALSE;

--- a/source/sw/src/game.h
+++ b/source/sw/src/game.h
@@ -2392,7 +2392,6 @@ void sendlogoff(void);
 
 extern int ototalclock, save_totalclock, gotlastpacketclock,smoothratio;
 extern SWBOOL ready2send;
-extern SWBOOL GamePaused;
 
 // local copy of variables updated by faketimerhandler
 extern int locselectedgun;

--- a/source/sw/src/network.cpp
+++ b/source/sw/src/network.cpp
@@ -29,6 +29,8 @@ Prepared for public release: 03/28/2005 - Charlie Wiederhold, 3D Realms
 #include "baselayer.h"
 #include "mmulti.h"
 
+#include "gamecontrol.h"
+
 #include "keys.h"
 #include "game.h"
 #include "tags.h"
@@ -70,7 +72,6 @@ SYNC BUG NOTES:
 //#define MAXSYNCBYTES 16
 static uint8_t tempbuf[576], packbuf[576];
 int PlayClock;
-extern SWBOOL PauseKeySet;
 
 gNET gNet;
 extern short PlayerQuitMenuLevel;
@@ -128,7 +129,6 @@ int save_totalclock;
 
 // must start out as 0
 
-SWBOOL GamePaused = FALSE;
 SWBOOL NetBroadcastMode = TRUE;
 SWBOOL NetModeOverride = FALSE;
 
@@ -386,32 +386,16 @@ int DecodeBits(SW_PACKET *pak, SW_PACKET *old_pak, uint8_t* buf)
 }
 
 void
-PauseGame(void)
-{
-    if (PauseKeySet)
-        return;
-
-    if (DemoPlaying || DemoRecording)
-        return;
-
-    if (GamePaused)
-        return;
-
-    if (numplayers < 2)
-        GamePaused = TRUE;
-}
-
-void
 ResumeGame(void)
 {
-    if (PauseKeySet)
+    if (paused)
         return;
 
     if (DemoPlaying || DemoRecording)
         return;
 
     if (numplayers < 2)
-        GamePaused = FALSE;
+        paused = 0;
 }
 
 void

--- a/source/sw/src/network.h
+++ b/source/sw/src/network.h
@@ -186,7 +186,6 @@ void SendVersion(int version);
 void InitNetPlayerOptions(void);
 void CheckVersion(int GameVersion);
 void SW_SendMessage(short pnum,const char *text);
-void PauseGame(void);
 void ResumeGame(void);
 
 END_SW_NS

--- a/source/sw/src/panel.cpp
+++ b/source/sw/src/panel.cpp
@@ -6229,7 +6229,7 @@ pChopsShake(PANEL_SPRITEp psp)
 void
 pChopsWait(PANEL_SPRITEp psp)
 {
-    //if (!GamePaused && RANDOM_P2(1024) < 10)
+    //if (!paused && RANDOM_P2(1024) < 10)
     if (RANDOM_P2(1024) < 10)
     {
         // random x position

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -7846,9 +7846,9 @@ void PauseMultiPlay(void)
             {
                 FLAG_KEY_RELEASE(pp, SK_PAUSE);
 
-                GamePaused ^= 1;
+                paused ^= 1;
 
-                if (GamePaused)
+                if (paused)
                 {
                     short w,h;
                     auto m = GStrings("Game Paused");
@@ -7859,14 +7859,12 @@ void PauseMultiPlay(void)
 
                     SavePrediction = PredictionOn;
                     PredictionOn = FALSE;
-                    Mus_SetPaused(true);
                 }
                 else
                 {
                     PredictionOn = SavePrediction;
                     TRAVERSE_CONNECT(p)
                     pClearTextLine(Player + p, 100);
-                    Mus_SetPaused(false);
                 }
             }
         }
@@ -7962,8 +7960,7 @@ domovethings(void)
 
 #if 0
     {
-        extern SWBOOL PauseKeySet;
-        if (inputState.GetKeyStatus(KEYSC_F5) && !(inputState.GetKeyStatus(KEYSC_ALT) || inputState.GetKeyStatus(KEYSC_RALT)) && !PauseKeySet)
+        if (inputState.GetKeyStatus(KEYSC_F5) && !(inputState.GetKeyStatus(KEYSC_ALT) || inputState.GetKeyStatus(KEYSC_RALT)) && !paused)
         {
             inputState.GetKeyStatus(KEYSC_F5) = 0;
             ResChange();
@@ -7991,7 +7988,7 @@ domovethings(void)
         DoPlayerMenuKeys(pp);
     }
 
-    if (GamePaused)
+    if (paused)
     {
         if (!ReloadPrompt)
             return;

--- a/source/sw/src/quake.cpp
+++ b/source/sw/src/quake.cpp
@@ -28,6 +28,8 @@ Prepared for public release: 03/28/2005 - Charlie Wiederhold, 3D Realms
 #include "build.h"
 #include "common.h"
 
+#include "gamecontrol.h"
+
 #include "names2.h"
 #include "game.h"
 #include "tags.h"
@@ -190,7 +192,7 @@ void QuakeViewChange(PLAYERp pp, int *z_diff, int *x_diff, int *y_diff, short *a
     *y_diff = 0;
     *ang_diff = 0;
 
-    if (GamePaused)
+    if (paused)
         return;
 
     // find the closest quake - should be a strength value

--- a/source/sw/src/vis.cpp
+++ b/source/sw/src/vis.cpp
@@ -26,6 +26,8 @@ Prepared for public release: 03/28/2005 - Charlie Wiederhold, 3D Realms
 #include "ns.h"
 #include "build.h"
 
+#include "gamecontrol.h"
+
 #include "names2.h"
 #include "game.h"
 #include "tags.h"
@@ -91,7 +93,7 @@ void VisViewChange(PLAYERp pp, int *vis)
     int x,y,z;
     short sectnum;
 
-    if (GamePaused)
+    if (paused)
         return;
 
     // find the closest quake - should be a strength value


### PR DESCRIPTION
Observed that even since older releases like 0.4.1, the pause key on the keyboard was not operational for games like Duke3D/RR. Furthermore, with some of the changes made to stop interpolations while paused, it somewhat made the pause key worse.

These changes were mostly to uplift and repair Duke3D/RR but have been standardised across all games.

Gist of the changes are
- Re-enable 'paused' int similar to GZDoom.
- Re-enable `S_SetSoundPaused()` and adjust to work with Raze so music stops when focus lost/minimised, etc.
- Pinch `S_PauseSound()` from GZDoom.
- Pinch `S_ResumeSound()` from GZDoom.
- Remove `S_PauseSounds()` from Duke3D/RR code base in lieu of aforementioned functions.
- Re-arrange input code for some games so that `lastInputTicks` is always updated even while paused.
- Define function `updatePauseStatus()` in gamecontrol.cpp for standardised pausing with games.
- Ensure all music and sound stops while paused with pause key.
- Make Shadow Warrior pausing actually work after backport of VoidSW input code.