### PR TITLE
Visibility Fix, Option #1

### DIFF
--- a/source/build/include/polymost.h
+++ b/source/build/include/polymost.h
@@ -108,5 +108,6 @@ EDUKE32_STATIC_ASSERT(DAMETH_NARROW_MASKPROPS(DAMETH_MASKPROPS) == DAMETH_MASK);
 
 extern float fcosglobalang, fsinglobalang;
 extern float fxdim, fydim, fydimen, fviewingrange;
+extern int32_t viewingrangerecip;
 
 #endif

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -1104,7 +1104,7 @@ static int32_t globaluclip, globaldclip;
 //char globparaceilclip, globparaflorclip;
 
 int32_t xyaspect;
-static int32_t viewingrangerecip;
+int32_t viewingrangerecip;
 
 static char globalxshift, globalyshift;
 static int32_t globalxpanning, globalypanning;

--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -266,7 +266,7 @@ static void polymost_updaterotmat(void)
     };
     multiplyMatrix4f(matrix, tiltmatrix);
     renderSetViewMatrix(matrix);
-    renderSetVisibility(((float)(g_visibility) / r_ambientlight) * fviewingrange * (7.5f / (65536.f * 65536.f)));
+    renderSetVisibility(mulscale16(g_visibility, mulscale16(xdimenscale, viewingrangerecip)) * fviewingrange * (1.f / (65536.f * 65536.f)) / r_ambientlight);
 }
 
 static void polymost_flatskyrender(vec2f_t const* const dpxy, int32_t const n, int32_t method, const vec2_16_t& tilesiz);


### PR DESCRIPTION
* Changes performed in 0bd460d9e3bbaf239f4a33f9ce589dff58660bea didn't take into account xdimenscale and viewingrangerecip like the days of old and this wasn't picked up in d80a32d37905e12e57d2c2e86097290dbf236114 or d80a32d37905e12e57d2c2e86097290dbf236114, where the applied fixes only appeared to work because they worked for me at 2560x1440p.
* Remove calculation of (7.5f / (65536.f * 65536.f)) which needed to become (1.f / (65536.f * 65536.f)) and just the actual value.

See https://forum.zdoom.org/viewtopic.php?f=341&t=68838 for discussion.