### PR TITLE
Blood: Fix issues with weapon not switching properly if cycling the weapons too quickly.

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -159,16 +159,19 @@ void ctrlGetInput(void)
         cl_crosshair = !cl_crosshair;
     }
 
-    if (buttonMap.ButtonPressed(gamefunc_Next_Weapon))
+    if (gPlayer[myconnectindex].nextWeapon == 0)
     {
-        buttonMap.ClearButton(gamefunc_Next_Weapon);
-        gInput.keyFlags.nextWeapon = 1;
-    }
+        if (buttonMap.ButtonPressed(gamefunc_Next_Weapon))
+        {
+            buttonMap.ClearButton(gamefunc_Next_Weapon);
+            gInput.keyFlags.nextWeapon = 1;
+        }
 
-    if (buttonMap.ButtonPressed(gamefunc_Previous_Weapon))
-    {
-        buttonMap.ClearButton(gamefunc_Previous_Weapon);
-        gInput.keyFlags.prevWeapon = 1;
+        if (buttonMap.ButtonPressed(gamefunc_Previous_Weapon))
+        {
+            buttonMap.ClearButton(gamefunc_Previous_Weapon);
+            gInput.keyFlags.prevWeapon = 1;
+        }
     }
 
     if (buttonMap.ButtonDown(gamefunc_Show_Opponents_Weapon))


### PR DESCRIPTION
- This means that while weapons can't be changed mid-animation, they switch consistently. I feel they animate quick enough, anyway.