### PR TITLE
- fix joystick scaling for all games.

### DIFF
--- a/source/core/inputstate.cpp
+++ b/source/core/inputstate.cpp
@@ -195,9 +195,9 @@ void CONTROL_GetInput(ControlInfo* info)
 
 		I_GetAxes(joyaxes);
 
-		info->dyaw += joyaxes[JOYAXIS_Yaw];
-		info->dx += joyaxes[JOYAXIS_Side];
-		info->dz += joyaxes[JOYAXIS_Forward];
-		info->dpitch += joyaxes[JOYAXIS_Pitch];
+		info->dyaw += -joyaxes[JOYAXIS_Yaw] * joyaxesScale;
+		info->dx += -joyaxes[JOYAXIS_Side] * joyaxesScale;
+		info->dz += -joyaxes[JOYAXIS_Forward] * joyaxesScale;
+		info->dpitch += -joyaxes[JOYAXIS_Pitch] * joyaxesScale;
 	}
 }

--- a/source/core/inputstate.h
+++ b/source/core/inputstate.h
@@ -179,6 +179,9 @@ public:
 
 extern InputState inputState;
 
+constexpr int   analogExtent = 32767; // used as a divisor for scaling joystick input.
+constexpr float joyaxesScale = (float)analogExtent * 0.75f; // used as a multiplier for scaling joystick input.
+
 void CONTROL_GetInput(ControlInfo* info);
 int32_t handleevents(void);
 

--- a/source/exhumed/src/player.cpp
+++ b/source/exhumed/src/player.cpp
@@ -189,7 +189,6 @@ void PlayerInterruptKeys()
     int const turnAmount = playerRunning ? 12 : 8;
     int const keyMove    = playerRunning ? 12 : 6;
     constexpr int const analogTurnAmount = 12;
-    constexpr int const analogExtent = 32767; // KEEPINSYNC sdlayer.cpp
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {
@@ -198,12 +197,12 @@ void PlayerInterruptKeys()
         input.xVel = -(info.mousex + strafeyaw) >> 6;
         strafeyaw  = (info.mousex + strafeyaw) % 64;
 
-        input.xVel -= info.dyaw * keyMove / analogExtent;
+        input.xVel -= scaleAdjustmentToInterval(info.dyaw * keyMove / analogExtent);
     }
     else
     {
         input.nAngle = fix16_sadd(input.nAngle, fix16_sdiv(fix16_from_int(info.mousex), fix16_from_int(32)));
-        input.nAngle = fix16_sadd(input.nAngle, fix16_from_int(info.dyaw * analogTurnAmount / (analogExtent >> 1)));
+        input.nAngle = fix16_sadd(input.nAngle, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw * analogTurnAmount / (analogExtent >> 1))));
     }
 
     g_MyAimMode = in_mousemode || buttonMap.ButtonDown(gamefunc_Mouse_Aiming);
@@ -215,9 +214,9 @@ void PlayerInterruptKeys()
 
     if (!in_mouseflip) input.horizon = -input.horizon;
 
-    input.horizon = fix16_ssub(input.horizon, fix16_from_int(info.dpitch * analogTurnAmount / analogExtent));
-    input.xVel -= info.dx * keyMove / analogExtent;
-    input.yVel -= info.dz * keyMove / analogExtent;
+    input.horizon = fix16_ssub(input.horizon, fix16_from_dbl(scaleAdjustmentToInterval(info.dpitch * analogTurnAmount / analogExtent)));
+    input.xVel -= scaleAdjustmentToInterval(info.dx * keyMove / analogExtent);
+    input.yVel -= scaleAdjustmentToInterval(info.dz * keyMove / analogExtent);
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {


### PR DESCRIPTION
* Repairs https://forum.zdoom.org/viewtopic.php?f=340&t=67239 and https://forum.zdoom.org/viewtopic.php?f=340&t=67933
* Values that come from GZDoom backend are too low to be suitable for the Build games which were dividing by 'analogExtent'.
* Remove definition of analogExtent from all games and define in inputstate.h, then define joyaxesScale as 75% of analogExtent to provide a bit of headroom and not have a scale of 1.0 be full speed.
* Invert the returned results of GetAxes() as the returned floats are reversed for build games.
* Leverage scaleAdjustmentToInverval() on game-side code to consistently scale the input irrespective of frame rate, vsync etc.