### PR TITLE
- change mouse input from int to float and adjust games accordingly.

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -366,16 +366,12 @@ void ctrlGetInput(void)
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {
-        static int strafeyaw;
-
-        input.strafe = -(info.mousex + strafeyaw) >> 3;
-        strafeyaw    = (info.mousex + strafeyaw) % 8;
-
+        input.strafe -= info.mousex * 32.f;
         input.strafe -= scaleAdjustmentToInterval(info.dyaw * keyMove);
     }
     else
     {
-        input.q16turn = fix16_sadd(input.q16turn, fix16_sdiv(fix16_from_int(info.mousex), fix16_from_int(32)));
+        input.q16turn = fix16_sadd(input.q16turn, fix16_from_float(info.mousex));
         input.q16turn = fix16_sadd(input.q16turn, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw)));
     }
 
@@ -383,9 +379,9 @@ void ctrlGetInput(void)
     input.forward -= scaleAdjustmentToInterval(info.dz * keyMove);
 
     if (mouseaim)
-        input.q16mlook = fix16_sadd(input.q16mlook, fix16_sdiv(fix16_from_int(info.mousey), fix16_from_float(mlookScale * 64.f)));
+        input.q16mlook = fix16_sadd(input.q16mlook, fix16_from_float(info.mousey / mlookScale));
     else
-        input.forward -= info.mousey;
+        input.forward -= info.mousey * 64.f;
     if (!in_mouseflip)
         input.q16mlook = -input.q16mlook;
 

--- a/source/core/inputstate.cpp
+++ b/source/core/inputstate.cpp
@@ -46,22 +46,24 @@
 
 void InputState::GetMouseDelta(ControlInfo * info)
 {
-    vec2_t input;
+    vec2f_t input, finput;
 
 	input = g_mousePos;
 	g_mousePos = {};
 
-    vec2f_t finput = { float(input.x) / 3.0f, float(input.y) };
-
     if (in_mousesmoothing)
     {
-        static vec2_t last;
-        finput = { float(input.x + last.x) * 0.5f, float(input.y + last.y) * 0.5f };
+        static vec2f_t last;
+        finput = { (input.x + last.x) * 0.5f, (input.y + last.y) * 0.5f };
         last = input;
     }
+    else
+    {
+    	finput = { input.x, input.y };
+    }
 
-    info->mousex = int(finput.x * (16.f) * in_mousesensitivity * in_mousescalex);
-    info->mousey = int(finput.y * (16.f) * in_mousesensitivity * in_mousescaley);
+    info->mousex = finput.x * (16.f / 32.f) * in_mousesensitivity * in_mousescalex / 3.f;
+    info->mousey = finput.y * (16.f / 64.f) * in_mousesensitivity * in_mousescaley;
 
 	// todo: Use these when the mouse is used for moving instead of turning.
 	//info->mousex = int(finput.x * (4.f) * in_mousesensitivity * in_mouseside);
@@ -69,7 +71,7 @@ void InputState::GetMouseDelta(ControlInfo * info)
 
 	if (in_mousebias)
 	{
-		if (abs(info->mousex) > abs(info->mousey))
+		if (fabs(info->mousex) > fabs(info->mousey))
 			info->mousey /= in_mousebias;
 		else
 			info->mousex /= in_mousebias;

--- a/source/core/inputstate.h
+++ b/source/core/inputstate.h
@@ -21,8 +21,8 @@ struct ControlInfo
 	float       dyaw;
 	float       dpitch;
 	float       droll;
-	int32_t     mousex;
-	int32_t     mousey;
+	float       mousex;
+	float       mousey;
 };
 
 
@@ -42,7 +42,7 @@ class InputState
 	uint8_t g_keyAsciiPos;
 	uint8_t g_keyAsciiEnd;
 
-	vec2_t  g_mousePos;
+	vec2f_t  g_mousePos;
 
 	void keySetState(int32_t key, int32_t state);
 
@@ -140,11 +140,11 @@ public:
 
 	void AddEvent(const event_t* ev);
 
-	void MouseSetPos(int x, int y)
+	void MouseSetPos(float x, float y)
 	{
 		g_mousePos = { x, y };
 	}
-	void MouseAddToPos(int x, int y)
+	void MouseAddToPos(float x, float y)
 	{
 		g_mousePos.x += x;
 		g_mousePos.y += y;

--- a/source/duke3d/src/player.cpp
+++ b/source/duke3d/src/player.cpp
@@ -3090,23 +3090,19 @@ void P_GetInput(int const playerNum)
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {
-        static int strafeyaw;
-
-        input.svel = -(info.mousex + strafeyaw) >> 3;
-        strafeyaw  = (info.mousex + strafeyaw) % 8;
-
+        input.svel -= info.mousex * 4.f;
         input.svel -= scaleAdjustmentToInterval(info.dyaw * keyMove);
     }
     else
     {
-        input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
+        input.q16avel = fix16_sadd(input.q16avel, fix16_from_float(info.mousex));
         input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw)));
     }
 
     if (mouseaim)
