### PR TITLE
Change Next/Previous Weapon button handling for Shadow Warrior.

### DIFF
--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -3190,7 +3190,7 @@ getinput(SW_PACKET *loc, SWBOOL tied)
         }
     }
 
-    if (buttonMap.ButtonDown(gamefunc_Next_Weapon))
+    if (buttonMap.ButtonPressed(gamefunc_Next_Weapon))
     {
         USERp u = User[pp->PlayerSprite];
         short next_weapon = u->WeaponNum + 1;
@@ -3230,7 +3230,7 @@ getinput(SW_PACKET *loc, SWBOOL tied)
     }
 
 
-    if (buttonMap.ButtonDown(gamefunc_Previous_Weapon))
+    if (buttonMap.ButtonPressed(gamefunc_Previous_Weapon))
     {
         USERp u = User[pp->PlayerSprite];
         short prev_weapon = u->WeaponNum - 1;


### PR DESCRIPTION
This was pushed in https://github.com/coelckers/Raze/pull/20, but ended up being reverted when rebasing framerate-based input on upstream's implementation.

This was reported by Kinsie, who tested a build with this commit re-applied and confirmed it resolved the issues he was experiencing.

![image](https://user-images.githubusercontent.com/48643140/85249994-9cfbd580-b498-11ea-9e16-a2f891541c2d.png)