### PR TITLE
- allow shade in glbackend.h to accept negative values, but still at a max of numshades-1

### DIFF
--- a/source/glbackend/glbackend.h
+++ b/source/glbackend/glbackend.h
@@ -143,7 +143,7 @@ public:
 
 	void SetShade(int32_t shade, int numshades)
 	{
-		renderState.Shade = clamp(shade, 0, numshades-1);
+		renderState.Shade = std::max(shade, numshades-1);
 	}
 
 	void SetVisibility(float visibility)


### PR DESCRIPTION
* This fixes some issues with distance lighting issues in Duke3D as reported at https://forum.zdoom.org/viewtopic.php?f=341&t=68838&start=75#p1158417.
* Implemented as inline if as max() was not available and didn't want to drag a header in for one thing.