### PR TITLE
- simplify visibility calculation from changes performed in d80a32d37905e12e57d2c2e86097290dbf236114.

### DIFF
--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -266,7 +266,7 @@ static void polymost_updaterotmat(void)
     };
     multiplyMatrix4f(matrix, tiltmatrix);
     renderSetViewMatrix(matrix);
-    renderSetVisibility(((float)(g_visibility) / (8.f / 15.f) / r_ambientlight) * fviewingrange * (4.f / (65536.f * 65536.f)));
+    renderSetVisibility(((float)(g_visibility) / r_ambientlight) * fviewingrange * (7.5f / (65536.f * 65536.f)));
 }
 
 static void polymost_flatskyrender(vec2f_t const* const dpxy, int32_t const n, int32_t method, const vec2_16_t& tilesiz);


### PR DESCRIPTION
More stylistic than anything else. Achives an identical result from the test spot I've been using with a simpler algorithm that's easier to read.