-        input.q16horz = fix16_sadd(input.q16horz, fix16_sdiv(fix16_from_int(info.mousey), F16(64)));
+        input.q16horz = fix16_sadd(input.q16horz, fix16_from_float(info.mousey));
     else
-        input.fvel = -(info.mousey >> 3);
+        input.fvel -= info.mousey * 8.f;
 
     if (!in_mouseflip) input.q16horz = -input.q16horz;
 

--- a/source/exhumed/src/player.cpp
+++ b/source/exhumed/src/player.cpp
@@ -191,25 +191,21 @@ void PlayerInterruptKeys()
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {
-        static int strafeyaw;
-
-        input.xVel = -(info.mousex + strafeyaw) >> 6;
-        strafeyaw  = (info.mousex + strafeyaw) % 64;
-
+        input.xVel -= info.mousex * 4.f;
         input.xVel -= info.dyaw * keyMove;
     }
     else
     {
-        input.nAngle = fix16_sadd(input.nAngle, fix16_sdiv(fix16_from_int(info.mousex), fix16_from_int(32)));
+        input.nAngle = fix16_sadd(input.nAngle, fix16_from_float(info.mousex));
         input.nAngle = fix16_sadd(input.nAngle, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw)));
     }
 
     g_MyAimMode = in_mousemode || buttonMap.ButtonDown(gamefunc_Mouse_Aiming);
 
     if (g_MyAimMode)
-        input.horizon = fix16_sadd(input.horizon, fix16_sdiv(fix16_from_int(info.mousey), fix16_from_int(64)));
+        input.horizon = fix16_sadd(input.horizon, fix16_from_float(info.mousey));
     else
-        input.yVel = -(info.mousey >> 6);
+        input.yVel -= info.mousey * 8.f;
 
     if (!in_mouseflip) input.horizon = -input.horizon;
 

--- a/source/rr/src/player.cpp
+++ b/source/rr/src/player.cpp
@@ -3260,23 +3260,19 @@ void P_GetInput(int const playerNum)
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {
-        static int strafeyaw;
-
-        input.svel = -(info.mousex + strafeyaw) >> 3;
-        strafeyaw  = (info.mousex + strafeyaw) % 8;
-
+        input.svel -= info.mousex * 4.f;
         input.svel -= scaleAdjustmentToInterval(info.dyaw * keyMove);
     }
     else
     {
-        input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
+        input.q16avel = fix16_sadd(input.q16avel, fix16_from_float(info.mousex));
         input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw)));
     }
 
     if (mouseaim)
-        input.q16horz = fix16_sadd(input.q16horz, fix16_sdiv(fix16_from_int(info.mousey), F16(64)));
+        input.q16horz = fix16_sadd(input.q16horz, fix16_from_float(info.mousey));
     else
-        input.fvel = -(info.mousey >> 3);
+        input.fvel -= info.mousey * 8.f;
 
     if (!in_mouseflip) input.q16horz = -input.q16horz;
 
@@ -3671,7 +3667,7 @@ void P_GetInputMotorcycle(int playerNum)
 
     input_t input {};
 
