### PR TITLE
Fix default global visibility value and make r_ambientlight work for all games.

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -3277,7 +3277,7 @@ void viewDrawScreen(bool sceneonly)
             }
             memcpy(bakMirrorGotpic, gotpic + 510, 2);
             memcpy(gotpic + 510, otherMirrorGotpic, 2);
-            g_visibility = (int32_t)(ClipLow(gVisibility - 32 * pOther->visibility, 0) * (numplayers > 1 ? 1.f : r_ambientlightrecip));
+            g_visibility = (int32_t)(ClipLow(gVisibility - 32 * pOther->visibility, 0));
             int vc4, vc8;
             getzsofslope(vcc, vd8, vd4, &vc8, &vc4);
             if (vd0 >= vc4)
@@ -3351,7 +3351,7 @@ void viewDrawScreen(bool sceneonly)
             }
             nSprite = nextspritestat[nSprite];
         }
-        g_visibility = (int32_t)(ClipLow(gVisibility - 32 * gView->visibility - unk, 0) * (numplayers > 1 ? 1.f : r_ambientlightrecip));
+        g_visibility = (int32_t)(ClipLow(gVisibility - 32 * gView->visibility - unk, 0));
         cA = (cA + interpolateangfix16(fix16_from_int(deliriumTurnO), fix16_from_int(deliriumTurn), gInterpolate)) & 0x7ffffff;
         int vfc, vf8;
         getzsofslope(nSectnum, cX, cY, &vfc, &vf8);

--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -266,7 +266,7 @@ static void polymost_updaterotmat(void)
     };
     multiplyMatrix4f(matrix, tiltmatrix);
     renderSetViewMatrix(matrix);
-    renderSetVisibility(((float)(g_visibility) / r_ambientlight) * fviewingrange * (4.f / (65536.f * 65536.f)));
+    renderSetVisibility(((float)(g_visibility) / (8.f / 15.f) / r_ambientlight) * fviewingrange * (4.f / (65536.f * 65536.f)));
 }
 
 static void polymost_flatskyrender(vec2f_t const* const dpxy, int32_t const n, int32_t method, const vec2_16_t& tilesiz);

--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -266,7 +266,7 @@ static void polymost_updaterotmat(void)
     };
     multiplyMatrix4f(matrix, tiltmatrix);
     renderSetViewMatrix(matrix);
-    renderSetVisibility(g_visibility * fviewingrange * (4.f / (65536.f * 65536.f)));
+    renderSetVisibility(((float)(g_visibility) / r_ambientlight) * fviewingrange * (4.f / (65536.f * 65536.f)));
 }
 
 static void polymost_flatskyrender(vec2f_t const* const dpxy, int32_t const n, int32_t method, const vec2_16_t& tilesiz);

--- a/source/core/gamecvars.cpp
+++ b/source/core/gamecvars.cpp
@@ -343,13 +343,10 @@ CUSTOM_CVARD(Int, r_showfpsperiod, 0, 0, "time in seconds before averaging min a
 	if (self < 0 || self > 5) self = 1;
 }
 
-float r_ambientlightrecip;
-
 CUSTOM_CVARD(Float, r_ambientlight, 1.0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "sets the global map light level")
 {
 	if (self < 0.1f) self = 0.1f;
 	else if (self > 10.f) self = 10.f;
-	else r_ambientlightrecip = 1.f / self;
 }
 
 CVARD(Bool, r_shadows, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "enable/disable sprite and model shadows")

--- a/source/core/gamecvars.h
+++ b/source/core/gamecvars.h
@@ -115,7 +115,6 @@ EXTERN_CVAR(Int, playercolor)
 EXTERN_CVAR(Int, playerteam)
 
 extern bool gNoAutoLoad;
-extern float r_ambientlightrecip;
 extern int hud_statusbarrange;	// will be set by the game's configuration setup.
 bool G_ChangeHudLayout(int direction);
 bool G_CheckAutorun(bool button);

--- a/source/duke3d/src/game.cpp
+++ b/source/duke3d/src/game.cpp
@@ -650,7 +650,7 @@ void G_DrawRooms(int32_t playerNum, int32_t smoothRatio)
         smoothRatio = 65536;
 
     int const playerVis = pPlayer->visibility;
-    g_visibility        = (playerVis <= 0) ? 0 : (int32_t)(playerVis * (numplayers > 1 ? 1.f : r_ambientlightrecip));
+    g_visibility        = (playerVis <= 0) ? 0 : (int32_t)(playerVis);
 
     CAMERA(sect) = pPlayer->cursectnum;
 

--- a/source/exhumed/src/osdcmds.h
+++ b/source/exhumed/src/osdcmds.h
@@ -30,8 +30,6 @@ int32_t registerosdcommands(void);
 void GAME_onshowosd(int shown);
 void GAME_clearbackground(int numcols, int numrows);
 
-//extern float r_ambientlight,r_ambientlightrecip;
-
 extern const char *const ConsoleButtons[];
 
 //extern uint32_t cl_cheatmask;

--- a/source/rr/src/game.cpp
+++ b/source/rr/src/game.cpp
@@ -860,7 +860,7 @@ void G_DrawRooms(int32_t playerNum, int32_t smoothRatio)
         pPlayer->visibility = ud.const_visibility;
 
     int const playerVis = pPlayer->visibility;
-    g_visibility        = (playerVis <= 0) ? 0 : (int32_t)(playerVis * (numplayers > 1 ? 1.f : r_ambientlightrecip));
+    g_visibility        = (playerVis <= 0) ? 0 : (int32_t)(playerVis);
 
     CAMERA(sect) = pPlayer->cursectnum;
 


### PR DESCRIPTION
This is to address the issues raised [here](https://forum.zdoom.org/viewtopic.php?f=340&t=68838).

The lighting level was only controllable for Duke3D and RR. The first commit makes r_ambientlight effective for all games and not just the aforementioned.

The second commit fixes the default lighting value back to what it was prior to 0bd460d9e3bbaf239f4a33f9ce589dff58660bea.

* Output from PrintVis() in 9dfd3ddd02631f9362e2d61211d92ef5b26c3a69 showed resulting global visibility as 0.078125.
![Duke_0000](https://user-images.githubusercontent.com/48643140/85216533-ed0b6700-b3c8-11ea-9471-f093fdc40f37.png)

* Following 0bd460d9e3bbaf239f4a33f9ce589dff58660bea, resulting global visibility shown as 0.041667.
![Duke_0000](https://user-images.githubusercontent.com/48643140/85216535-f563a200-b3c8-11ea-844e-ca4730fd22b3.png)

* Scaling g_visibility by (8.f / 15.f) (0.533333) restores resulting global visibility to 0.078125.
![Duke_0001](https://user-images.githubusercontent.com/48643140/85216538-f8f72900-b3c8-11ea-823d-d0e04d6c653d.png)

Please test and let me know how things look on your end. 