### PR TITLE
- add `gl_texture` CVAR to glbackend à la GZDoom.

### DIFF
--- a/source/glbackend/glbackend.cpp
+++ b/source/glbackend/glbackend.cpp
@@ -50,6 +50,8 @@
 #include "hw_renderstate.h"
 #include "hw_cvars.h"
 
+CVAR(Bool, gl_texture, true, 0)
+
 F2DDrawer twodpsp;
 static int BufferLock = 0;
 
@@ -167,7 +169,7 @@ void PolymostRenderState::Apply(FRenderState& state, GLState& oldState)
 	}
 	else
 	{
-		state.EnableTexture(true);
+		state.EnableTexture(gl_texture);
 		state.SetMaterial(mMaterial.mMaterial, mMaterial.mClampMode, mMaterial.mTranslation, mMaterial.mOverrideShader);
 	}
 	/* todo: bind indexed textures */


### PR DESCRIPTION
* Will be useful for further debugging of the lighting to determine whether Build actually did/does do different visibility for floor/walls/ceilings, etc.
* Idea inspired by Gez: https://forum.zdoom.org/viewtopic.php?f=341&t=68838&start=75#p1158294