-    input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
+    input.q16avel = fix16_sadd(input.q16avel, fix16_from_float(info.mousex));
     input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw)));
 
     input.svel -= scaleAdjustmentToInterval(info.dx * keyMove);
@@ -3920,7 +3916,7 @@ void P_GetInputBoat(int playerNum)
 
     input_t input {};
 
-    input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
+    input.q16avel = fix16_sadd(input.q16avel, fix16_from_float(info.mousex));
     input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw)));
 
     input.svel -= scaleAdjustmentToInterval(info.dx * keyMove);
@@ -4162,23 +4158,19 @@ void P_DHGetInput(int const playerNum)
 
     if (buttonMap.ButtonDown(gamefunc_Strafe))
     {
-        static int strafeyaw;
-
-        input.svel = -(info.mousex + strafeyaw) >> 3;
-        strafeyaw  = (info.mousex + strafeyaw) % 8;
-
+        input.svel -= info.mousex * 4.f;
         input.svel -= scaleAdjustmentToInterval(info.dyaw * keyMove);
     }
     else
     {
-        input.q16avel = fix16_sadd(input.q16avel, fix16_sdiv(fix16_from_int(info.mousex), F16(32)));
+        input.q16avel = fix16_sadd(input.q16avel, fix16_from_float(info.mousex));
         input.q16avel = fix16_sadd(input.q16avel, fix16_from_dbl(scaleAdjustmentToInterval(info.dyaw)));
     }
 
     if (mouseaim)
-        input.q16horz = fix16_sadd(input.q16horz, fix16_sdiv(fix16_from_int(info.mousey), F16(64)));
+        input.q16horz = fix16_sadd(input.q16horz, fix16_from_float(info.mousey));
     else
-        input.fvel = -(info.mousey >> 3);
+        input.fvel -= info.mousey * 8.f;
 
     if (!in_mouseflip) input.q16horz = -input.q16horz;
 

--- a/source/sw/src/game.cpp
+++ b/source/sw/src/game.cpp
@@ -3030,19 +3030,19 @@ getinput(SW_PACKET *loc, SWBOOL tied)
 
     if (buttonMap.ButtonDown(gamefunc_Strafe) && !pp->sop)
     {
-        svel = -info.mousex;
+        svel -= (info.mousex * ticrateScale) * 4.f;
         svel -= info.dyaw * keymove;
     }
     else
     {
-        q16angvel = fix16_div(fix16_from_int(info.mousex), fix16_from_float(angvelScale * 32.f));
-        q16angvel += fix16_from_dbl(scaleAdjustmentToInterval((info.dyaw * ticrateScale) / angvelScale));
+        q16angvel = fix16_sadd(q16angvel, fix16_from_float(info.mousex / angvelScale));
+        q16angvel = fix16_sadd(q16angvel, fix16_from_dbl(scaleAdjustmentToInterval((info.dyaw * ticrateScale) / angvelScale)));
     }
 
     if (mouseaim)
-        q16aimvel = -fix16_div(fix16_from_int(info.mousey), fix16_from_float(aimvelScale * 64.f));
+        q16aimvel = fix16_ssub(q16aimvel, fix16_from_float(info.mousey / aimvelScale));
     else
-        vel = -(info.mousey >> 6);
+        vel -= (info.mousey * ticrateScale) * 8.f;
 
     if (in_mouseflip)
         q16aimvel = -q16aimvel;


### PR DESCRIPTION
When I was looking at all the controller code, I thought the mouse movement code would be better off being a float for more precision. If we're going to implicitely convert it to float by dividing it by float-type CVARSs, might as well maintain it.

Overall the game code has been simplified in the process as rather than dividing mousex/y by 32/64 respectively, the appropriate scaling is done in `GetMouseDelta()`.

* Calculate game-side mousex/mousey divisions into the calculations performed in `InputState::GetMouseDelta()`.
* Standard mouse forward/side movement speeds in Exhumed & SW with that of other games.
* Remove `strafeyaw` code from Duke/Exhumed/RR as it's not necessary and was leading to situations where the player would continually keep moving sideways even without input.
* Change mouse forward/side velocities to -= current value as is done with controller input and the player's angle/aim velocities.