### PR TITLE
- change cl_defaultconfiguration default from '2' (leftbinds) to '0' (defbinds).

### DIFF
--- a/source/common/console/c_bind.cpp
+++ b/source/common/console/c_bind.cpp
@@ -739,7 +739,7 @@ void C_SetDefaultKeys(const char* baseconfig)
 //
 //
 //=============================================================================
-CVAR(Int, cl_defaultconfiguration, 2, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Int, cl_defaultconfiguration, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 
 void C_BindDefaults()


### PR DESCRIPTION
Probably more of a subjective change, but the preset named default should be the out-of-box default in my mind. It's also one of the first things I change on a fresh configuration.