### PR TITLE
All Games: sine/cosine uplift and misc angle stuff

### DIFF
--- a/source/blood/src/common_game.h
+++ b/source/blood/src/common_game.h
@@ -28,7 +28,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "misc.h"
 #include "printf.h"
 #include "v_text.h"
-#include "binaryangle.h"
 #include "seqcb.h"
 
 BEGIN_BLD_NS

--- a/source/blood/src/misc.h
+++ b/source/blood/src/misc.h
@@ -89,16 +89,6 @@ inline int Cos(int ang)
     return costable[ang & 2047];
 }
 
-inline double Sinf(double ang)
-{
-    return (1 << 30) * sin(BANG2RAD * ang);
-}
-
-inline double Cosf(double ang)
-{
-    return (1 << 30) * sin(BANG2RAD * (ang + 512.));
-}
-
 inline int SinScale16(int ang)
 {
     return FixedToInt(costable[(ang - 512) & 2047]);

--- a/source/blood/src/player.cpp
+++ b/source/blood/src/player.cpp
@@ -1353,9 +1353,9 @@ void ProcessInput(PLAYER *pPlayer)
         char bSeqStat = playerSeqPlaying(pPlayer, 16);
         if (pPlayer->fraggerId != -1)
         {
-            fixed_t fraggerAng = gethiq16angle(sprite[pPlayer->fraggerId].x - pSprite->x, sprite[pPlayer->fraggerId].y - pSprite->y);
-            pPlayer->angold = pSprite->ang = FixedToInt(fraggerAng);
-            pPlayer->angle.addadjustment(FixedToFloat(getincangleq16(pPlayer->angle.ang.asq16(), fraggerAng)));
+            auto fraggerAng = bvectangbam(sprite[pPlayer->fraggerId].x - pSprite->x, sprite[pPlayer->fraggerId].y - pSprite->y);
+            pPlayer->angold = pSprite->ang = fraggerAng.asbuild();
+            pPlayer->angle.addadjustment(getincanglebam(pPlayer->angle.ang, fraggerAng));
         }
         pPlayer->deathTime += 4;
         if (!bSeqStat)

--- a/source/blood/src/prediction.cpp
+++ b/source/blood/src/prediction.cpp
@@ -232,9 +232,9 @@ static void fakeProcessInput(PLAYER *pPlayer, InputPacket *pInput)
     predict.at20 = clamp(predict.at20+pInput->horz, IntToFixed(-60), IntToFixed(60));
 
     if (predict.at20 > 0)
-        predict.at24 = FloatToFixed(fmulscale30(120., Sinf(FixedToFloat(predict.at20) * 8.)));
+        predict.at24 = FloatToFixed(fmulscale30(120., bsinf(FixedToFloat(predict.at20) * 8., 16)));
     else if (predict.at20 < 0)
-        predict.at24 = FloatToFixed(fmulscale30(180., Sinf(FixedToFloat(predict.at20) * 8.)));
+        predict.at24 = FloatToFixed(fmulscale30(180., bsinf(FixedToFloat(predict.at20) * 8., 16)));
     else
         predict.at24 = 0;
 #endif

--- a/source/blood/src/sfx.cpp
+++ b/source/blood/src/sfx.cpp
@@ -127,7 +127,7 @@ void GameInterface::UpdateSounds()
 
     if (gMe->pSprite)
     {
-        listener.angle = -(float)gMe->pSprite->ang * pi::pi() / 1024; // Build uses a period of 2048.
+        listener.angle = -gMe->pSprite->ang * BAngRadian; // Build uses a period of 2048.
         listener.velocity.Zero();
         listener.position = GetSoundPos(&gMe->pSprite->pos);
         listener.valid = true;

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -1029,8 +1029,9 @@ FString GameInterface::GetCoordString()
 
 bool GameInterface::DrawAutomapPlayer(int x, int y, int z, int a)
 {
-    int nCos = z * sintable[(0 - a) & 2047];
-    int nSin = z * sintable[(1536 - a) & 2047];
+    // [MR]: Confirm that this is correct as math doesn't match the variable names.
+    int nCos = z * -bsin(a);
+    int nSin = z * -bcos(a);
     int nCos2 = mulscale16(nCos, yxaspect);
     int nSin2 = mulscale16(nSin, yxaspect);
     int nPSprite = gView->pSprite->index;

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -631,7 +631,7 @@ void viewDrawScreen(bool sceneonly)
         int viewingRange = viewingrange;
         videoSetCorrectedAspect();
 
-        int v1 = xs_CRoundToInt(double(viewingrange) * tan(r_fov * (PI / 360.)));
+        int v1 = xs_CRoundToInt(double(viewingrange) * tan(r_fov * (pi::pi() / 360.)));
 
         renderSetAspect(v1, yxaspect);
 

--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -740,7 +740,7 @@ void viewDrawScreen(bool sceneonly)
         //int tiltcs, tiltdim;
         uint8_t v4 = powerupCheck(gView, kPwUpCrystalBall) > 0;
 #ifdef USE_OPENGL
-        renderSetRollAngle(rotscrnang.asbam() / (double)(BAMUNIT));
+        renderSetRollAngle(rotscrnang.asbuildf());
 #endif
         if (v78 || bDelirium)
         {

--- a/source/build/include/build.h
+++ b/source/build/include/build.h
@@ -23,11 +23,20 @@ static_assert('\xff' == 255, "Char must be unsigned!");
 #include "palette.h"
 #include "pragmas.h"
 
+    //Make all variables in BUILD.H defined in the ENGINE,
+    //and externed in GAME
+#ifdef engine_c_
+#  define EXTERN
+#else
+#  define EXTERN extern
+#endif
+
+EXTERN int16_t sintable[2048];
 
 #include "buildtiles.h"
 #include "c_cvars.h"
 #include "cmdlib.h"
-#include "m_fixed.h"
+#include "binaryangle.h"
 #include "mathutil.h"
 
 typedef int64_t coord_t;
@@ -101,14 +110,6 @@ enum {
     RS_CENTER = (1<<29),    // proper center align.
     RS_CENTERORIGIN = (1<<30),
 };
-
-    //Make all variables in BUILD.H defined in the ENGINE,
-    //and externed in GAME
-#ifdef engine_c_
-#  define EXTERN
-#else
-#  define EXTERN extern
-#endif
 
 
 enum {
@@ -264,7 +265,6 @@ EXTERN int16_t numsectors, numwalls;
 EXTERN int32_t display_mirror;
 
 EXTERN int32_t randomseed;
-EXTERN int16_t sintable[2048];
 
 EXTERN int16_t numshades;
 EXTERN uint8_t paletteloaded;

--- a/source/build/include/build.h
+++ b/source/build/include/build.h
@@ -47,11 +47,6 @@ enum rendmode_t {
     REND_POLYMER
 };
 
-#define PI 3.14159265358979323846
-#define fPI 3.14159265358979323846f
-
-#define BANG2RAD (PI * (1./1024.))
-
 enum
 {
     MAXSECTORS = 4096,
@@ -716,14 +711,6 @@ int32_t wallvisible(int32_t const x, int32_t const y, int16_t const wallnum);
 #ifdef USE_OPENGL
 void    renderSetRollAngle(float rolla);
 #endif
-
-//
-// Calculates and returns a sintable[] value of the equivilent index (and supports fractional indexes also)
-//
-inline double calcSinTableValue(double index)
-{
-    return 16384. * sin(BANG2RAD * index);
-}
 
 void PrecacheHardwareTextures(int nTile);
 void Polymost_Startup();

--- a/source/build/src/clip.cpp
+++ b/source/build/src/clip.cpp
@@ -649,8 +649,8 @@ int32_t clipmove(vec3_t * const pos, int16_t * const sectnum, int32_t xvect, int
 
                     if (clipinsideboxline(cent.x, cent.y, p1.x, p1.y, p2.x, p2.y, rad) != 0)
                     {
-                        vec2_t v = { mulscale14(sintable[(spr->ang+256+512) & 2047], walldist),
-                                     mulscale14(sintable[(spr->ang+256) & 2047], walldist) };
+                        vec2_t v = { mulscale14(bcos(spr->ang + 256), walldist),
+                                     mulscale14(bsin(spr->ang + 256), walldist) };
 
                         if ((p1.x-pos->x) * (p2.y-pos->y) >= (p2.x-pos->x) * (p1.y-pos->y))  // Front
                             addclipline(p1.x+v.x, p1.y+v.y, p2.x+v.y, p2.y-v.x, (int16_t)j+49152, false);
@@ -685,8 +685,8 @@ int32_t clipmove(vec3_t * const pos, int16_t * const sectnum, int32_t xvect, int
                     get_floorspr_points((uspriteptr_t) spr, 0, 0, &rxi[0], &rxi[1], &rxi[2], &rxi[3],
                         &ryi[0], &ryi[1], &ryi[2], &ryi[3]);
 
-                    vec2_t v = { mulscale14(sintable[(spr->ang-256+512)&2047], walldist),
-                                 mulscale14(sintable[(spr->ang-256)&2047], walldist) };
+                    vec2_t v = { mulscale14(bcos(spr->ang - 256), walldist),
+                                 mulscale14(bsin(spr->ang - 256), walldist) };
 
                     if ((rxi[0]-pos->x) * (ryi[1]-pos->y) < (rxi[1]-pos->x) * (ryi[0]-pos->y))
                     {
@@ -934,8 +934,8 @@ int pushmove(vec3_t *const vect, int16_t *const sectnum,
                     if (j != 0)
                     {
                         j = getangle(wall[wal->point2].x-wal->x, wall[wal->point2].y-wal->y);
-                        int32_t dx = (sintable[(j+1024)&2047]>>11);
-                        int32_t dy = (sintable[(j+512)&2047]>>11);
+                        int32_t dx = -bsin(j, -11);
+                        int32_t dy = bcos(j, -11);
                         int bad2 = 16;
                         do
                         {
@@ -1140,8 +1140,8 @@ void getzrange(const vec3_t *pos, int16_t sectnum,
                         get_floorspr_points((uspriteptr_t) &sprite[j], pos->x, pos->y, &v1.x, &v2.x, &v3.x, &v4.x,
                                             &v1.y, &v2.y, &v3.y, &v4.y);
 
-                        vec2_t const da = { mulscale14(sintable[(sprite[j].ang - 256 + 512) & 2047], walldist + 4),
-                                            mulscale14(sintable[(sprite[j].ang - 256) & 2047], walldist + 4) };
+                        vec2_t const da = { mulscale14(bcos(sprite[j].ang - 256), walldist + 4),
+                                            mulscale14(bsin(sprite[j].ang - 256), walldist + 4) };
 
                         v1.x += da.x; v2.x -= da.y; v3.x -= da.x; v4.x += da.y;
                         v1.y += da.y; v2.y += da.x; v3.y -= da.y; v4.y -= da.x;

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -1647,9 +1647,8 @@ void renderDrawMapView(int32_t dax, int32_t day, int32_t zoome, int16_t ang)
 
     zoome <<= 8;
 
-    vec2_t const bakgvect = { divscale28(sintable[(1536 - ang) & 2047], zoome),
-                        divscale28(sintable[(2048 - ang) & 2047], zoome) };
-    vec2_t const vect = { mulscale8(sintable[(2048 - ang) & 2047], zoome), mulscale8(sintable[(1536 - ang) & 2047], zoome) };
+    vec2_t const bakgvect = { divscale28(-bcos(ang), zoome), divscale28(-bsin(ang), zoome) };
+    vec2_t const vect = { mulscale8(-bsin(ang), zoome), mulscale8(-bcos(ang), zoome) };
     vec2_t const vect2 = { mulscale16(vect.x, yxaspect), mulscale16(vect.y, yxaspect) };
 
     int32_t sortnum = 0;
@@ -2396,8 +2395,8 @@ void neartag(int32_t xs, int32_t ys, int32_t zs, int16_t sectnum, int16_t ange,
 {
     int16_t tempshortcnt, tempshortnum;
 
-    const int32_t vx = mulscale14(sintable[(ange+2560)&2047],neartagrange);
-    const int32_t vy = mulscale14(sintable[(ange+2048)&2047],neartagrange);
+    const int32_t vx = mulscale14(bcos(ange), neartagrange);
+    const int32_t vy = mulscale14(bsin(ange), neartagrange);
     vec3_t hitv = { xs+vx, ys+vy, 0 };
     const vec3_t sv = { xs, ys, zs };
 
@@ -2445,7 +2444,7 @@ void neartag(int32_t xs, int32_t ys, int32_t zs, int16_t sectnum, int16_t ange,
                 {
                     if (good&1) *neartagsector = nextsector;
                     if (good&2) *neartagwall = z;
-                    *neartaghitdist = dmulscale14(intx-xs,sintable[(ange+2560)&2047],inty-ys,sintable[(ange+2048)&2047]);
+                    *neartaghitdist = dmulscale14(intx-xs, bcos(ange), inty-ys, bsin(ange));
                     hitv.x = intx; hitv.y = inty; hitv.z = intz;
                 }
 
@@ -2477,8 +2476,7 @@ void neartag(int32_t xs, int32_t ys, int32_t zs, int16_t sectnum, int16_t ange,
                 if (try_facespr_intersect(spr, sv, vx, vy, 0, &hitv, 1))
                 {
                     *neartagsprite = z;
-                    *neartaghitdist = dmulscale14(hitv.x-xs, sintable[(ange+2560)&2047],
-                                                  hitv.y-ys, sintable[(ange+2048)&2047]);
+                    *neartaghitdist = dmulscale14(hitv.x-xs, bcos(ange), hitv.y-ys, bsin(ange));
                 }
             }
         }
@@ -2884,8 +2882,8 @@ void updatesectorneighborz(int32_t const x, int32_t const y, int32_t const z, in
 //
 void rotatepoint(vec2_t const pivot, vec2_t p, int16_t const daang, vec2_t * const p2)
 {
-    int const dacos = sintable[(daang+2560)&2047];
-    int const dasin = sintable[(daang+2048)&2047];
+    int const dacos = bcos(daang);
+    int const dasin = bsin(daang);
     p.x -= pivot.x;
     p.y -= pivot.y;
     p2->x = dmulscale14(p.x, dacos, -p.y, dasin) + pivot.x;

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -412,19 +412,19 @@ static int32_t engineLoadTables(void)
             reciptable[i] = divscale30(2048, i+2048);
 
         for (i=0; i<=512; i++)
-            sintable[i] = (int16_t)(16384.f * sinf((float)i * BANG2RAD) + 0.0001f);
+            sintable[i] = bsinf(i);
         for (i=513; i<1024; i++)
             sintable[i] = sintable[1024-i];
         for (i=1024; i<2048; i++)
             sintable[i] = -sintable[i-1024];
 
         for (i=0; i<640; i++)
-            radarang[i] = (int16_t)(atanf(((float)(640-i)-0.5f) * (1.f/160.f)) * (-64.f * (1.f/BANG2RAD)) + 0.0001f);
+            radarang[i] = atan((639.5 - i) / 160.) * (-64. / BAngRadian);
         for (i=0; i<640; i++)
             radarang[1279-i] = -radarang[i];
 
         for (i=0; i<5120; i++)
-            qradarang[i] = FloatToFixed(atanf(((float)(5120-i)-0.5f) * (1.f/1280.f)) * (-64.f * (1.f/BANG2RAD)));
+            qradarang[i] = FloatToFixed(atan((5119.5 - i) / 1280.) * (-64. / BAngRadian));
         for (i=0; i<5120; i++)
             qradarang[10239-i] = -qradarang[i];
 
@@ -1000,10 +1000,8 @@ void set_globalang(fixed_t const ang)
     qglobalang = ang & 0x7FFFFFF;
 
     float const f_ang = FixedToFloat(ang);
-    float const f_ang_radians = f_ang * M_PI * (1.f/1024.f);
-
-    float const fcosang = cosf(f_ang_radians) * 16384.f;
-    float const fsinang = sinf(f_ang_radians) * 16384.f;
+    float const fcosang = bcosf(f_ang);
+    float const fsinang = bsinf(f_ang);
 
 #ifdef USE_OPENGL
     fcosglobalang = fcosang;
@@ -3195,7 +3193,7 @@ void alignflorslope(int16_t dasect, int32_t x, int32_t y, int32_t z)
 #ifdef USE_OPENGL
 void renderSetRollAngle(float rolla)
 {
-    gtang = rolla * (fPI * (1.f/1024.f));
+    gtang = rolla * BAngRadian;
 }
 #endif
 

--- a/source/build/src/engine_priv.h
+++ b/source/build/src/engine_priv.h
@@ -196,8 +196,8 @@ static inline void get_wallspr_points(T const * const spr, int32_t *x1, int32_t 
     if (spr->cstat&4)
         xoff = -xoff;
 
-    dax = sintable[ang&2047]*xrepeat;
-    day = sintable[(ang+1536)&2047]*xrepeat;
+    dax = bsin(ang) * xrepeat;
+    day = -bcos(ang) * xrepeat;
 
     l = tileWidth(tilenum);
     k = (l>>1)+xoff;
@@ -217,8 +217,8 @@ static inline void get_floorspr_points(T const * const spr, int32_t px, int32_t 
                                        int32_t *y1, int32_t *y2, int32_t *y3, int32_t *y4)
 {
     const int32_t tilenum = spr->picnum;
-    const int32_t cosang = sintable[(spr->ang+512)&2047];
-    const int32_t sinang = sintable[spr->ang&2047];
+    const int32_t cosang = bcos(spr->ang);
+    const int32_t sinang = bsin(spr->ang);
 
     vec2_t const span = { tileWidth(tilenum), tileHeight(tilenum)};
     vec2_t const repeat = { spr->xrepeat, spr->yrepeat };

--- a/source/build/src/mdsprite.cpp
+++ b/source/build/src/mdsprite.cpp
@@ -1197,8 +1197,8 @@ void md3_vox_calcmat_common(tspriteptr_t tspr, const vec3f_t *a0, float f, float
 
     k0 = ((float)(tspr->x+spriteext[tspr->owner].position_offset.x-globalposx))*f*(1.f/1024.f);
     k1 = ((float)(tspr->y+spriteext[tspr->owner].position_offset.y-globalposy))*f*(1.f/1024.f);
-    k4 = (float)sintable[(tspr->ang+spriteext[tspr->owner].angoff+1024)&2047] * (1.f/16384.f);
-    k5 = (float)sintable[(tspr->ang+spriteext[tspr->owner].angoff+ 512)&2047] * (1.f/16384.f);
+    k4 = -bsinf(tspr->ang+spriteext[tspr->owner].angoff, -14);
+    k5 = bcosf(tspr->ang+spriteext[tspr->owner].angoff, -14);
     k2 = k0*(1-k4)+k1*k5;
     k3 = k1*(1-k4)-k0*k5;
     k6 = - gsinang; 
@@ -1403,10 +1403,10 @@ static int32_t polymost_md3draw(md3model_t *m, tspriteptr_t tspr)
         if ((sext->pivot_offset.z) && !(tspr->clipdist & TSPR_FLAGS_MDHACK))  // Compare with SCREEN_FACTORS above
             a0.z = (float)sext->pivot_offset.z / (gxyaspect * fxdimen * (65536.f/128.f) * (m0.z+m1.z));
 
-        k0 = (float)sintable[(sext->pitch+512)&2047] * (1.f/16384.f);
-        k1 = (float)sintable[sext->pitch&2047] * (1.f/16384.f);
-        k2 = (float)sintable[(sext->roll+512)&2047] * (1.f/16384.f);
-        k3 = (float)sintable[sext->roll&2047] * (1.f/16384.f);
+        k0 = bcosf(sext->pitch, -14);
+        k1 = bsinf(sext->pitch, -14);
+        k2 = bcosf(sext->roll, -14);
+        k3 = bsinf(sext->roll, -14);
     }
 
     VSMatrix imat = 0;

--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -2235,7 +2235,7 @@ void polymost_scansector(int32_t sectnum)
             {
                 if ((spr->cstat&(64+48))!=(64+16) ||
                     (r_voxels && tiletovox[spr->picnum] >= 0 && voxmodels[tiletovox[spr->picnum]]) ||
-                    dmulscale6(sintable[(spr->ang+512)&2047],-s.x, sintable[spr->ang&2047],-s.y) > 0)
+                    dmulscale6(bcos(spr->ang), -s.x, bsin(spr->ang), -s.y) > 0)
                     if (renderAddTsprite(z, sectnum))
                         break;
             }
@@ -3088,13 +3088,13 @@ void polymost_drawsprite(int32_t snum)
 
     if (spriteext[spritenum].flags & SPREXT_AWAY1)
     {
-        pos.x += (sintable[(tspr->ang + 512) & 2047] >> 13);
-        pos.y += (sintable[(tspr->ang) & 2047] >> 13);
+        pos.x += bcos(tspr->ang, -13);
+        pos.y += bsin(tspr->ang, -13);
     }
     else if (spriteext[spritenum].flags & SPREXT_AWAY2)
     {
-        pos.x -= (sintable[(tspr->ang + 512) & 2047] >> 13);
-        pos.y -= (sintable[(tspr->ang) & 2047] >> 13);
+        pos.x -= bcos(tspr->ang, -13);
+        pos.y -= bsin(tspr->ang, -13);
     }
 
     vec2_t tsiz;
@@ -3125,7 +3125,7 @@ void polymost_drawsprite(int32_t snum)
             float foffs2 = TSPR_OFFSET(tspr);
 			if (fabs(foffs2) < fabs(foffs)) foffs = foffs2;
 
-            vec2f_t const offs = { (float)(sintable[(ang + 512) & 2047] >> 6)* foffs,  (float) (sintable[(ang) & 2047] >> 6) * foffs };
+            vec2f_t const offs = { float(bcosf(ang, -6) * foffs), float(bsinf(ang, -6) * foffs) };
 
             vec2f_t s0 = { (float)(tspr->x - globalposx) + offs.x,
                            (float)(tspr->y - globalposy) + offs.y};
@@ -3227,8 +3227,8 @@ void polymost_drawsprite(int32_t snum)
             if (globalorientation & 8)
                 off.y = -off.y;
 
-            vec2f_t const extent = { (float)tspr->xrepeat * (float)sintable[(tspr->ang) & 2047] * (1.0f / 65536.f),
-                                     (float)tspr->xrepeat * (float)sintable[(tspr->ang + 1536) & 2047] * (1.0f / 65536.f) };
+            vec2f_t const extent = { float(tspr->xrepeat * bsinf(tspr->ang, -16)),
+                                     float(tspr->xrepeat * -bcosf(tspr->ang, -16)) };
 
             float f = (float)(tsiz.x >> 1) + (float)off.x;
 
@@ -3273,8 +3273,7 @@ void polymost_drawsprite(int32_t snum)
                 {
                     int32_t const ang = getangle(wall[w].x - POINT2(w).x, wall[w].y - POINT2(w).y);
                     float const foffs = TSPR_OFFSET(tspr);
-                    vec2f_t const offs = { (float)(sintable[(ang + 1024) & 2047] >> 6) * foffs,
-                                     (float)(sintable[(ang + 512) & 2047] >> 6) * foffs};
+                    vec2d_t const offs = { -bsinf(ang, -6) * foffs, bcosf(ang, -6) * foffs };
 
                     vec0.x -= offs.x;
                     vec0.y -= offs.y;
@@ -3423,8 +3422,8 @@ void polymost_drawsprite(int32_t snum)
                               p1 = { (float)((tsiz.x >> 1) + off.x) * tspr->xrepeat,
                                      (float)((tsiz.y >> 1) + off.y) * tspr->yrepeat };
 
-                float const c = sintable[(tspr->ang + 512) & 2047] * (1.0f / 65536.f);
-                float const s = sintable[tspr->ang & 2047] * (1.0f / 65536.f);
+                float const c = bcosf(tspr->ang, -16);
+                float const s = bsinf(tspr->ang, -16);
 
                 vec2f_t pxy[6];
 

--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -2458,7 +2458,7 @@ void polymost_drawrooms()
     {
         // calculates the extend of the zenith glitch
         float verticalfovtan = (fviewingrange * (windowxy2.y-windowxy1.y) * 5.f) / ((float)yxaspect * (windowxy2.x-windowxy1.x) * 4.f);
-        float verticalfov = atanf(verticalfovtan) * (2.f / fPI);
+        float verticalfov = atanf(verticalfovtan) * (2.f / pi::pi());
         static constexpr float const maxhorizangle = 0.6361136f; // horiz of 199 in degrees
         float zenglitch = verticalfov + maxhorizangle - 0.95f; // less than 1 because the zenith glitch extends a bit
         if (zenglitch > 0.f)
@@ -2850,7 +2850,7 @@ void polymost_prepareMirror(int32_t dax, int32_t day, int32_t daz, fixed_t daang
     {
         // calculates the extend of the zenith glitch
         float verticalfovtan = (fviewingrange * (windowxy2.y-windowxy1.y) * 5.f) / ((float)yxaspect * (windowxy2.x-windowxy1.x) * 4.f);
-        float verticalfov = atanf(verticalfovtan) * (2.f / fPI);
+        float verticalfov = atanf(verticalfovtan) * (2.f / pi::pi());
         static constexpr float const maxhorizangle = 0.6361136f; // horiz of 199 in degrees
         float zenglitch = verticalfov + maxhorizangle - 0.95f; // less than 1 because the zenith glitch extends a bit
         if (zenglitch > 0.f)

--- a/source/build/src/voxmodel.cpp
+++ b/source/build/src/voxmodel.cpp
@@ -1031,8 +1031,8 @@ int32_t polymost_voxdraw(voxmodel_t* m, tspriteptr_t const tspr)
     if ((sprite[tspr->owner].cstat&48)==16)
     {
         f *= 1.25f;
-        a0.y -= tspr->xoffset*sintable[(spriteext[tspr->owner].angoff+512)&2047]*(1.f/(64.f*16384.f));
-        a0.x += tspr->xoffset*sintable[(spriteext[tspr->owner].angoff)&2047]*(1.f/(64.f*16384.f));
+        a0.y -= tspr->xoffset * bcosf(spriteext[tspr->owner].angoff, -20);
+        a0.x += tspr->xoffset * bsinf(spriteext[tspr->owner].angoff, -20);
     }
 
     if (globalorientation&8) { m0.z = -m0.z; a0.z = -a0.z; } //y-flipping

--- a/source/core/automap.cpp
+++ b/source/core/automap.cpp
@@ -236,11 +236,11 @@ void AutomapControl()
 			if (buttonMap.ButtonDown(gamefunc_AM_PanDown))
 				panvert -= keymove;
 
-			int momx = mulscale9(panvert, sintable[(follow_a + 512) & 2047]);
-			int momy = mulscale9(panvert, sintable[(follow_a) & 2047]);
+			int momx = mulscale9(panvert, bcos(follow_a));
+			int momy = mulscale9(panvert, bsin(follow_a));
 
-			momx += mulscale9(panhorz, sintable[(follow_a) & 2047]);
-			momy += mulscale9(panhorz, sintable[(follow_a + 1536) & 2047]);
+			momx += mulscale9(panhorz, bsin(follow_a));
+			momy += mulscale9(panhorz, -bcos(follow_a));
 
 			follow_x += int(momx * j);
 			follow_y += int(momy * j);
@@ -406,8 +406,8 @@ bool ShowRedLine(int j, int i)
 
 void drawredlines(int cposx, int cposy, int czoom, int cang)
 {
-	int xvect = sintable[(-cang) & 2047] * czoom;
-	int yvect = sintable[(1536 - cang) & 2047] * czoom;
+	int xvect = -bsin(cang) * czoom;
+	int yvect = -bcos(cang) * czoom;
 	int xvect2 = mulscale16(xvect, yxaspect);
 	int yvect2 = mulscale16(yvect, yxaspect);
 
@@ -458,8 +458,8 @@ void drawredlines(int cposx, int cposy, int czoom, int cang)
 
 static void drawwhitelines(int cposx, int cposy, int czoom, int cang)
 {
-	int xvect = sintable[(-cang) & 2047] * czoom;
-	int yvect = sintable[(1536 - cang) & 2047] * czoom;
+	int xvect = -bsin(cang) * czoom;
+	int yvect = -bcos(cang) * czoom;
 	int xvect2 = mulscale16(xvect, yxaspect);
 	int yvect2 = mulscale16(yvect, yxaspect);
 
@@ -508,13 +508,13 @@ void DrawPlayerArrow(int cposx, int cposy, int cang, int pl_x, int pl_y, int zoo
 		0, 65536, 32768, 32878,
 	};
 
-	int xvect = sintable[(-cang) & 2047] * zoom;
-	int yvect = sintable[(1536 - cang) & 2047] * zoom;
+	int xvect = -bsin(cang) * zoom;
+	int yvect = -bcos(cang) * zoom;
 	int xvect2 = mulscale16(xvect, yxaspect);
 	int yvect2 = mulscale16(yvect, yxaspect);
 
-	int pxvect = sintable[(-pl_angle) & 2047];
-	int pyvect = sintable[(1536 - pl_angle) & 2047];
+	int pxvect = -bsin(pl_angle);
+	int pyvect = -bcos(pl_angle);
 
 	for (int i = 0; i < 12; i += 4)
 	{

--- a/source/core/binaryangle.h
+++ b/source/core/binaryangle.h
@@ -46,7 +46,8 @@ class FSerializer;
 
 enum
 {
-	BAMUNIT = 1 << 21,
+	BAMBITS = 21,
+	BAMUNIT = 1 << BAMBITS,
 	SINSHIFT = 14
 };
 
@@ -89,6 +90,18 @@ inline int32_t bcos(const int16_t& ang, const int8_t& shift = 0)
 inline double bcosf(const double& ang, const int8_t& shift = 0)
 {
 	return cos(ang * BAngRadian) * (shift >= -SINSHIFT ? uint64_t(1) << (SINSHIFT + shift) : 1. / (uint64_t(1) << abs(SINSHIFT + shift)));
+}
+
+
+//---------------------------------------------------------------------------
+//
+// Shift a Build angle left by 21 bits.
+//
+//---------------------------------------------------------------------------
+
+inline constexpr uint32_t BAngToBAM(int ang)
+{
+	return ang << BAMBITS;
 }
 
 
@@ -164,7 +177,7 @@ public:
 
 inline constexpr binangle bamang(uint32_t v) { return binangle(v); }
 inline constexpr binangle q16ang(uint32_t v) { return binangle(v << 5); }
-inline constexpr binangle buildang(uint32_t v) { return binangle(v << 21); }
+inline constexpr binangle buildang(uint32_t v) { return binangle(v << BAMBITS); }
 inline binangle radang(double v) { return binangle(xs_CRoundToUInt(v * (0x80000000u / pi::pi()))); }
 inline binangle degang(double v) { return binangle(FloatToAngle(v)); }
 
@@ -246,7 +259,7 @@ public:
 
 inline constexpr lookangle bamlook(int32_t v) { return lookangle(v); }
 inline constexpr lookangle q16look(int32_t v) { return lookangle(v << 5); }
-inline constexpr lookangle buildlook(int32_t v) { return lookangle(v << 21); }
+inline constexpr lookangle buildlook(int32_t v) { return lookangle(v << BAMBITS); }
 inline lookangle radlook(double v) { return lookangle(xs_CRoundToUInt(v * (0x80000000u / pi::pi()))); }
 inline lookangle deglook(double v) { return lookangle(FloatToAngle(v)); }
 

--- a/source/core/binaryangle.h
+++ b/source/core/binaryangle.h
@@ -141,6 +141,25 @@ public:
 	int bsin(const int8_t& shift = 0) const { return ::bsin(asbuild(), shift); }
 	int bcos(const int8_t& shift = 0) const { return ::bcos(asbuild(), shift); }
 
+	bool operator< (binangle other) const
+	{
+		return value < other.value;
+	}
+
+	bool operator> (binangle other) const
+	{
+		return value > other.value;
+	}
+
+	bool operator<= (binangle other) const
+	{
+		return value <= other.value;
+	}
+
+	bool operator>= (binangle other) const
+	{
+		return value >= other.value;
+	}
 	constexpr bool operator== (binangle other) const
 	{
 		return value == other.value;
@@ -171,6 +190,28 @@ public:
 	constexpr binangle operator- (binangle other) const
 	{
 		return binangle(value - other.value);
+	}
+
+	constexpr binangle &operator<<= (const uint8_t& shift)
+	{
+		value <<= shift;
+		return *this;
+	}
+
+	constexpr binangle &operator>>= (const uint8_t& shift)
+	{
+		value >>= shift;
+		return *this;
+	}
+
+	constexpr binangle operator<< (const uint8_t& shift) const
+	{
+		return binangle(value << shift);
+	}
+
+	constexpr binangle operator>> (const uint8_t& shift) const
+	{
+		return binangle(value >> shift);
 	}
 
 };
@@ -223,6 +264,25 @@ public:
 	int bsin(const int8_t& shift = 0) const { return ::bsin(asbuild(), shift); }
 	int bcos(const int8_t& shift = 0) const { return ::bcos(asbuild(), shift); }
 
+	bool operator< (lookangle other) const
+	{
+		return value < other.value;
+	}
+
+	bool operator> (lookangle other) const
+	{
+		return value > other.value;
+	}
+
+	bool operator<= (lookangle other) const
+	{
+		return value <= other.value;
+	}
+
+	bool operator>= (lookangle other) const
+	{
+		return value >= other.value;
+	}
 	constexpr bool operator== (lookangle other) const
 	{
 		return value == other.value;
@@ -253,6 +313,28 @@ public:
 	constexpr lookangle operator- (lookangle other) const
 	{
 		return lookangle(value - other.value);
+	}
+
+	constexpr lookangle &operator<<= (const uint8_t& shift)
+	{
+		value <<= shift;
+		return *this;
+	}
+
+	constexpr lookangle &operator>>= (const uint8_t& shift)
+	{
+		value >>= shift;
+		return *this;
+	}
+
+	constexpr lookangle operator<< (const uint8_t& shift) const
+	{
+		return lookangle(value << shift);
+	}
+
+	constexpr lookangle operator>> (const uint8_t& shift) const
+	{
+		return lookangle(value >> shift);
 	}
 
 };
@@ -375,6 +457,28 @@ public:
 	constexpr fixedhoriz operator- (fixedhoriz other) const
 	{
 		return fixedhoriz(value - other.value);
+	}
+
+	constexpr fixedhoriz &operator<<= (const uint8_t& shift)
+	{
+		value <<= shift;
+		return *this;
+	}
+
+	constexpr fixedhoriz &operator>>= (const uint8_t& shift)
+	{
+		value >>= shift;
+		return *this;
+	}
+
+	constexpr fixedhoriz operator<< (const uint8_t& shift) const
+	{
+		return fixedhoriz(value << shift);
+	}
+
+	constexpr fixedhoriz operator>> (const uint8_t& shift) const
+	{
+		return fixedhoriz(value >> shift);
 	}
 
 };

--- a/source/core/binaryangle.h
+++ b/source/core/binaryangle.h
@@ -111,129 +111,6 @@ inline constexpr uint32_t BAngToBAM(int ang)
 //
 //---------------------------------------------------------------------------
 
-class binangle
-{
-	uint32_t value;
-	
-	constexpr binangle(uint32_t v) : value(v) {}
-	
-	friend constexpr binangle bamang(uint32_t v);
-	friend constexpr binangle q16ang(uint32_t v);
-	friend constexpr binangle buildang(uint32_t v);
-	friend binangle radang(double v);
-	friend binangle degang(double v);
-
-	friend FSerializer &Serialize(FSerializer &arc, const char *key, binangle &obj, binangle *defval);
-	
-public:
-	binangle() = default;
-	binangle(const binangle &other) = default;
-	// This class intentionally makes no allowances for implicit type conversions because those would render it ineffective.
-	constexpr short asbuild() const { return value >> 21; }
-	constexpr fixed_t asq16() const { return value >> 5; }
-	constexpr double asrad() const { return value * (pi::pi() / 0x80000000u); }
-	constexpr double asdeg() const { return AngleToFloat(value); }
-	constexpr uint32_t asbam() const { return value; }
-	
-	double fsin() const { return sin(asrad()); }
-	double fcos() const { return cos(asrad()); }
-	double ftan() const { return tan(asrad()); }
-	int bsin(const int8_t& shift = 0) const { return ::bsin(asbuild(), shift); }
-	int bcos(const int8_t& shift = 0) const { return ::bcos(asbuild(), shift); }
-
-	bool operator< (binangle other) const
-	{
-		return value < other.value;
-	}
-
-	bool operator> (binangle other) const
-	{
-		return value > other.value;
-	}
-
-	bool operator<= (binangle other) const
-	{
-		return value <= other.value;
-	}
-
-	bool operator>= (binangle other) const
-	{
-		return value >= other.value;
-	}
-	constexpr bool operator== (binangle other) const
-	{
-		return value == other.value;
-	}
-
-	constexpr bool operator!= (binangle other) const
-	{
-		return value != other.value;
-	}
-
-	constexpr binangle &operator+= (binangle other)
-	{
-		value += other.value;
-		return *this;
-	}
-
-	constexpr binangle &operator-= (binangle other)
-	{
-		value -= other.value;
-		return *this;
-	}
-
-	constexpr binangle operator+ (binangle other) const
-	{
-		return binangle(value + other.value);
-	}
-
-	constexpr binangle operator- (binangle other) const
-	{
-		return binangle(value - other.value);
-	}
-
-	constexpr binangle &operator<<= (const uint8_t& shift)
-	{
-		value <<= shift;
-		return *this;
-	}
-
-	constexpr binangle &operator>>= (const uint8_t& shift)
-	{
-		value >>= shift;
-		return *this;
-	}
-
-	constexpr binangle operator<< (const uint8_t& shift) const
-	{
-		return binangle(value << shift);
-	}
-
-	constexpr binangle operator>> (const uint8_t& shift) const
-	{
-		return binangle(value >> shift);
-	}
-
-};
-
-inline constexpr binangle bamang(uint32_t v) { return binangle(v); }
-inline constexpr binangle q16ang(uint32_t v) { return binangle(v << 5); }
-inline constexpr binangle buildang(uint32_t v) { return binangle(v << BAMBITS); }
-inline binangle radang(double v) { return binangle(xs_CRoundToUInt(v * (0x80000000u / pi::pi()))); }
-inline binangle degang(double v) { return binangle(FloatToAngle(v)); }
-
-inline FSerializer &Serialize(FSerializer &arc, const char *key, binangle &obj, binangle *defval)
-{
-	return Serialize(arc, key, obj.value, defval ? &defval->value : nullptr);
-}
-
-
-//---------------------------------------------------------------------------
-//
-//
-//
-//---------------------------------------------------------------------------
-
 class lookangle
 {
 	int32_t value;
@@ -247,6 +124,8 @@ class lookangle
 	friend lookangle deglook(double v);
 
 	friend FSerializer &Serialize(FSerializer &arc, const char *key, lookangle &obj, lookangle *defval);
+
+	friend class binangle;
 	
 public:
 	lookangle() = default;
@@ -346,6 +225,151 @@ inline lookangle radlook(double v) { return lookangle(xs_CRoundToUInt(v * (0x800
 inline lookangle deglook(double v) { return lookangle(FloatToAngle(v)); }
 
 inline FSerializer &Serialize(FSerializer &arc, const char *key, lookangle &obj, lookangle *defval)
+{
+	return Serialize(arc, key, obj.value, defval ? &defval->value : nullptr);
+}
+
+
+//---------------------------------------------------------------------------
+//
+//
+//
+//---------------------------------------------------------------------------
+
+class binangle
+{
+	uint32_t value;
+	
+	constexpr binangle(uint32_t v) : value(v) {}
+	
+	friend constexpr binangle bamang(uint32_t v);
+	friend constexpr binangle q16ang(uint32_t v);
+	friend constexpr binangle buildang(uint32_t v);
+	friend binangle radang(double v);
+	friend binangle degang(double v);
+
+	friend FSerializer &Serialize(FSerializer &arc, const char *key, binangle &obj, binangle *defval);
+	
+public:
+	binangle() = default;
+	binangle(const binangle &other) = default;
+	// This class intentionally makes no allowances for implicit type conversions because those would render it ineffective.
+	constexpr short asbuild() const { return value >> 21; }
+	constexpr fixed_t asq16() const { return value >> 5; }
+	constexpr double asrad() const { return value * (pi::pi() / 0x80000000u); }
+	constexpr double asdeg() const { return AngleToFloat(value); }
+	constexpr uint32_t asbam() const { return value; }
+	
+	double fsin() const { return sin(asrad()); }
+	double fcos() const { return cos(asrad()); }
+	double ftan() const { return tan(asrad()); }
+	int bsin(const int8_t& shift = 0) const { return ::bsin(asbuild(), shift); }
+	int bcos(const int8_t& shift = 0) const { return ::bcos(asbuild(), shift); }
+
+	bool operator< (binangle other) const
+	{
+		return value < other.value;
+	}
+
+	bool operator> (binangle other) const
+	{
+		return value > other.value;
+	}
+
+	bool operator<= (binangle other) const
+	{
+		return value <= other.value;
+	}
+
+	bool operator>= (binangle other) const
+	{
+		return value >= other.value;
+	}
+	constexpr bool operator== (binangle other) const
+	{
+		return value == other.value;
+	}
+
+	constexpr bool operator!= (binangle other) const
+	{
+		return value != other.value;
+	}
+
+	constexpr binangle &operator+= (binangle other)
+	{
+		value += other.value;
+		return *this;
+	}
+
+	constexpr binangle &operator-= (binangle other)
+	{
+		value -= other.value;
+		return *this;
+	}
+
+	constexpr binangle operator+ (binangle other) const
+	{
+		return binangle(value + other.value);
+	}
+
+	constexpr binangle operator- (binangle other) const
+	{
+		return binangle(value - other.value);
+	}
+
+	constexpr binangle &operator+= (lookangle other)
+	{
+		value += other.value;
+		return *this;
+	}
+
+	constexpr binangle &operator-= (lookangle other)
+	{
+		value -= other.value;
+		return *this;
+	}
+
+	constexpr binangle operator+ (lookangle other) const
+	{
+		return binangle(value + other.value);
+	}
+
+	constexpr binangle operator- (lookangle other) const
+	{
+		return binangle(value - other.value);
+	}
+
+	constexpr binangle &operator<<= (const uint8_t& shift)
+	{
+		value <<= shift;
+		return *this;
+	}
+
+	constexpr binangle &operator>>= (const uint8_t& shift)
+	{
+		value >>= shift;
+		return *this;
+	}
+
+	constexpr binangle operator<< (const uint8_t& shift) const
+	{
+		return binangle(value << shift);
+	}
+
+	constexpr binangle operator>> (const uint8_t& shift) const
+	{
+		return binangle(value >> shift);
+	}
+
+};
+
+inline constexpr binangle bamang(uint32_t v) { return binangle(v); }
+inline constexpr binangle q16ang(uint32_t v) { return binangle(v << 5); }
+inline constexpr binangle buildang(uint32_t v) { return binangle(v << BAMBITS); }
+inline binangle radang(double v) { return binangle(xs_CRoundToUInt(v * (0x80000000u / pi::pi()))); }
+inline binangle degang(double v) { return binangle(FloatToAngle(v)); }
+
+inline FSerializer &Serialize(FSerializer &arc, const char *key, binangle &obj, binangle *defval)
 {
 	return Serialize(arc, key, obj.value, defval ? &defval->value : nullptr);
 }

--- a/source/core/binaryangle.h
+++ b/source/core/binaryangle.h
@@ -132,6 +132,7 @@ public:
 	lookangle(const lookangle &other) = default;
 	// This class intentionally makes no allowances for implicit type conversions because those would render it ineffective.
 	constexpr short asbuild() const { return value >> 21; }
+	constexpr double asbuildf() const { return value * (1. / BAMUNIT); }
 	constexpr fixed_t asq16() const { return value >> 5; }
 	constexpr double asrad() const { return value * (pi::pi() / 0x80000000u); }
 	constexpr double asdeg() const { return AngleToFloat(value); }
@@ -255,6 +256,7 @@ public:
 	binangle(const binangle &other) = default;
 	// This class intentionally makes no allowances for implicit type conversions because those would render it ineffective.
 	constexpr short asbuild() const { return value >> 21; }
+	constexpr double asbuildf() const { return value * (1. / BAMUNIT); }
 	constexpr fixed_t asq16() const { return value >> 5; }
 	constexpr double asrad() const { return value * (pi::pi() / 0x80000000u); }
 	constexpr double asdeg() const { return AngleToFloat(value); }
@@ -423,6 +425,7 @@ public:
 
 	// This class intentionally makes no allowances for implicit type conversions because those would render it ineffective.
 	constexpr short asbuild() const { return FixedToInt(value); }
+	constexpr double asbuildf() const { return FixedToFloat(value); }
 	constexpr fixed_t asq16() const { return value; }
 	double aspitch() const { return HorizToPitch(value); }
 	int32_t asbam() const { return PitchToBAM(aspitch()); }

--- a/source/core/gamecontrol.h
+++ b/source/core/gamecontrol.h
@@ -12,7 +12,6 @@
 #include "i_time.h"
 #include "palentry.h"
 #include "pragmas.h"
-#include "binaryangle.h"
 
 extern FString currentGame;
 extern FString LumpFilter;

--- a/source/core/gameinput.cpp
+++ b/source/core/gameinput.cpp
@@ -40,17 +40,13 @@ int getincangle(int a, int na)
 	a &= 2047;
 	na &= 2047;
 
-	if(abs(a-na) < 1024)
-		return (na-a);
-	else
+	if(abs(a-na) >= 1024)
 	{
 		if(na > 1024) na -= 2048;
 		if(a > 1024) a -= 2048;
-
-		na -= 2048;
-		a -= 2048;
-		return (na-a);
 	}
+
+	return na-a;
 }
 
 fixed_t getincangleq16(fixed_t a, fixed_t na)
@@ -58,17 +54,27 @@ fixed_t getincangleq16(fixed_t a, fixed_t na)
 	a &= 0x7FFFFFF;
 	na &= 0x7FFFFFF;
 
-	if(abs(a-na) < IntToFixed(1024))
-		return (na-a);
-	else
+	if(abs(a-na) >= IntToFixed(1024))
 	{
 		if(na > IntToFixed(1024)) na -= IntToFixed(2048);
 		if(a > IntToFixed(1024)) a -= IntToFixed(2048);
-
-		na -= IntToFixed(2048);
-		a -= IntToFixed(2048);
-		return (na-a);
 	}
+
+	return na-a;
+}
+
+lookangle getincanglebam(binangle a, binangle na)
+{
+	int64_t cura = a.asbam() & 0xFFFFFFFF;
+	int64_t newa = na.asbam() & 0xFFFFFFFF;
+
+	if(abs(cura-newa) >= BAngToBAM(1024))
+	{
+		if(newa > BAngToBAM(1024)) newa -= BAngToBAM(2048);
+		if(cura > BAngToBAM(1024)) cura -= BAngToBAM(2048);
+	}
+
+	return bamlook(newa-cura);
 }
 
 //---------------------------------------------------------------------------

--- a/source/core/gameinput.h
+++ b/source/core/gameinput.h
@@ -114,6 +114,18 @@ struct PlayerAngle
 		rotscrnang = orotscrnang;
 	}
 
+	void addadjustment(int value)
+	{
+		if (!cl_syncinput)
+		{
+			adjustment += BAngToBAM(value);
+		}
+		else
+		{
+			ang += buildang(value);
+		}
+	}
+
 	void addadjustment(double value)
 	{
 		if (!cl_syncinput)
@@ -123,6 +135,30 @@ struct PlayerAngle
 		else
 		{
 			ang += bamang(xs_CRoundToUInt(value * BAMUNIT));
+		}
+	}
+
+	void addadjustment(lookangle value)
+	{
+		if (!cl_syncinput)
+		{
+			adjustment += value.asbam();
+		}
+		else
+		{
+			ang += bamang(value.asbam());
+		}
+	}
+
+	void addadjustment(binangle value)
+	{
+		if (!cl_syncinput)
+		{
+			adjustment += value.asbam();
+		}
+		else
+		{
+			ang += value;
 		}
 	}
 

--- a/source/core/gameinput.h
+++ b/source/core/gameinput.h
@@ -195,6 +195,20 @@ struct PlayerAngle
 		}
 	}
 
+	void settarget(binangle value, bool backup = false)
+	{
+		if (!cl_syncinput)
+		{
+			target = value.asbam();
+			if (target == 0) target += 1;
+		}
+		else
+		{
+			ang = value;
+			if (backup) oang = ang;
+		}
+	}
+
 	void processhelpers(double const scaleAdjust)
 	{
 		if (target)

--- a/source/core/gameinput.h
+++ b/source/core/gameinput.h
@@ -167,6 +167,20 @@ struct PlayerAngle
 		adjustment = 0;
 	}
 
+	void settarget(int value, bool backup = false)
+	{
+		if (!cl_syncinput)
+		{
+			target = value << BAMBITS;
+			if (target == 0) target += 1;
+		}
+		else
+		{
+			ang = buildang(value);
+			if (backup) oang = ang;
+		}
+	}
+
 	void settarget(double value, bool backup = false)
 	{
 		if (!cl_syncinput)

--- a/source/core/gameinput.h
+++ b/source/core/gameinput.h
@@ -229,12 +229,12 @@ struct PlayerAngle
 
 	binangle osum()
 	{
-		return bamang(oang.asbam() + olook_ang.asbam());
+		return oang + olook_ang;
 	}
 
 	binangle sum()
 	{
-		return bamang(ang.asbam() + look_ang.asbam());
+		return ang + look_ang;
 	}
 
 	binangle interpolatedsum(double const smoothratio)
@@ -248,8 +248,8 @@ struct PlayerAngle
 
 	lookangle interpolatedrotscrn(double const smoothratio)
 	{
-		double const ratio = smoothratio / FRACUNIT;
-		return bamlook(orotscrnang.asbam() + xs_CRoundToInt(ratio * (rotscrnang.asbam() - orotscrnang.asbam())));
+		double const ratio = smoothratio * (1. / FRACUNIT);
+		return bamlook(orotscrnang.asbam() + xs_CRoundToInt(ratio * (rotscrnang - orotscrnang).asbam()));
 	}
 };
 

--- a/source/core/gameinput.h
+++ b/source/core/gameinput.h
@@ -5,8 +5,9 @@
 #include "gamecvars.h"
 #include "packet.h"
 
-int getincangle(int c, int n);
-fixed_t getincangleq16(fixed_t c, fixed_t n);
+int getincangle(int a, int na);
+fixed_t getincangleq16(fixed_t a, fixed_t na);
+lookangle getincanglebam(binangle a, binangle na);
 
 struct PlayerHorizon
 {

--- a/source/exhumed/src/2d.cpp
+++ b/source/exhumed/src/2d.cpp
@@ -711,7 +711,7 @@ public:
 			
 			if (nLevelNew == i)
 			{
-				shade = (Sin(16 * currentclock) + 31) >> 8;
+				shade = (bsin(16 * currentclock) + 31) >> 8;
 			}
 			else if (nLevelBest >= i)
 			{

--- a/source/exhumed/src/anubis.cpp
+++ b/source/exhumed/src/anubis.cpp
@@ -218,8 +218,8 @@ void FuncAnubis(int a, int nDamage, int nRun)
                             AnubisList[nAnubis].nFrame = 0;
                             AnubisList[nAnubis].nTarget = nTarget;
 
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
                         }
                     }
                     return;
@@ -231,8 +231,8 @@ void FuncAnubis(int a, int nDamage, int nRun)
                         PlotCourseToSprite(nSprite, nTarget);
 
                         int nAngle = sprite[nSprite].ang & 0xFFF8;
-                        sprite[nSprite].xvel = Cos(nAngle) >> 2;
-                        sprite[nSprite].yvel = Sin(nAngle) >> 2;
+                        sprite[nSprite].xvel = bcos(nAngle, -2);
+                        sprite[nSprite].yvel = bsin(nAngle, -2);
                     }
 
                     switch (nMov & 0xC000)
@@ -257,8 +257,8 @@ void FuncAnubis(int a, int nDamage, int nRun)
                         case 0x8000:
                         {
                             sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
                             break;
                         }
 
@@ -321,8 +321,8 @@ void FuncAnubis(int a, int nDamage, int nRun)
                     {
                         AnubisList[nAnubis].nAction = 1;
 
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
                         AnubisList[nAnubis].nFrame = 0;
                     }
                     else

--- a/source/exhumed/src/bullet.cpp
+++ b/source/exhumed/src/bullet.cpp
@@ -213,8 +213,8 @@ void BulletHitsSprite(Bullet *pBullet, short nBulletSprite, short nHitSprite, in
             {
                 short nAngle = (pSprite->ang + 256) - RandomSize(9);
 
-                pHitSprite->xvel = Cos(nAngle) << 1;
-                pHitSprite->yvel = Sin(nAngle) << 1;
+                pHitSprite->xvel = bcos(nAngle, 1);
+                pHitSprite->yvel = bsin(nAngle, 1);
                 pHitSprite->zvel = (-(RandomSize(3) + 1)) << 8;
             }
             else
@@ -222,8 +222,8 @@ void BulletHitsSprite(Bullet *pBullet, short nBulletSprite, short nHitSprite, in
                 int xVel = pHitSprite->xvel;
                 int yVel = pHitSprite->yvel;
 
-                pHitSprite->xvel = Cos(pSprite->ang) >> 2;
-                pHitSprite->yvel = Sin(pSprite->ang) >> 2;
+                pHitSprite->xvel = bcos(pSprite->ang, -2);
+                pHitSprite->yvel = bsin(pSprite->ang, -2);
 
                 MoveCreature(nHitSprite);
 
@@ -276,8 +276,8 @@ void BulletHitsSprite(Bullet *pBullet, short nBulletSprite, short nHitSprite, in
 
 void BackUpBullet(int *x, int *y, short nAngle)
 {
-    *x -= Cos(nAngle) >> 11;
-    *y -= Sin(nAngle) >> 11;
+    *x -= bcos(nAngle, -11);
+    *y -= bsin(nAngle, -11);
 }
 
 int MoveBullet(short nBullet)
@@ -409,10 +409,10 @@ MOVEEND:
             hitdata_t hitData;
             int dz;
             if (bVanilla)
-                dz = -Sin(pBullet->field_C) * 8;
+                dz = -bsin(pBullet->field_C, 3);
             else
                 dz = -pBullet->field_C * 512;
-            hitscan(&startPos, pSprite->sectnum, Cos(pSprite->ang), Sin(pSprite->ang), dz, &hitData, CLIPMASK1);
+            hitscan(&startPos, pSprite->sectnum, bcos(pSprite->ang), bsin(pSprite->ang), dz, &hitData, CLIPMASK1);
             x2 = hitData.pos.x;
             y2 = hitData.pos.y;
             z2 = hitData.pos.z;
@@ -691,7 +691,7 @@ int BuildBullet(short nSprite, int nType, int, int, int val1, int nAngle, int va
 
     if (val2 < 10000)
     {
-        var_18 = ((-Sin(val2)) * pBulletInfo->field_4) >> 11;
+        var_18 = (-bsin(val2) * pBulletInfo->field_4) >> 11;
     }
     else
     {
@@ -766,8 +766,8 @@ int BuildBullet(short nSprite, int nType, int, int, int val1, int nAngle, int va
     }
 
     pBullet->z = 0;
-    pBullet->x = (sprite[nSprite].clipdist << 2) * Cos(nAngle);
-    pBullet->y = (sprite[nSprite].clipdist << 2) * Sin(nAngle);
+    pBullet->x = (sprite[nSprite].clipdist << 2) * bcos(nAngle);
+    pBullet->y = (sprite[nSprite].clipdist << 2) * bsin(nAngle);
     nBulletEnemy[nBullet] = -1;
 
     if (MoveBullet(nBullet))
@@ -777,8 +777,8 @@ int BuildBullet(short nSprite, int nType, int, int, int val1, int nAngle, int va
     else
     {
         pBullet->field_10 = pBulletInfo->field_4;
-        pBullet->x = (Cos(nAngle) >> 3) * pBulletInfo->field_4;
-        pBullet->y = (Sin(nAngle) >> 3) * pBulletInfo->field_4;
+        pBullet->x = bcos(nAngle, -3) * pBulletInfo->field_4;
+        pBullet->y = bsin(nAngle, -3) * pBulletInfo->field_4;
         pBullet->z = var_18 >> 3;
     }
 

--- a/source/exhumed/src/engine.h
+++ b/source/exhumed/src/engine.h
@@ -126,15 +126,5 @@ int GetMyAngle(int x, int y);
 int AngleDiff(short a, short b);
 int AngleDelta(int a, int b, int c);
 
-inline int Sin(int angle)
-{
-    return sintable[angle & kAngleMask];
-}
-
-inline int Cos(int angle)
-{
-    return sintable[(angle + 512) & kAngleMask];
-}
-
 END_PS_NS
 

--- a/source/exhumed/src/engine.h
+++ b/source/exhumed/src/engine.h
@@ -131,11 +131,6 @@ inline int Sin(int angle)
     return sintable[angle & kAngleMask];
 }
 
-inline double FSin(double angle)
-{
-    return calcSinTableValue(fmod(angle, kAngleMask + 1));
-}
-
 inline int Cos(int angle)
 {
     return sintable[(angle + 512) & kAngleMask];

--- a/source/exhumed/src/exhumed.cpp
+++ b/source/exhumed/src/exhumed.cpp
@@ -333,8 +333,8 @@ void GameInterface::Ticker()
 
         for (int i = 0; i < 4; i++)
         {
-            lPlayerXVel += localInput.fvel * Cos(inita) + localInput.svel * Sin(inita);
-            lPlayerYVel += localInput.fvel * Sin(inita) - localInput.svel * Cos(inita);
+            lPlayerXVel += localInput.fvel * bcos(inita) + localInput.svel * bsin(inita);
+            lPlayerYVel += localInput.fvel * bsin(inita) - localInput.svel * bcos(inita);
             lPlayerXVel -= (lPlayerXVel >> 5) + (lPlayerXVel >> 6);
             lPlayerYVel -= (lPlayerYVel >> 5) + (lPlayerYVel >> 6);
         }

--- a/source/exhumed/src/fish.cpp
+++ b/source/exhumed/src/fish.cpp
@@ -282,8 +282,8 @@ void IdleFish(short nFish, short edx)
     sprite[nSprite].ang += (256 - RandomSize(9)) + 1024;
     sprite[nSprite].ang &= kAngleMask;
 
-    sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 8;
-    sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 8;
+    sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -8);
+    sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -8);
 
     FishList[nFish].nAction = 0;
     FishList[nFish].nFrame = 0;
@@ -440,7 +440,7 @@ void FuncFish(int a, int nDamage, int nRun)
                             FishList[nFish].nFrame = 0;
 
                             int nAngle = GetMyAngle(sprite[nTarget].x - sprite[nSprite].x, sprite[nTarget].z - sprite[nSprite].z);
-                            sprite[nSprite].zvel = Sin(nAngle) >> 5;
+                            sprite[nSprite].zvel = bsin(nAngle, -5);
 
                             FishList[nFish].field_C = RandomSize(6) + 90;
                         }
@@ -474,8 +474,8 @@ void FuncFish(int a, int nDamage, int nRun)
 
                         if (z <= nHeight)
                         {
-                            sprite[nSprite].xvel = (Cos(sprite[nSprite].ang) >> 5) - (Cos(sprite[nSprite].ang) >> 7);
-                            sprite[nSprite].yvel = (Sin(sprite[nSprite].ang) >> 5) - (Sin(sprite[nSprite].ang) >> 7);
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -5) - bcos(sprite[nSprite].ang, -7);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -5) - bsin(sprite[nSprite].ang, -7);
                         }
                         else
                         {

--- a/source/exhumed/src/grenade.cpp
+++ b/source/exhumed/src/grenade.cpp
@@ -88,8 +88,8 @@ void BounceGrenade(short nGrenade, short nAngle)
 {
     GrenadeList[nGrenade].field_10 >>= 1;
 
-    GrenadeList[nGrenade].x = (Cos(nAngle) >> 5) * GrenadeList[nGrenade].field_10;
-    GrenadeList[nGrenade].y = (Sin(nAngle) >> 5) * GrenadeList[nGrenade].field_10;
+    GrenadeList[nGrenade].x = bcos(nAngle, -5) * GrenadeList[nGrenade].field_10;
+    GrenadeList[nGrenade].y = bsin(nAngle, -5) * GrenadeList[nGrenade].field_10;
 
     D3PlayFX(StaticSound[kSound3], GrenadeList[nGrenade].nSprite);
 }
@@ -126,7 +126,7 @@ int ThrowGrenade(short nPlayer, int, int, int ecx, int push1)
         GrenadeList[nGrenade].field_10 = ((90 - GrenadeList[nGrenade].field_E) * (90 - GrenadeList[nGrenade].field_E)) + nVel;
         sprite[nGrenadeSprite].zvel = (-64 * push1) - 4352;
 
-        int nMov = movesprite(nGrenadeSprite, Cos(nAngle) * (sprite[nPlayerSprite].clipdist << 3), Sin(nAngle) * (sprite[nPlayerSprite].clipdist << 3), ecx, 0, 0, CLIPMASK1);
+        int nMov = movesprite(nGrenadeSprite, bcos(nAngle) * (sprite[nPlayerSprite].clipdist << 3), bsin(nAngle) * (sprite[nPlayerSprite].clipdist << 3), ecx, 0, 0, CLIPMASK1);
         if (nMov & 0x8000)
         {
             nAngle = GetWallNormal(nMov & 0x3FFF);
@@ -139,11 +139,8 @@ int ThrowGrenade(short nPlayer, int, int, int ecx, int push1)
         sprite[nGrenadeSprite].zvel = sprite[nPlayerSprite].zvel;
     }
 
-    GrenadeList[nGrenade].x = Cos(nAngle) >> 4;
-    GrenadeList[nGrenade].x *= GrenadeList[nGrenade].field_10;
-
-    GrenadeList[nGrenade].y = Sin(nAngle) >> 4;
-    GrenadeList[nGrenade].y *= GrenadeList[nGrenade].field_10;
+    GrenadeList[nGrenade].x = bcos(nAngle, -4) * GrenadeList[nGrenade].field_10;
+    GrenadeList[nGrenade].y = bsin(nAngle, -4) * GrenadeList[nGrenade].field_10;
 
     nPlayerGrenade[nPlayer] = -1;
 
@@ -240,8 +237,8 @@ void ExplodeGrenade(short nGrenade)
         short nAngle = sprite[nPlayerSprite].ang;
 
         sprite[nGrenadeSprite].z = sprite[nPlayerSprite].z;
-        sprite[nGrenadeSprite].x = (Cos(nAngle) >> 5) + sprite[nPlayerSprite].x;
-        sprite[nGrenadeSprite].y = (Sin(nAngle) >> 5) + sprite[nPlayerSprite].y;
+        sprite[nGrenadeSprite].x = bcos(nAngle, -5) + sprite[nPlayerSprite].x;
+        sprite[nGrenadeSprite].y = bsin(nAngle, -5) + sprite[nPlayerSprite].y;
 
         changespritesect(nGrenadeSprite, sprite[nPlayerSprite].sectnum);
 

--- a/source/exhumed/src/gun.cpp
+++ b/source/exhumed/src/gun.cpp
@@ -302,7 +302,7 @@ int CheckCloseRange(short nPlayer, int *x, int *y, int *z, short *nSector)
     hitSect = hitData.sect;
     hitWall = hitData.wall;
 
-    int ecx = sintable[150] >> 3;
+    int ecx = bsin(150, -3);
 
     uint32_t xDiff = klabs(hitX - *x);
     uint32_t yDiff = klabs(hitY - *y);

--- a/source/exhumed/src/gun.cpp
+++ b/source/exhumed/src/gun.cpp
@@ -962,8 +962,8 @@ void DrawWeapons(double smooth)
     {
         // CHECKME - not & 0x7FF?
         double nBobAngle = obobangle + fmulscale16(((bobangle + 1024 - obobangle) & 2047) - 1024, smooth);
-        double nVal = (ototalvel[nLocalPlayer] + fmulscale16(totalvel[nLocalPlayer] - ototalvel[nLocalPlayer], smooth)) / 2.;
-        yOffset = (nVal * (calcSinTableValue(fmod(nBobAngle, 1024)) / 256.)) / 512.;
+        double nVal = (ototalvel[nLocalPlayer] + fmulscale16(totalvel[nLocalPlayer] - ototalvel[nLocalPlayer], smooth)) * 0.5;
+        yOffset = fmulscale9(nVal, bsinf(fmod(nBobAngle, 1024.), -8));
 
         if (var_34 == 1)
         {

--- a/source/exhumed/src/gun.cpp
+++ b/source/exhumed/src/gun.cpp
@@ -289,8 +289,8 @@ int CheckCloseRange(short nPlayer, int *x, int *y, int *z, short *nSector)
 
     short nSprite = PlayerList[nPlayer].nSprite;
 
-    int xVect = Sin(sprite[nSprite].ang + 512);
-    int yVect = Sin(sprite[nSprite].ang);
+    int xVect = bcos(sprite[nSprite].ang);
+    int yVect = bsin(sprite[nSprite].ang);
 
     vec3_t startPos = { *x, *y, *z };
     hitdata_t hitData;
@@ -697,8 +697,8 @@ loc_flag:
             int theY = sprite[nPlayerSprite].y;
             int theZ = sprite[nPlayerSprite].z;
 
-            int ebp = Cos(nAngle) * (sprite[nPlayerSprite].clipdist << 3);
-            int ebx = Sin(nAngle) * (sprite[nPlayerSprite].clipdist << 3);
+            int ebp = bcos(nAngle) * (sprite[nPlayerSprite].clipdist << 3);
+            int ebx = bsin(nAngle) * (sprite[nPlayerSprite].clipdist << 3);
 
             if (WeaponInfo[nWeapon].c)
             {
@@ -711,8 +711,8 @@ loc_flag:
                     ecx = theVal;
 
                 int var_44 = (nAngle + 512) & kAngleMask;
-                ebp += (Cos(var_44) >> 11) * ecx;
-                ebx += (Sin(var_44) >> 11) * ecx;
+                ebp += bcos(var_44, -11) * ecx;
+                ebx += bsin(var_44, -11) * ecx;
             }
 
             int nHeight = (-GetSpriteHeight(nPlayerSprite)) >> 1;
@@ -867,8 +867,8 @@ loc_flag:
                     BuildSnake(nPlayer, nHeight);
                     nQuake[nPlayer] = 512;
 
-                    nXDamage[nPlayer] -= Sin(sprite[nPlayerSprite].ang + 512) << 9;
-                    nYDamage[nPlayer] -= Sin(sprite[nPlayerSprite].ang) << 9;
+                    nXDamage[nPlayer] -= bcos(sprite[nPlayerSprite].ang, 9);
+                    nYDamage[nPlayer] -= bsin(sprite[nPlayerSprite].ang, 9);
                     break;
                 }
                 case kWeaponRing:

--- a/source/exhumed/src/gun.cpp
+++ b/source/exhumed/src/gun.cpp
@@ -967,7 +967,7 @@ void DrawWeapons(double smooth)
 
         if (var_34 == 1)
         {
-            xOffset = ((FSin(nBobAngle + 512) / 256.) * nVal) / 256.;
+            xOffset = fmulscale8(bcosf(nBobAngle, -8), nVal);
         }
     }
     else

--- a/source/exhumed/src/lavadude.cpp
+++ b/source/exhumed/src/lavadude.cpp
@@ -329,8 +329,8 @@ void FuncLava(int a, int nDamage, int nRun)
 
                         PlotCourseToSprite(nSprite, nTarget);
 
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
 
                         if (nTarget >= 0 && !RandomSize(1))
                         {
@@ -357,8 +357,8 @@ void FuncLava(int a, int nDamage, int nRun)
                         sprite[nSprite].z = z;
 
                         sprite[nSprite].ang = (sprite[nSprite].ang + ((RandomWord() & 0x3FF) + 1024)) & kAngleMask;
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
                         break;
                     }
 
@@ -369,8 +369,8 @@ void FuncLava(int a, int nDamage, int nRun)
                     if ((nVal & 0xC000) == 0x8000)
                     {
                         sprite[nSprite].ang = (sprite[nSprite].ang + ((RandomWord() & 0x3FF) + 1024)) & kAngleMask;
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
                         break;
                     }
                     else if ((nVal & 0xC000) == 0xC000)
@@ -419,7 +419,7 @@ void FuncLava(int a, int nDamage, int nRun)
                         int nHeight = GetSpriteHeight(nSprite);
                         GetUpAngle(nSprite, -64000, nTarget, (-(nHeight >> 1)));
 
-                        BuildBullet(nSprite, 10, Cos(sprite[nSprite].ang) << 8, Sin(sprite[nSprite].ang) << 8, -1, sprite[nSprite].ang, nTarget + 10000, 1);
+                        BuildBullet(nSprite, 10, bcos(sprite[nSprite].ang, 8), bsin(sprite[nSprite].ang, 8), -1, sprite[nSprite].ang, nTarget + 10000, 1);
                     }
                     else if (var_1C)
                     {

--- a/source/exhumed/src/lighting.cpp
+++ b/source/exhumed/src/lighting.cpp
@@ -632,8 +632,8 @@ void AddFlow(int nSprite, int nSpeed, int b)
 
         sFlowInfo[nFlow].field_14 = (tilesiz[nPic].x << 14) - 1;
         sFlowInfo[nFlow].field_18 = (tilesiz[nPic].y << 14) - 1;
-        sFlowInfo[nFlow].field_C  = -Cos(nAngle) * nSpeed;
-        sFlowInfo[nFlow].field_10 = Sin(nAngle) * nSpeed;
+        sFlowInfo[nFlow].field_C  = -bcos(nAngle) * nSpeed;
+        sFlowInfo[nFlow].field_10 = bsin(nAngle) * nSpeed;
     }
     else
     {
@@ -651,8 +651,8 @@ void AddFlow(int nSprite, int nSpeed, int b)
 
         sFlowInfo[nFlow].field_14 = (tilesiz[nPic].x * wall[var_18].xrepeat) << 8;
         sFlowInfo[nFlow].field_18 = (tilesiz[nPic].y * wall[var_18].yrepeat) << 8;
-        sFlowInfo[nFlow].field_C = -Cos(nAngle) * nSpeed;
-        sFlowInfo[nFlow].field_10 = Sin(nAngle) * nSpeed;
+        sFlowInfo[nFlow].field_C = -bcos(nAngle) * nSpeed;
+        sFlowInfo[nFlow].field_10 = bsin(nAngle) * nSpeed;
     }
 
     sFlowInfo[nFlow].field_8 = 0;

--- a/source/exhumed/src/lion.cpp
+++ b/source/exhumed/src/lion.cpp
@@ -282,8 +282,8 @@ void FuncLion(int a, int nDamage, int nRun)
                                 LionList[nLion].nAction = 2;
                                 LionList[nLion].nFrame = 0;
 
-                                sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                                sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                                sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                                sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                                 LionList[nLion].nTarget = nTarget;
                                 return;
                             }
@@ -298,8 +298,8 @@ void FuncLion(int a, int nDamage, int nRun)
                             if (RandomBit())
                             {
                                 sprite[nSprite].ang = RandomWord() & kAngleMask;
-                                sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                                sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                                sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                                sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                             }
                             else
                             {
@@ -324,13 +324,13 @@ void FuncLion(int a, int nDamage, int nRun)
 
                         if (sprite[nSprite].cstat & 0x8000)
                         {
-                            sprite[nSprite].xvel = Cos(nAng) * 2;
-                            sprite[nSprite].yvel = Sin(nAng) * 2;
+                            sprite[nSprite].xvel = bcos(nAng, 1);
+                            sprite[nSprite].yvel = bsin(nAng, 1);
                         }
                         else
                         {
-                            sprite[nSprite].xvel = Cos(nAng) >> 1;
-                            sprite[nSprite].yvel = Sin(nAng) >> 1;
+                            sprite[nSprite].xvel = bcos(nAng, -1);
+                            sprite[nSprite].yvel = bsin(nAng, -1);
                         }
                     }
 
@@ -342,8 +342,8 @@ void FuncLion(int a, int nDamage, int nRun)
                     {
                         // loc_378FA:
                         sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                         break;
                     }
                     else if ((nMov & 0xC000) == 0xC000)
@@ -374,8 +374,8 @@ void FuncLion(int a, int nDamage, int nRun)
                         {
                             // loc_378FA:
                             sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                             break;
                         }
                     }
@@ -446,7 +446,7 @@ void FuncLion(int a, int nDamage, int nRun)
                             vec3_t startPos = { x, y, z };
                             hitdata_t hitData;
 
-                            hitscan(&startPos, sprite[nSprite].sectnum, Cos(nScanAngle), Sin(nScanAngle), 0, &hitData, CLIPMASK1);
+                            hitscan(&startPos, sprite[nSprite].sectnum, bcos(nScanAngle), bsin(nScanAngle), 0, &hitData, CLIPMASK1);
 
                             hitx = hitData.pos.x;
                             hity = hitData.pos.y;
@@ -471,8 +471,8 @@ void FuncLion(int a, int nDamage, int nRun)
                         sprite[nSprite].ang = nAngle;
 
                         LionList[nLion].nAction = 6;
-                        sprite[nSprite].xvel = (Cos(sprite[nSprite].ang)) - (Cos(sprite[nSprite].ang) >> 3);
-                        sprite[nSprite].yvel = (Sin(sprite[nSprite].ang)) - (Sin(sprite[nSprite].ang) >> 3);
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang) - bcos(sprite[nSprite].ang, -3);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang) - bsin(sprite[nSprite].ang, -3);
                         D3PlayFX(StaticSound[kSound24], nSprite);
                     }
 
@@ -510,8 +510,8 @@ void FuncLion(int a, int nDamage, int nRun)
                         {
                             // loc_378FA:
                             sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                             break;
                         }
                     }
@@ -538,8 +538,8 @@ void FuncLion(int a, int nDamage, int nRun)
                         sprite[nSprite].zvel = -1000;
 
                         LionList[nLion].nAction = 6;
-                        sprite[nSprite].xvel = (Cos(sprite[nSprite].ang)) - (Cos(sprite[nSprite].ang) >> 3);
-                        sprite[nSprite].yvel = (Sin(sprite[nSprite].ang)) - (Sin(sprite[nSprite].ang) >> 3);
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang) - bcos(sprite[nSprite].ang, -3);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang) - bsin(sprite[nSprite].ang, -3);
                         D3PlayFX(StaticSound[kSound24], nSprite);
                     }
 

--- a/source/exhumed/src/map.cpp
+++ b/source/exhumed/src/map.cpp
@@ -68,8 +68,9 @@ template<typename T> void GetSpriteExtents(T const* const pSprite, int* top, int
 
 bool GameInterface::DrawAutomapPlayer(int x, int y, int z, int a)
 {
-    int nCos = z * sintable[(0 - a) & 2047];
-    int nSin = z * sintable[(1536 - a) & 2047];
+    // [MR]: Confirm that this is correct as math doesn't match the variable names.
+    int nCos = z * -bsin(a);
+    int nSin = z * -bcos(a);
     int nCos2 = mulscale16(nCos, yxaspect);
     int nSin2 = mulscale16(nSin, yxaspect);
 

--- a/source/exhumed/src/move.cpp
+++ b/source/exhumed/src/move.cpp
@@ -661,8 +661,8 @@ int MoveCreatureWithCaution(int nSprite)
             mychangespritesect(nSprite, nSectorPre);
 
             sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-            sprite[nSprite].xvel = Sin(sprite[nSprite].ang + 512) >> 2;
-            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
             return 0;
         }
     }
@@ -770,13 +770,13 @@ void CheckSectorFloor(short nSector, int z, int *x, int *y)
 
     if (z >= sector[nSector].floorz)
     {
-        *x += (Cos(nAng) << 3) * nSpeed;
-        *y += (sintable[nAng] << 3) * nSpeed; // no anglemask in original code
+        *x += bcos(nAng, 3) * nSpeed;
+        *y += bsin(nAng, 3) * nSpeed;
     }
     else if (nFlag & 0x800)
     {
-        *x += (Cos(nAng) << 4) * nSpeed;
-        *y += (sintable[nAng] << 4) * nSpeed; // no anglemask in original code
+        *x += bcos(nAng, 4) * nSpeed;
+        *y += bsin(nAng, 4) * nSpeed;
     }
 }
 
@@ -891,8 +891,8 @@ void MoveSector(short nSector, int nAngle, int *nXVel, int *nYVel)
     }
     else
     {
-        nXVect = Sin(nAngle + 512) << 6;
-        nYVect = Sin(nAngle) << 6;
+        nXVect = bcos(nAngle, 6);
+        nYVect = bsin(nAngle, 6);
     }
 
     short nBlock = sector[nSector].extra;
@@ -1039,8 +1039,8 @@ void MoveSector(short nSector, int nAngle, int *nXVel, int *nYVel)
                 nSectorB = nNextSector;
 
                 clipmove_old((int32_t*)&x, (int32_t*)&y, (int32_t*)&z, &nSectorB,
-                    -xvect - (Sin(nAngle + 512) * (4 * sprite[i].clipdist)),
-                    -yvect - (Sin(nAngle) * (4 * sprite[i].clipdist)),
+                    -xvect - (bcos(nAngle) * (4 * sprite[i].clipdist)),
+                    -yvect - (bsin(nAngle) * (4 * sprite[i].clipdist)),
                     4 * sprite[i].clipdist, 0, 0, CLIPMASK0);
 
 
@@ -1055,8 +1055,8 @@ void MoveSector(short nSector, int nAngle, int *nXVel, int *nYVel)
                     else
                     {
                         movesprite(i,
-                            (xvect << 14) + Sin(nAngle + 512) * sprite[i].clipdist,
-                            (yvect << 14) + Sin(nAngle) * sprite[i].clipdist,
+                            (xvect << 14) + bcos(nAngle) * sprite[i].clipdist,
+                            (yvect << 14) + bsin(nAngle) * sprite[i].clipdist,
                             0, 0, 0, CLIPMASK0);
                     }
                 }
@@ -1235,10 +1235,10 @@ int AngleChase(int nSprite, int nSprite2, int ebx, int ecx, int push1)
 
     sprite[nSprite].ang = nAngle;
 
-    int eax = klabs(Cos(sprite[nSprite].zvel));
+    int eax = klabs(bcos(sprite[nSprite].zvel));
 
-    int x = ((Cos(nAngle) * ebx) >> 14) * eax;
-    int y = ((Sin(nAngle) * ebx) >> 14) * eax;
+    int x = ((bcos(nAngle) * ebx) >> 14) * eax;
+    int y = ((bsin(nAngle) * ebx) >> 14) * eax;
 
     int xshift = x >> 8;
     int yshift = y >> 8;
@@ -1251,9 +1251,9 @@ int AngleChase(int nSprite, int nSprite2, int ebx, int ecx, int push1)
         sqrtNum = INT_MAX;
     }
 
-    int z = Sin(sprite[nSprite].zvel) * ksqrt(sqrtNum);
+    int z = bsin(sprite[nSprite].zvel) * ksqrt(sqrtNum);
 
-    return movesprite(nSprite, x >> 2, y >> 2, (z >> 13) + (Sin(ecx) >> 5), 0, 0, nClipType);
+    return movesprite(nSprite, x >> 2, y >> 2, (z >> 13) + bsin(ecx, -5), 0, 0, nClipType);
 }
 
 int GetWallNormal(short nWall)
@@ -1279,8 +1279,8 @@ void WheresMyMouth(int nPlayer, int *x, int *y, int *z, short *sectnum)
     *sectnum = sprite[nSprite].sectnum;
 
     clipmove_old((int32_t*)x, (int32_t*)y, (int32_t*)z, sectnum,
-        Cos(sprite[nSprite].ang) << 7,
-        Sin(sprite[nSprite].ang) << 7,
+        bcos(sprite[nSprite].ang, 7),
+        bsin(sprite[nSprite].ang, 7),
         5120, 1280, 1280, CLIPMASK1);
 }
 
@@ -1512,8 +1512,8 @@ void FuncCreatureChunk(int a, int, int nRun)
             int nSqrt = lsqrt(((sprite[nSprite].yvel >> 10) * (sprite[nSprite].yvel >> 10)
                 + (sprite[nSprite].xvel >> 10) * (sprite[nSprite].xvel >> 10)) >> 8);
 
-            sprite[nSprite].xvel = Cos(nAngle) * (nSqrt >> 1);
-            sprite[nSprite].yvel = Sin(nAngle) * (nSqrt >> 1);
+            sprite[nSprite].xvel = bcos(nAngle) * (nSqrt >> 1);
+            sprite[nSprite].yvel = bsin(nAngle) * (nSqrt >> 1);
             return;
         }
     }

--- a/source/exhumed/src/mummy.cpp
+++ b/source/exhumed/src/mummy.cpp
@@ -239,7 +239,7 @@ void FuncMummy(int a, int nDamage, int nRun)
                                 MummyList[nMummy].nAction = 1;
                                 MummyList[nMummy].G = 90;
 
-                                sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
+                                sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
                                 sprite[nSprite].yvel = sintable[sprite[nSprite].ang] >> 2; // NOTE no angle masking in original code
                             }
                         }
@@ -281,8 +281,8 @@ void FuncMummy(int a, int nDamage, int nRun)
                     // loc_2B5A8
                     if (!MummyList[nMummy].B)
                     {
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                     }
 
                     if (sprite[nSprite].xvel || sprite[nSprite].yvel)
@@ -325,8 +325,8 @@ void FuncMummy(int a, int nDamage, int nRun)
                             case 0x8000:
                             {
                                 sprite[nSprite].ang = (sprite[nSprite].ang + ((RandomWord() & 0x3FF) + 1024)) & kAngleMask;
-                                sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-                                sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+                                sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+                                sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
                                 return;
                             }
 

--- a/source/exhumed/src/mummy.cpp
+++ b/source/exhumed/src/mummy.cpp
@@ -240,7 +240,7 @@ void FuncMummy(int a, int nDamage, int nRun)
                                 MummyList[nMummy].G = 90;
 
                                 sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
-                                sprite[nSprite].yvel = sintable[sprite[nSprite].ang] >> 2; // NOTE no angle masking in original code
+                                sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
                             }
                         }
                     }

--- a/source/exhumed/src/object.cpp
+++ b/source/exhumed/src/object.cpp
@@ -1383,13 +1383,13 @@ int BuildSpark(int nSprite, int nVal)
 
         if (nVal)
         {
-            spr->xvel = Cos(nAngle) >> 5;
-            spr->yvel = Sin(nAngle) >> 5;
+            spr->xvel = bcos(nAngle, -5);
+            spr->yvel = bsin(nAngle, -5);
         }
         else
         {
-            spr->xvel = Cos(nAngle) >> 6;
-            spr->yvel = Sin(nAngle) >> 6;
+            spr->xvel = bcos(nAngle, -6);
+            spr->yvel = bsin(nAngle, -6);
         }
 
         spr->zvel = -(RandomSize(4) << 7);
@@ -2173,7 +2173,7 @@ void DoDrips()
     {
         sBob[i].field_2 += 4;
 
-        int edx = Sin(sBob[i].field_2 << 3) >> 4;
+        int edx = bsin(sBob[i].field_2 << 3, -4);
         short nSector = sBob[i].nSector;
 
         if (sBob[i].field_3)
@@ -2426,8 +2426,8 @@ void DoMovingSects()
         // loc_23872:
         int nAngle = GetMyAngle(sTrailPoint[nTrail].x - pBlockInfo->x, sTrailPoint[nTrail].y - pBlockInfo->y);
 
-        int nXVel = (Sin(nAngle + 512) << 4) * sMoveSect[i].field_10;
-        int nYVel = (Sin(nAngle) << 4) * sMoveSect[i].field_10;
+        int nXVel = bcos(nAngle, 4) * sMoveSect[i].field_10;
+        int nYVel = bsin(nAngle, 4) * sMoveSect[i].field_10;
 
         int ebx = (sTrailPoint[nTrail].x - pBlockInfo->x) << 14;
 

--- a/source/exhumed/src/queen.cpp
+++ b/source/exhumed/src/queen.cpp
@@ -966,7 +966,6 @@ __MOVEQS:
 
                                 // DEMO-TODO: in disassembly angle was used without masking and thus causing OOB issue.
                                 // This behavior probably would be needed emulated for demo compatibility
-                                // int dx = sintable[nAngle + 512] << 10;
                                 int dx = bcos(nAngle, 10);
                                 int dy = bsin(nAngle, 10);
                                 int dz = (RandomSize(5) - RandomSize(5)) << 7;

--- a/source/exhumed/src/queen.cpp
+++ b/source/exhumed/src/queen.cpp
@@ -227,16 +227,8 @@ void SetHeadVel(short nSprite)
 {
     short nAngle = sprite[nSprite].ang;
 
-    if (nVelShift >= 0)
-    {
-        sprite[nSprite].xvel = Cos(nAngle) >> (int8_t)(nVelShift);
-        sprite[nSprite].yvel = Sin(nAngle) >> (int8_t)(nVelShift);
-    }
-    else
-    {
-        sprite[nSprite].xvel = Cos(nAngle) << (int8_t)(-nVelShift);
-        sprite[nSprite].yvel = Sin(nAngle) << (int8_t)(-nVelShift);
-    }
+    sprite[nSprite].xvel = bcos(nAngle, nVelShift);
+    sprite[nSprite].yvel = bsin(nAngle, nVelShift);
 }
 
 int QueenAngleChase(short nSprite, short nSprite2, int val1, int val2)
@@ -298,10 +290,10 @@ int QueenAngleChase(short nSprite, short nSprite2, int val1, int val2)
     pSprite->ang = nAngle;
 
     int da = pSprite->zvel;
-    int x = klabs(Cos(da));
+    int x = klabs(bcos(da));
 
-    int v26 = x * ((val1 * Cos(nAngle)) >> 14);
-    int v27 = x * ((val1 * Sin(nAngle)) >> 14);
+    int v26 = x * ((val1 * bcos(nAngle)) >> 14);
+    int v27 = x * ((val1 * bsin(nAngle)) >> 14);
 
     uint32_t xDiff = klabs((int32_t)(v26 >> 8));
     uint32_t yDiff = klabs((int32_t)(v27 >> 8));
@@ -314,9 +306,9 @@ int QueenAngleChase(short nSprite, short nSprite2, int val1, int val2)
         sqrtNum = INT_MAX;
     }
 
-    int nSqrt = ksqrt(sqrtNum) * Sin(da);
+    int nSqrt = ksqrt(sqrtNum) * bsin(da);
 
-    return movesprite(nSprite, v26 >> 2, v27 >> 2, (Sin(bobangle) >> 5) + (nSqrt >> 13), 0, 0, CLIPMASK1);
+    return movesprite(nSprite, v26 >> 2, v27 >> 2, bsin(bobangle, -5) + (nSqrt >> 13), 0, 0, CLIPMASK1);
 }
 
 int DestroyTailPart()
@@ -424,8 +416,8 @@ int BuildQueenEgg(short nQueen, int nVal)
     {
         sprite[nSprite2].xrepeat = 30;
         sprite[nSprite2].yrepeat = 30;
-        sprite[nSprite2].xvel = Cos(sprite[nSprite2].ang);
-        sprite[nSprite2].yvel = Sin(sprite[nSprite2].ang);
+        sprite[nSprite2].xvel = bcos(sprite[nSprite2].ang);
+        sprite[nSprite2].yvel = bsin(sprite[nSprite2].ang);
         sprite[nSprite2].zvel = -6000;
         sprite[nSprite2].cstat = 0;
     }
@@ -567,8 +559,8 @@ void FuncQueenEgg(int a, int nDamage, int nRun)
                         }
 
                         sprite[nSprite].ang = nAngle;
-                        sprite[nSprite].xvel = Cos(nAngle) >> 1;
-                        sprite[nSprite].yvel = Sin(nAngle) >> 1;
+                        sprite[nSprite].xvel = bcos(nAngle, -1);
+                        sprite[nSprite].yvel = bsin(nAngle, -1);
                     }
 
                     break;
@@ -600,8 +592,8 @@ void FuncQueenEgg(int a, int nDamage, int nRun)
                     case 0x8000:
                         sprite[nSprite].ang += (RandomSize(9) + 768);
                         sprite[nSprite].ang &= kAngleMask;
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 3;
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 3;
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -3);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -3);
                         sprite[nSprite].zvel = -RandomSize(5);
                         break;
                     }
@@ -975,8 +967,8 @@ __MOVEQS:
                                 // DEMO-TODO: in disassembly angle was used without masking and thus causing OOB issue.
                                 // This behavior probably would be needed emulated for demo compatibility
                                 // int dx = sintable[nAngle + 512] << 10;
-                                int dx = Cos(nAngle) << 10;
-                                int dy = Sin(nAngle) << 10;
+                                int dx = bcos(nAngle, 10);
+                                int dy = bsin(nAngle, 10);
                                 int dz = (RandomSize(5) - RandomSize(5)) << 7;
 
                                 movesprite(nSprite, dx, dy, dz, 0, 0, CLIPMASK1);
@@ -1167,8 +1159,8 @@ int BuildQueen(int nSprite, int x, int y, int z, int nSector, int nAngle, int nC
 
 void SetQueenSpeed(short nSprite, int nSpeed)
 {
-    sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> (2 - nSpeed);
-    sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> (2 - nSpeed);
+    sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -(2 - nSpeed));
+    sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -(2 - nSpeed));
 }
 
 void FuncQueen(int a, int nDamage, int nRun)

--- a/source/exhumed/src/rat.cpp
+++ b/source/exhumed/src/rat.cpp
@@ -84,8 +84,8 @@ void InitRats()
 
 void SetRatVel(short nSprite)
 {
-    sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-    sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+    sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+    sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
 }
 
 int BuildRat(short nSprite, int x, int y, int z, short nSector, int nAngle)

--- a/source/exhumed/src/rex.cpp
+++ b/source/exhumed/src/rex.cpp
@@ -266,8 +266,8 @@ void FuncRex(int a, int nDamage, int nRun)
                             RexList[nRex].nAction = 1;
                             RexList[nRex].nFrame  = 0;
 
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
 
                             D3PlayFX(StaticSound[kSound48], nSprite);
 
@@ -300,8 +300,8 @@ void FuncRex(int a, int nDamage, int nRun)
                             if (((PlotCourseToSprite(nSprite, nTarget) >> 8) >= 60) || RexList[nRex].field_A > 0)
                             {
                                 int nAngle = sprite[nSprite].ang & 0xFFF8;
-                                sprite[nSprite].xvel = Cos(nAngle) >> 2;
-                                sprite[nSprite].yvel = Sin(nAngle) >> 2;
+                                sprite[nSprite].xvel = bcos(nAngle, -2);
+                                sprite[nSprite].yvel = bsin(nAngle, -2);
                             }
                             else
                             {
@@ -332,8 +332,8 @@ void FuncRex(int a, int nDamage, int nRun)
                         case 0x8000:
                         {
                             sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
                             RexList[nRex].nAction = 1;
                             RexList[nRex].nFrame  = 0;
                             nAction = 1;
@@ -351,8 +351,8 @@ void FuncRex(int a, int nDamage, int nRun)
                     {
                         PlotCourseToSprite(nSprite, nTarget);
 
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
 
                         int nMov = MoveCreatureWithCaution(nSprite);
 
@@ -364,8 +364,8 @@ void FuncRex(int a, int nDamage, int nRun)
                             RexList[nRex].field_A = 60;
 
                             sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 2;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 2;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -2);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -2);
                             RexList[nRex].nAction = 1;
                                 RexList[nRex].nFrame  = 0;
                             nAction = 1;
@@ -384,8 +384,8 @@ void FuncRex(int a, int nDamage, int nRun)
 
                                 runlist_DamageEnemy(nSprite2, nSprite, 15);
 
-                                    int xVel = Cos(nAngle) * 15;
-                                    int yVel = Sin(nAngle) * 15;
+                                    int xVel = bcos(nAngle) * 15;
+                                    int yVel = bsin(nAngle) * 15;
 
                                 if (sprite[nSprite2].statnum == 100)
                                 {

--- a/source/exhumed/src/roach.cpp
+++ b/source/exhumed/src/roach.cpp
@@ -135,8 +135,8 @@ int BuildRoach(int nType, int nSprite, int x, int y, int z, short nSector, int a
 
 void GoRoach(short nSprite)
 {
-    sprite[nSprite].xvel = (Cos(sprite[nSprite].ang) >> 1) - (Cos(sprite[nSprite].ang) >> 3);
-    sprite[nSprite].yvel = (Sin(sprite[nSprite].ang) >> 1) - (Sin(sprite[nSprite].ang) >> 3);
+    sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1) - bcos(sprite[nSprite].ang, -3);
+    sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1) - bsin(sprite[nSprite].ang, -3);
 }
 
 void FuncRoach(int a, int nDamage, int nRun)

--- a/source/exhumed/src/runlist.cpp
+++ b/source/exhumed/src/runlist.cpp
@@ -1582,8 +1582,8 @@ int runlist_CheckRadialDamage(short nSprite)
             {
                 int nAngle = GetMyAngle(x, y);
 
-                sprite[nSprite].xvel += (edi * Cos(nAngle)) >> 3;
-                sprite[nSprite].yvel += (edi * Sin(nAngle)) >> 3;
+                sprite[nSprite].xvel += (edi * bcos(nAngle)) >> 3;
+                sprite[nSprite].yvel += (edi * bsin(nAngle)) >> 3;
                 sprite[nSprite].zvel -= edi * 24;
 
                 if (sprite[nSprite].zvel < -3584) {

--- a/source/exhumed/src/scorp.cpp
+++ b/source/exhumed/src/scorp.cpp
@@ -274,8 +274,8 @@ void FuncScorp(int a, int nDamage, int nRun)
                                 D3PlayFX(StaticSound[kSound41], nSprite);
 
                                 scorpion[nScorp].nFrame = 0;
-                                sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                                sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                                sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                                sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
 
                                 scorpion[nScorp].nAction = 1;
                                 scorpion[nScorp].nTarget = nTarget;
@@ -359,8 +359,8 @@ void FuncScorp(int a, int nDamage, int nRun)
                         {
                             scorpion[nScorp].nAction = 1;
 
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
 
                             scorpion[nScorp].nFrame = 0;
                             return;
@@ -430,8 +430,8 @@ void FuncScorp(int a, int nDamage, int nRun)
 
                         int nVel = RandomSize(5) + 1;
 
-                        sprite[nSpiderSprite].xvel = (Cos(sprite[nSpiderSprite].ang) >> 8) * nVel;
-                        sprite[nSpiderSprite].yvel = (Sin(sprite[nSpiderSprite].ang) >> 8) * nVel;
+                        sprite[nSpiderSprite].xvel = bcos(sprite[nSpiderSprite].ang, -8) * nVel;
+                        sprite[nSpiderSprite].yvel = bsin(sprite[nSpiderSprite].ang, -8) * nVel;
                         sprite[nSpiderSprite].zvel = (-(RandomSize(5) + 3)) << 8;
                     }
 
@@ -464,8 +464,8 @@ FS_Pink_A:
     sprite[nSprite].ang += RandomSize(7) - 63;
     sprite[nSprite].ang &= kAngleMask;
 
-    sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-    sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+    sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+    sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
 
 FS_Pink_B:
     if (scorpion[nScorp].g)

--- a/source/exhumed/src/sequence.cpp
+++ b/source/exhumed/src/sequence.cpp
@@ -379,7 +379,7 @@ void seq_DrawPilotLightSeq(double xOffset, double yOffset)
             double x = ChunkXpos[nFrameBase] + (160 + xOffset);
             double y = ChunkYpos[nFrameBase] + (100 + yOffset);
 
-            hud_drawsprite(x, y, 65536, fmod(-2 * (PlayerList[nLocalPlayer].angle.ang.asbam() / (double)BAMUNIT), kAngleMask + 1), nTile, 0, 0, 1);
+            hud_drawsprite(x, y, 65536, fmod(-2 * PlayerList[nLocalPlayer].angle.ang.asbuildf(), kAngleMask + 1), nTile, 0, 0, 1);
             nFrameBase++;
         }
     }

--- a/source/exhumed/src/set.cpp
+++ b/source/exhumed/src/set.cpp
@@ -196,9 +196,9 @@ void FuncSoul(int a, int, int nRun)
             sprite[nSprite].extra += (nSprite & 0x0F) + 5;
             sprite[nSprite].extra &= kAngleMask;
 
-            int nVel = (Cos(sprite[nSprite].extra) >> 7);
+            int nVel = bcos(sprite[nSprite].extra, -7);
 
-            if (movesprite(nSprite, Cos(sprite[nSprite].ang) * nVel, Sin(sprite[nSprite].ang) * nVel, sprite[nSprite].zvel, 5120, 0, CLIPMASK0) & 0x10000)
+            if (movesprite(nSprite, bcos(sprite[nSprite].ang) * nVel, bsin(sprite[nSprite].ang) * nVel, sprite[nSprite].zvel, 5120, 0, CLIPMASK0) & 0x10000)
             {
                 int nSet = sprite[nSprite].hitag;
                 int nSetSprite = SetList[nSet].nSprite;
@@ -363,8 +363,8 @@ void FuncSet(int a, int nDamage, int nRun)
                             SetList[nSet].nFrame  = 0;
                             SetList[nSet].nTarget = nTarget;
 
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                         }
                     }
 
@@ -457,8 +457,8 @@ void FuncSet(int a, int nDamage, int nRun)
 
                         // loc_338E2
                         int nAngle = sprite[nSprite].ang & 0xFFF8;
-                        sprite[nSprite].xvel = Cos(nAngle) >> 1;
-                        sprite[nSprite].yvel = Sin(nAngle) >> 1;
+                        sprite[nSprite].xvel = bcos(nAngle, -1);
+                        sprite[nSprite].yvel = bsin(nAngle, -1);
 
                         if (SetList[nSet].field_D)
                         {
@@ -488,8 +488,8 @@ void FuncSet(int a, int nDamage, int nRun)
                             }
 
                             sprite[nSprite].ang = (sprite[nSprite].ang + 256) & kAngleMask;
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> 1;
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> 1;
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -1);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -1);
                             break;
                         }
                         else if ((nMov & 0xC000) == 0xC000)
@@ -591,8 +591,8 @@ void FuncSet(int a, int nDamage, int nRun)
                         SetList[nSet].nAction = 8;
                         SetList[nSet].nFrame  = 0;
 
-                        sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                        sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                        sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                        sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
                     }
                     return;
                 }

--- a/source/exhumed/src/snake.cpp
+++ b/source/exhumed/src/snake.cpp
@@ -158,7 +158,7 @@ int BuildSnake(short nPlayer, short zVal)
 
     int nSqrt = ksqrt(sqrtNum);
 
-    if (nSqrt < (sintable[512] >> 4))
+    if (nSqrt < bsin(512, -4))
     {
         BackUpBullet(&hitx, &hity, nAngle);
         nSprite = insertsprite(hitsect, 202);

--- a/source/exhumed/src/snake.cpp
+++ b/source/exhumed/src/snake.cpp
@@ -137,7 +137,7 @@ int BuildSnake(short nPlayer, short zVal)
 
     vec3_t pos = { x, y, z };
     hitdata_t hitData;
-    hitscan(&pos, sprite[nPlayerSprite].sectnum, Cos(nAngle), Sin(nAngle), 0, &hitData, CLIPMASK1);
+    hitscan(&pos, sprite[nPlayerSprite].sectnum, bcos(nAngle), bsin(nAngle), 0, &hitData, CLIPMASK1);
 
     hitx = hitData.pos.x;
     hity = hitData.pos.y;
@@ -333,9 +333,9 @@ void FuncSnake(int a, int, int nRun)
             {
 SEARCH_ENEMY:
                 nMov = movesprite(nSprite,
-                    600 * Cos(sprite[nSprite].ang),
-                    600 * Sin(sprite[nSprite].ang),
-                    Sin(SnakeList[nSnake].sE) >> 5,
+                    600 * bcos(sprite[nSprite].ang),
+                    600 * bsin(sprite[nSprite].ang),
+                    bsin(SnakeList[nSnake].sE, -5),
                     0, 0, CLIPMASK1);
 
                 FindSnakeEnemy(nSnake);
@@ -370,8 +370,8 @@ SEARCH_ENEMY:
             else
             {
                 short nAngle = sprite[nSprite].ang;
-                int var_30 = -(64 * Cos(nAngle));
-                int var_34 = -(64 * Sin(nAngle));
+                int var_30 = -bcos(nAngle, 6);
+                int var_34 = -bsin(nAngle, 6);
 
                 int var_20 = SnakeList[nSnake].sE;
 
@@ -395,9 +395,9 @@ SEARCH_ENEMY:
 
                     mychangespritesect(nSprite2, nSector);
 
-                    int eax = (Sin(var_20) * SnakeList[nSnake].c[i]) >> 9;
+                    int eax = (bsin(var_20) * SnakeList[nSnake].c[i]) >> 9;
 
-                    movesprite(nSprite2, var_30 + var_30 * i + eax * Cos(var_28), var_30 + var_34 * i + eax * Sin(var_28),
+                    movesprite(nSprite2, var_30 + var_30 * i + eax * bcos(var_28), var_30 + var_34 * i + eax * bsin(var_28),
                         -zVal*(i-1), 0, 0, CLIPMASK1);
 
                     var_20 = (var_20 + 128) & kAngleMask;

--- a/source/exhumed/src/sound.cpp
+++ b/source/exhumed/src/sound.cpp
@@ -454,7 +454,7 @@ void EXSoundEngine::CalcPosVel(int type, const void* source, const float pt[3], 
         else if (type == SOURCE_Swirly)
         {
             int which = *(int*)source;
-            float phase = (leveltime << (6 + which)) * (M_PI / 1024);
+            float phase = (leveltime << (6 + which)) * BAngRadian;
             pos->X = fcampos.X + 256 * cos(phase);
             pos->Z = fcampos.Z + 256 * sin(phase);
         }
@@ -517,7 +517,7 @@ void GameInterface::UpdateSounds()
     }
     auto fv = GetSoundPos(&pos);
     SoundListener listener;
-    listener.angle = -(float)ang * pi::pi() / 1024; // Build uses a period of 2048.
+    listener.angle = -ang * BAngRadian; // Build uses a period of 2048.
     listener.velocity.Zero();
     listener.position = GetSoundPos(&pos);
     listener.underwater = false;

--- a/source/exhumed/src/spider.cpp
+++ b/source/exhumed/src/spider.cpp
@@ -192,7 +192,7 @@ void FuncSpider(int a, int nDamage, int nRun)
                                 SpiderList[nSpider].nFrame = 0;
                             SpiderList[nSpider].nTarget = nTarget;
 
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
                             sprite[nSprite].yvel = sintable[sprite[nSprite].ang]; // NOTE - not angle masking here in original code
                             return;
                         }
@@ -243,8 +243,8 @@ void FuncSpider(int a, int nDamage, int nRun)
 
                         if (RandomSize(3))
                         {
-                            sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                            sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                            sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
                         }
                         else
                         {
@@ -350,8 +350,8 @@ void FuncSpider(int a, int nDamage, int nRun)
                 case 0x8000:
                 {
                     sprite[nSprite].ang = (sprite[nSprite].ang + 256) & 0x7EF;
-                    sprite[nSprite].xvel = Cos(sprite[nSprite].ang);
-                    sprite[nSprite].yvel = Sin(sprite[nSprite].ang);
+                    sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
+                    sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
                     return;
                 }
                 case 0xC000:

--- a/source/exhumed/src/spider.cpp
+++ b/source/exhumed/src/spider.cpp
@@ -193,7 +193,7 @@ void FuncSpider(int a, int nDamage, int nRun)
                             SpiderList[nSpider].nTarget = nTarget;
 
                             sprite[nSprite].xvel = bcos(sprite[nSprite].ang);
-                            sprite[nSprite].yvel = sintable[sprite[nSprite].ang]; // NOTE - not angle masking here in original code
+                            sprite[nSprite].yvel = bsin(sprite[nSprite].ang);
                             return;
                         }
                     }

--- a/source/exhumed/src/status.cpp
+++ b/source/exhumed/src/status.cpp
@@ -745,7 +745,7 @@ private:
         {
             int s = -8;
             if (althud_flashing && pp->nHealth > 800)
-                s += (sintable[(leveltime << 7) & 2047] >> 10);
+                s += bsin(leveltime << 7, -10);
             int intens = clamp(255 - 4 * s, 0, 255);
             auto pe = PalEntry(255, intens, intens, intens);
             format.Format("%d", pp->nHealth >> 3);

--- a/source/exhumed/src/view.cpp
+++ b/source/exhumed/src/view.cpp
@@ -170,8 +170,8 @@ static void analyzesprites()
                 int xval = pSprite->x - x;
                 int yval = pSprite->y - y;
 
-                int vcos = Cos(nAngle);
-                int vsin = Sin(nAngle);
+                int vcos = bcos(nAngle);
+                int vsin = bsin(nAngle);
 
 
                 int edx = ((vcos * yval) + (xval * vsin)) >> 14;
@@ -242,7 +242,7 @@ void DrawView(double smoothRatio, bool sceneonly)
 
     fixed_t dang = IntToFixed(1024);
 
-    zbob = Sin(2 * bobangle) >> 3;
+    zbob = bsin(2 * bobangle, -3);
 
     int nPlayerSprite = PlayerList[nLocalPlayer].nSprite;
     int nPlayerOldCstat = sprite[nPlayerSprite].cstat;
@@ -333,8 +333,8 @@ void DrawView(double smoothRatio, bool sceneonly)
     else
     {
         clipmove_old((int32_t*)&playerX, (int32_t*)&playerY, (int32_t*)&playerZ, &nSector,
-            -2000 * Sin(inita + 512),
-            -2000 * Sin(inita),
+            -2000 * bcos(inita),
+            -2000 * bsin(inita),
             4, 0, 0, CLIPMASK1);
 
         pan = q16horiz(0);

--- a/source/exhumed/src/view.cpp
+++ b/source/exhumed/src/view.cpp
@@ -298,7 +298,7 @@ void DrawView(double smoothRatio, bool sceneonly)
             sprite[nDoppleSprite[nLocalPlayer]].cstat |= CSTAT_SPRITE_INVISIBLE;
         }
 
-        renderSetRollAngle(rotscrnang.asbam() / (double)BAMUNIT);
+        renderSetRollAngle(rotscrnang.asbuildf());
     }
 
     nCameraa = nAngle;

--- a/source/exhumed/src/view.cpp
+++ b/source/exhumed/src/view.cpp
@@ -375,7 +375,7 @@ void DrawView(double smoothRatio, bool sceneonly)
         static uint8_t sectorCeilingPal[MAXSECTORS];
         static uint8_t wallPal[MAXWALLS];
         int const viewingRange = viewingrange;
-        int const vr = xs_CRoundToInt(65536.f * tanf(r_fov * (fPI / 360.f)));
+        int const vr = xs_CRoundToInt(65536.f * tanf(r_fov * (pi::pi() / 360.f)));
 
 
         videoSetCorrectedAspect();

--- a/source/exhumed/src/wasp.cpp
+++ b/source/exhumed/src/wasp.cpp
@@ -71,16 +71,8 @@ void InitWasps()
 
 void SetWaspVel(short nSprite)
 {
-    if (nWaspVelShift < 0)
-    {
-        sprite[nSprite].xvel = Cos(sprite[nSprite].ang) << -nWaspVelShift;
-        sprite[nSprite].yvel = Sin(sprite[nSprite].ang) << -nWaspVelShift;
-    }
-    else
-    {
-        sprite[nSprite].xvel = Cos(sprite[nSprite].ang) >> nWaspVelShift;
-        sprite[nSprite].yvel = Sin(sprite[nSprite].ang) >> nWaspVelShift;
-    }
+    sprite[nSprite].xvel = bcos(sprite[nSprite].ang, -nWaspVelShift);
+    sprite[nSprite].yvel = bsin(sprite[nSprite].ang, -nWaspVelShift);
 }
 
 int BuildWasp(short nSprite, int x, int y, int z, short nSector, short nAngle)
@@ -284,7 +276,7 @@ void FuncWasp(int a, int nDamage, int nRun)
 
                 case 0:
                 {
-                    sprite[nSprite].zvel = Sin(WaspList[nWasp].field_E) >> 4;
+                    sprite[nSprite].zvel = bsin(WaspList[nWasp].field_E, -4);
 
                     WaspList[nWasp].field_E += WaspList[nWasp].field_10;
                     WaspList[nWasp].field_E &= kAngleMask;

--- a/source/games/duke/src/actors.cpp
+++ b/source/games/duke/src/actors.cpp
@@ -462,7 +462,7 @@ void moveplayers(void)
 
 				if (p->actorsqu != nullptr)
 				{
-					p->angle.addadjustment(FixedToFloat(getincangleq16(p->angle.ang.asq16(), gethiq16angle(p->actorsqu->s.x - p->posx, p->actorsqu->s.y - p->posy)) >> 2));
+					p->angle.addadjustment(getincanglebam(p->angle.ang, bvectangbam(p->actorsqu->s.x - p->posx, p->actorsqu->s.y - p->posy)) >> 2);
 				}
 
 				if (spri->extra > 0)
@@ -485,7 +485,7 @@ void moveplayers(void)
 
 					if (p->wackedbyactor != nullptr && p->wackedbyactor->s.statnum < MAXSTATUS)
 					{
-						p->angle.addadjustment(FixedToFloat(getincangleq16(p->angle.ang.asq16(), gethiq16angle(p->wackedbyactor->s.x - p->posx, p->wackedbyactor->s.y - p->posy)) >> 1));
+						p->angle.addadjustment(getincanglebam(p->angle.ang, bvectangbam(p->wackedbyactor->s.x - p->posx, p->wackedbyactor->s.y - p->posy)) >> 1);
 					}
 				}
 				spri->ang = p->angle.ang.asbuild();

--- a/source/games/duke/src/actors.cpp
+++ b/source/games/duke/src/actors.cpp
@@ -730,7 +730,8 @@ void movecrane(DDukeActor *actor, int crane)
 				actor->SetActiveCrane(true);
 				ps[p].on_crane = actor;
 				S_PlayActorSound(isRR() ? 390 : DUKE_GRUNT, ps[p].GetActor());
-				ps[p].angle.settarget(spri->ang + 1024);
+				auto ang = ps[p].angle.ang;
+				ps[p].angle.settarget(ang + getincanglebam(ang, buildang(spri->ang + 1024)));
 			}
 			else
 			{

--- a/source/games/duke/src/actors_d.cpp
+++ b/source/games/duke/src/actors_d.cpp
@@ -868,16 +868,12 @@ int ifhitbyweapon_d(DDukeActor *actor)
 					case SEENINE:
 					case OOZFILTER:
 					case EXPLODINGBARREL:
-						ps[p].posxv +=
-							actor->extra*(sintable[(actor->ang+512)&2047]) << 2;
-						ps[p].posyv +=
-							actor->extra*(sintable[actor->ang&2047]) << 2;
+						ps[p].posxv += actor->extra * bcos(actor->ang, 2);
+						ps[p].posyv += actor->extra * bsin(actor->ang, 2);
 						break;
 					default:
-						ps[p].posxv +=
-							actor->extra*(sintable[(actor->ang+512)&2047]) << 1;
-						ps[p].posyv +=
-							actor->extra*(sintable[actor->ang&2047]) << 1;
+						ps[p].posxv += actor->extra * bcos(actor->ang, 1);
+						ps[p].posyv += actor->extra * bsin(actor->ang, 1);
 						break;
 				}
 			}
@@ -1113,8 +1109,8 @@ static void movetripbomb(DDukeActor *actor)
 		s->ang = actor->temp_data[5];
 
 		actor->temp_data[3] = s->x; actor->temp_data[4] = s->y;
-		s->x += sintable[(actor->temp_data[5] + 512) & 2047] >> 9;
-		s->y += sintable[(actor->temp_data[5]) & 2047] >> 9;
+		s->x += bcos(actor->temp_data[5], -9);
+		s->y += bsin(actor->temp_data[5], -9);
 		s->z -= (3 << 8);
 
 		// Laser fix from EDuke32.
@@ -1150,8 +1146,8 @@ static void movetripbomb(DDukeActor *actor)
 				}
 				x -= 1024;
 
-				s->x += sintable[(actor->temp_data[5] + 512) & 2047] >> 4;
-				s->y += sintable[(actor->temp_data[5]) & 2047] >> 4;
+				s->x += bcos(actor->temp_data[5], -4);
+				s->y += bsin(actor->temp_data[5], -4);
 				updatesectorneighbor(s->x, s->y, &curSectNum, 1024, 2048);
 
 				if (curSectNum == -1)
@@ -1183,8 +1179,8 @@ static void movetripbomb(DDukeActor *actor)
 
 
 		actor->temp_data[3] = s->x; actor->temp_data[4] = s->y;
-		s->x += sintable[(actor->temp_data[5] + 512) & 2047] >> 9;
-		s->y += sintable[(actor->temp_data[5]) & 2047] >> 9;
+		s->x += bcos(actor->temp_data[5], -9);
+		s->y += bsin(actor->temp_data[5], -9);
 		s->z -= (3 << 8);
 		setsprite(actor, s->pos);
 
@@ -1805,8 +1801,8 @@ static void weaponcommon_d(DDukeActor* proj)
 
 	Collision coll;
 	movesprite_ex(proj,
-		(k * (sintable[(s->ang + 512) & 2047])) >> 14,
-		(k * (sintable[s->ang & 2047])) >> 14, ll, CLIPMASK1, coll);
+		mulscale14(k, bcos(s->ang)),
+		mulscale14(k, bsin(s->ang)), ll, CLIPMASK1, coll);
 
 	if (s->picnum == RPG && proj->temp_actor != nullptr)
 		if (FindDistance2D(s->x - proj->temp_actor->s.x, s->y - proj->temp_actor->s.y) < 256)
@@ -1840,8 +1836,8 @@ static void weaponcommon_d(DDukeActor* proj)
 		for (k = -3; k < 2; k++)
 		{
 			auto spawned = EGS(s->sectnum,
-				s->x + ((k * sintable[(s->ang + 512) & 2047]) >> 9),
-				s->y + ((k * sintable[s->ang & 2047]) >> 9),
+				s->x + mulscale9(k, bcos(s->ang)),
+				s->y + mulscale9(k, bsin(s->ang)),
 				s->z + ((k * ksgn(s->zvel)) * abs(s->zvel / 24)), FIRELASER, -40 + (k << 2),
 				s->xrepeat, s->yrepeat, 0, 0, 0, proj->GetOwner(), 5);
 
@@ -2504,11 +2500,11 @@ static void greenslime(DDukeActor *actor)
 				t[3] = 1;
 		}
 
-		s->xrepeat = 20 + (sintable[t[1] & 2047] >> 13);
-		s->yrepeat = 15 + (sintable[t[1] & 2047] >> 13);
+		s->xrepeat = 20 + bsin(t[1], -13);
+		s->yrepeat = 15 + bsin(t[1], -13);
 
-		s->x = ps[p].posx + (sintable[(ps[p].angle.ang.asbuild() + 512) & 2047] >> 7);
-		s->y = ps[p].posy + (sintable[ps[p].angle.ang.asbuild() & 2047] >> 7);
+		s->x = ps[p].posx + ps[p].angle.ang.bcos(-7);
+		s->y = ps[p].posy + ps[p].angle.ang.bsin(-7);
 
 		return;
 	}
@@ -2587,8 +2583,8 @@ static void greenslime(DDukeActor *actor)
 		int l = s5->s.ang;
 
 		s->z = s5->s.z;
-		s->x = s5->s.x + (sintable[(l + 512) & 2047] >> 11);
-		s->y = s5->s.y + (sintable[l & 2047] >> 11);
+		s->x = s5->s.x + bcos(l, -11);
+		s->y = s5->s.y + bsin(l, -11);
 
 		s->picnum = GREENSLIME + 2 + (global_random & 1);
 
@@ -2664,15 +2660,15 @@ static void greenslime(DDukeActor *actor)
 		else
 		{
 			if (s->xvel < 32) s->xvel += 4;
-			s->xvel = 64 - (sintable[(t[1] + 512) & 2047] >> 9);
+			s->xvel = 64 - bcos(t[1], -9);
 
 			s->ang += getincangle(s->ang,
 				getangle(ps[p].posx - s->x, ps[p].posy - s->y)) >> 3;
 			// TJR
 		}
 
-		s->xrepeat = 36 + (sintable[(t[1] + 512) & 2047] >> 11);
-		s->yrepeat = 16 + (sintable[t[1] & 2047] >> 13);
+		s->xrepeat = 36 + bcos(t[1], -11);
+		s->yrepeat = 16 + bsin(t[1], -13);
 
 		if (rnd(4) && (sector[sect].ceilingstat & 1) == 0 &&
 			abs(actor->floorz - actor->ceilingz)
@@ -2770,8 +2766,8 @@ static void flamethrowerflame(DDukeActor *actor)
 	}
 
 	Collision coll;
-	movesprite_ex(actor, (xvel * (sintable[(s->ang + 512) & 2047])) >> 14,
-		(xvel * (sintable[s->ang & 2047])) >> 14, s->zvel, CLIPMASK1, coll);
+	movesprite_ex(actor, mulscale14(xvel, bcos(s->ang)),
+		mulscale14(xvel, bsin(s->ang)), s->zvel, CLIPMASK1, coll);
 
 	if (s->sectnum < 0)
 	{
@@ -2894,8 +2890,8 @@ static void heavyhbomb(DDukeActor *actor)
 
 	Collision coll;
 	movesprite_ex(actor,
-		(s->xvel * (sintable[(s->ang + 512) & 2047])) >> 14,
-		(s->xvel * (sintable[s->ang & 2047])) >> 14,
+		mulscale14(s->xvel, bcos(s->ang)),
+		mulscale14(s->xvel, bsin(s->ang)),
 		s->zvel, CLIPMASK0, coll);
 
 	if (sector[s->sectnum].lotag == 1 && s->zvel == 0)
@@ -3752,7 +3748,7 @@ void moveeffectors_d(void)   //STATNUM 3
 
 		case 29:
 			act->s.hitag += 64;
-			l = mulscale12((int)act->s.yvel, sintable[act->s.hitag & 2047]);
+			l = mulscale12(act->s.yvel, bsin(act->s.hitag));
 			sc->floorz = act->s.z + l;
 			break;
 		case 31: // True Drop Floor
@@ -3835,7 +3831,7 @@ void move_d(DDukeActor *actor, int playernum, int xvel)
 	}
 
 	if (a & spin)
-		spr->ang += sintable[((t[0] << 3) & 2047)] >> 6;
+		spr->ang += bsin(t[0] << 3, -6);
 
 	if (a & face_player_slow)
 	{
@@ -3855,7 +3851,7 @@ void move_d(DDukeActor *actor, int playernum, int xvel)
 	if ((a & jumptoplayer) == jumptoplayer)
 	{
 		if (t[0] < 16)
-			spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] >> 5);
+			spr->zvel -= bcos(t[0] << 4, -5);
 	}
 
 	if (a & face_player_smart)
@@ -3995,8 +3991,8 @@ void move_d(DDukeActor *actor, int playernum, int xvel)
 
 		Collision coll;
 		actor->movflag = movesprite_ex(actor,
-			(daxvel * (sintable[(angdif + 512) & 2047])) >> 14,
-			(daxvel * (sintable[angdif & 2047])) >> 14, spr->zvel, CLIPMASK0, coll);
+			mulscale14(daxvel, bcos(angdif)),
+			mulscale14(daxvel, bsin(angdif)), spr->zvel, CLIPMASK0, coll);
 	}
 
 	if (a)

--- a/source/games/duke/src/actors_r.cpp
+++ b/source/games/duke/src/actors_r.cpp
@@ -565,7 +565,7 @@ void movefta_r(void)
 							(isRRRA() && (isIn(s->picnum, COOT, COOTSTAYPUT, BIKER, BIKERB, BIKERBV2, CHEER, CHEERB,
 								CHEERSTAYPUT, MINIONBOAT, HULKBOAT, CHEERBOAT, RABBIT, COOTPLAY, BILLYPLAY, MAKEOUT, MAMA)
 								|| (s->picnum == MINION && s->pal == 8)))
-							 || (sintable[(s->ang + 512) & 2047] * (px - sx) + sintable[s->ang & 2047] * (py - sy) >= 0))
+							 || (bcos(s->ang) * (px - sx) + bsin(s->ang) * (py - sy) >= 0))
 						{
 							int r1 = krand();
 							int r2 = krand();
@@ -708,16 +708,12 @@ int ifhitbyweapon_r(DDukeActor *actor)
 				case EXPLODINGBARREL:
 				case TRIPBOMBSPRITE:
 				case RPG2:
-					ps[p].posxv +=
-						actor->extra * (sintable[(actor->ang + 512) & 2047]) << 2;
-					ps[p].posyv +=
-						actor->extra * (sintable[actor->ang & 2047]) << 2;
+					ps[p].posxv += actor->extra * bcos(actor->ang, 2);
+					ps[p].posyv += actor->extra * bsin(actor->ang, 2);
 					break;
 				default:
-					ps[p].posxv +=
-						actor->extra * (sintable[(actor->ang + 512) & 2047]) << 1;
-					ps[p].posyv +=
-						actor->extra * (sintable[actor->ang & 2047]) << 1;
+					ps[p].posxv += actor->extra * bcos(actor->ang, 1);
+					ps[p].posyv += actor->extra * bsin(actor->ang, 1);
 					break;
 				}
 			}
@@ -1277,8 +1273,8 @@ static bool weaponhitwall(DDukeActor *proj, int wal, const vec3_t& oldpos)
 			}
 			if (s->extra <= 0)
 			{
-				s->x += sintable[(s->ang + 512) & 2047] >> 7;
-				s->y += sintable[s->ang & 2047] >> 7;
+				s->x += bcos(s->ang, -7);
+				s->y += bsin(s->ang, -7);
 				auto Owner = proj->GetOwner();
 				if (!isRRRA() || !Owner || (Owner->s.picnum != CHEER && Owner->s.picnum != CHEERSTAYPUT))
 				{
@@ -1419,8 +1415,8 @@ static void weaponcommon_r(DDukeActor *proj)
 
 	Collision coll;
 	movesprite_ex(proj,
-		(k * (sintable[(s->ang + 512) & 2047])) >> 14,
-		(k * (sintable[s->ang & 2047])) >> 14, ll, CLIPMASK1, coll);
+		mulscale14(k, bcos(s->ang)),
+		mulscale14(k, bsin(s->ang)), ll, CLIPMASK1, coll);
 
 	if ((s->picnum == RPG || (isRRRA() && isIn(s->picnum, RPG2, RRTILE1790))) && proj->temp_actor != nullptr)
 		if (FindDistance2D(s->x - proj->temp_actor->s.x, s->y - proj->temp_actor->s.y) < 256)
@@ -1453,8 +1449,8 @@ static void weaponcommon_r(DDukeActor *proj)
 		for (k = -3; k < 2; k++)
 		{
 			auto x = EGS(s->sectnum,
-				s->x + ((k * sintable[(s->ang + 512) & 2047]) >> 9),
-				s->y + ((k * sintable[s->ang & 2047]) >> 9),
+				s->x + mulscale9(k, bcos(s->ang)),
+				s->y + mulscale9(k, bsin(s->ang)),
 				s->z + ((k * ksgn(s->zvel)) * abs(s->zvel / 24)), FIRELASER, -40 + (k << 2),
 				s->xrepeat, s->yrepeat, 0, 0, 0, proj->GetOwner(), 5);
 
@@ -1928,8 +1924,8 @@ void movetransports_r(void)
 
 							changespritesect(act2, Owner->s.sectnum);
 
-							movesprite_ex(act2, (spr2->xvel * sintable[(spr2->ang + 512) & 2047]) >> 14,
-								(spr2->xvel * sintable[spr2->ang & 2047]) >> 14, 0, CLIPMASK1, coll);
+							movesprite_ex(act2, mulscale14(spr2->xvel, bcos(spr2->ang)),
+								mulscale14(spr2->xvel, bsin(spr2->ang)), 0, CLIPMASK1, coll);
 
 							break;
 						case 161:
@@ -1944,8 +1940,8 @@ void movetransports_r(void)
 
 							changespritesect(act2, Owner->s.sectnum);
 
-							movesprite_ex(act2, (spr2->xvel * sintable[(spr2->ang + 512) & 2047]) >> 14,
-								(spr2->xvel * sintable[spr2->ang & 2047]) >> 14, 0, CLIPMASK1, coll);
+							movesprite_ex(act2, mulscale14(spr2->xvel, bcos(spr2->ang)),
+								mulscale14(spr2->xvel, bsin(spr2->ang)), 0, CLIPMASK1, coll);
 
 							break;
 						}
@@ -2155,8 +2151,8 @@ static void rrra_specialstats()
 				S_PlaySound(183);
 			s->extra--;
 			int j = movesprite_ex(act,
-				(s->hitag * sintable[(s->ang + 512) & 2047]) >> 14,
-				(s->hitag * sintable[s->ang & 2047]) >> 14,
+				mulscale14(s->hitag, bcos(s->ang)),
+				mulscale14(s->hitag, bsin(s->ang)),
 				s->hitag << 1, CLIPMASK0, coll);
 			if (j > 0)
 			{
@@ -2595,8 +2591,8 @@ static void heavyhbomb(DDukeActor *actor)
 
 	Collision coll;
 	movesprite_ex(actor,
-		(s->xvel * (sintable[(s->ang + 512) & 2047])) >> 14,
-		(s->xvel * (sintable[s->ang & 2047])) >> 14,
+		mulscale14(s->xvel, bcos(s->ang)),
+		mulscale14(s->xvel, bsin(s->ang)),
 		s->zvel, CLIPMASK0, coll);
 
 	if (sector[s->sectnum].lotag == 1 && s->zvel == 0)
@@ -2789,8 +2785,8 @@ static int henstand(DDukeActor *actor)
 		makeitfall(actor);
 		Collision coll;
 		movesprite_ex(actor,
-			(sintable[(s->ang + 512) & 2047] * s->xvel) >> 14,
-			(sintable[s->ang & 2047] * s->xvel) >> 14,
+			mulscale14(bcos(s->ang), s->xvel),
+			mulscale14(bsin(s->ang), s->xvel),
 			s->zvel, CLIPMASK0, coll);
 		if (coll.type)
 		{
@@ -2912,8 +2908,8 @@ void moveactors_r(void)
 				if (sector[sect].lotag == 903)
 					makeitfall(act);
 				movesprite_ex(act,
-					(s->xvel*sintable[(s->ang+512)&2047])>>14,
-					(s->xvel*sintable[s->ang&2047])>>14,
+					mulscale14(s->xvel, bcos(s->ang)),
+					mulscale14(s->xvel, bsin(s->ang)),
 					s->zvel,CLIPMASK0, coll);
 				switch (sector[sect].lotag)
 				{
@@ -2953,8 +2949,8 @@ void moveactors_r(void)
 				}
 				makeitfall(act);
 				movesprite_ex(act,
-					(s->xvel*(sintable[(s->ang+512)&2047]))>>14,
-					(s->xvel*(sintable[s->ang&2047]))>>14,
+					mulscale14(s->xvel, bcos(s->ang)),
+					mulscale14(s->xvel, bsin(s->ang)),
 					s->zvel,CLIPMASK0, coll);
 				if (coll.type > kHitSector)
 				{
@@ -2984,8 +2980,8 @@ void moveactors_r(void)
 				}
 				makeitfall(act);
 				movesprite_ex(act,
-					(s->xvel*sintable[(s->ang+512)&2047])>>14,
-					(s->xvel*sintable[s->ang&2047])>>14,
+					mulscale14(s->xvel, bcos(s->ang)),
+					mulscale14(s->xvel, bsin(s->ang)),
 					s->zvel,CLIPMASK0, coll);
 				if (s->z >= sector[sect].floorz - (8<<8))
 				{
@@ -3083,8 +3079,8 @@ void moveactors_r(void)
 					if (s->xvel)
 					{
 						movesprite_ex(act,
-							(s->xvel*sintable[(s->ang+512)&2047])>>14,
-							(s->xvel*sintable[s->ang&2047])>>14,
+							mulscale14(s->xvel, bcos(s->ang)),
+							mulscale14(s->xvel, bsin(s->ang)),
 							s->zvel,CLIPMASK0, coll);
 						s->xvel--;
 					}
@@ -3633,7 +3629,7 @@ void moveeffectors_r(void)   //STATNUM 3
 
 		case 29:
 			act->s.hitag += 64;
-			l = mulscale12((int)act->s.yvel, sintable[act->s.hitag & 2047]);
+			l = mulscale12(act->s.yvel, bsin(act->s.hitag));
 			sc->floorz = act->s.z + l;
 			break;
 
@@ -3734,7 +3730,7 @@ void move_r(DDukeActor *actor, int pnum, int xvel)
 	}
 
 	if (a & spin)
-		spr->ang += sintable[((t[0] << 3) & 2047)] >> 6;
+		spr->ang += bsin(t[0] << 3, -6);
 
 	if (a & face_player_slow)
 	{
@@ -3771,12 +3767,12 @@ void move_r(DDukeActor *actor, int pnum, int xvel)
 			if (spr->picnum == CHEER)
 			{
 				if (t[0] < 16)
-					spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] / 40);
+					spr->zvel -= bcos(t[0] << 4) / 40;
 			}
 			else
 			{
 				if (t[0] < 16)
-					spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] >> 5);
+					spr->zvel -= bcos(t[0] << 4, -5);
 			}
 		}
 		if (a & justjump1)
@@ -3784,12 +3780,12 @@ void move_r(DDukeActor *actor, int pnum, int xvel)
 			if (spr->picnum == RABBIT)
 			{
 				if (t[0] < 8)
-					spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] / 30);
+					spr->zvel -= bcos(t[0] << 4) / 30;
 			}
 			else if (spr->picnum == MAMA)
 			{
 				if (t[0] < 8)
-					spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] / 35);
+					spr->zvel -= bcos(t[0] << 4) / 35;
 			}
 		}
 		if (a & justjump2)
@@ -3797,24 +3793,24 @@ void move_r(DDukeActor *actor, int pnum, int xvel)
 			if (spr->picnum == RABBIT)
 			{
 				if (t[0] < 8)
-					spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] / 24);
+					spr->zvel -= bcos(t[0] << 4) / 24;
 			}
 			else if (spr->picnum == MAMA)
 			{
 				if (t[0] < 8)
-					spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] / 28);
+					spr->zvel -= bcos(t[0] << 4) / 28;
 			}
 		}
 		if (a & windang)
 		{
 			if (t[0] < 8)
-				spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] / 24);
+				spr->zvel -= bcos(t[0] << 4) / 24;
 		}
 	}
 	else if ((a & jumptoplayer) == jumptoplayer)
 	{
 		if (t[0] < 16)
-			spr->zvel -= (sintable[(512 + (t[0] << 4)) & 2047] >> 5);
+			spr->zvel -= bcos(t[0] << 4, -5);
 	}
 
 
@@ -3986,8 +3982,8 @@ void move_r(DDukeActor *actor, int pnum, int xvel)
 
 		Collision coll;
 		actor->movflag = movesprite_ex(actor,
-			(daxvel * (sintable[(angdif + 512) & 2047])) >> 14,
-			(daxvel * (sintable[angdif & 2047])) >> 14, spr->zvel, CLIPMASK0, coll);
+			mulscale14(daxvel, bcos(angdif)),
+			mulscale14(daxvel, bsin(angdif)), spr->zvel, CLIPMASK0, coll);
 	}
 
 	if (a)

--- a/source/games/duke/src/animatesprites_d.cpp
+++ b/source/games/duke/src/animatesprites_d.cpp
@@ -245,8 +245,8 @@ void animatesprites_d(int x, int y, int a, int smoothratio)
 					t->ang = getangle(x - t->x, y - t->y);
 					t->x = Owner->x;
 					t->y = Owner->y;
-					t->x += sintable[(t->ang + 512) & 2047] >> 10;
-					t->y += sintable[t->ang & 2047] >> 10;
+					t->x += bcos(t->ang, -10);
+					t->y += bsin(t->ang, -10);
 				}
 			}
 			break;
@@ -255,7 +255,7 @@ void animatesprites_d(int x, int y, int a, int smoothratio)
 			t->z -= (4 << 8);
 			break;
 		case CRYSTALAMMO:
-			t->shade = (sintable[(ud.levelclock << 4) & 2047] >> 10);
+			t->shade = bsin(ud.levelclock << 4, -10);
 			continue;
 		case VIEWSCREEN:
 		case VIEWSCREEN2:
@@ -615,8 +615,8 @@ void animatesprites_d(int x, int y, int a, int smoothratio)
 								{
 									// Alter the shadow's position so that it appears behind the sprite itself.
 									int look = getangle(shadowspr->x - ps[screenpeek].posx, shadowspr->y - ps[screenpeek].posy);
-									shadowspr->x += sintable[(look + 2560) & 2047] >> 9;
-									shadowspr->y += sintable[(look + 2048) & 2047] >> 9;
+									shadowspr->x += bcos(look, -9);
+									shadowspr->y += bsin(look, -9);
 								}
 							}
 							spritesortcnt++;

--- a/source/games/duke/src/animatesprites_r.cpp
+++ b/source/games/duke/src/animatesprites_r.cpp
@@ -242,8 +242,8 @@ void animatesprites_r(int x, int y, int a, int smoothratio)
 					t->ang = getangle(x - t->x, y - t->y);
 					t->x = Owner->x;
 					t->y = Owner->y;
-					t->x += sintable[(t->ang + 512) & 2047] >> 10;
-					t->y += sintable[t->ang & 2047] >> 10;
+					t->x += bcos(t->ang, -10);
+					t->y += bsin(t->ang, -10);
 				}
 			}
 			break;
@@ -252,7 +252,7 @@ void animatesprites_r(int x, int y, int a, int smoothratio)
 			t->z -= (4 << 8);
 			break;
 		case CRYSTALAMMO:
-			t->shade = (sintable[(ud.levelclock << 4) & 2047] >> 10);
+			t->shade = bsin(ud.levelclock << 4, -10);
 			break;
 		case SHRINKSPARK:
 			if (Owner && (Owner->picnum == CHEER || Owner->picnum == CHEERSTAYPUT) && isRRRA())
@@ -771,8 +771,8 @@ void animatesprites_r(int x, int y, int a, int smoothratio)
 									{
 										// Alter the shadow's position so that it appears behind the sprite itself.
 										int look = getangle(shadowspr->x - ps[screenpeek].posx, shadowspr->y - ps[screenpeek].posy);
-										shadowspr->x += sintable[(look + 2560) & 2047] >> 9;
-										shadowspr->y += sintable[(look + 2048) & 2047] >> 9;
+										shadowspr->x += bcos(look, -9);
+										shadowspr->y += bsin(look, -9);
 									}
 								}
 								spritesortcnt++;

--- a/source/games/duke/src/game_misc.cpp
+++ b/source/games/duke/src/game_misc.cpp
@@ -411,8 +411,8 @@ bool GameInterface::DrawAutomapPlayer(int cposx, int cposy, int czoom, int cang)
 	PalEntry col;
 	spritetype* spr;
 
-	xvect = sintable[(-cang) & 2047] * czoom;
-	yvect = sintable[(1536 - cang) & 2047] * czoom;
+	xvect = -bsin(cang) * czoom;
+	yvect = -bcos(cang) * czoom;
 	xvect2 = mulscale16(xvect, yxaspect);
 	yvect2 = mulscale16(yvect, yxaspect);
 
@@ -444,8 +444,8 @@ bool GameInterface::DrawAutomapPlayer(int cposx, int cposy, int czoom, int cang)
 				x1 = dmulscale16(ox, xvect, -oy, yvect);
 				y1 = dmulscale16(oy, xvect2, ox, yvect2);
 
-				ox = (sintable[(spr->ang + 512) & 2047] >> 7);
-				oy = (sintable[(spr->ang) & 2047] >> 7);
+				ox = bcos(spr->ang, -7);
+				oy = bsin(spr->ang, -7);
 				x2 = dmulscale16(ox, xvect, -oy, yvect);
 				y2 = dmulscale16(oy, xvect, ox, yvect);
 
@@ -470,8 +470,8 @@ bool GameInterface::DrawAutomapPlayer(int cposx, int cposy, int czoom, int cang)
 					if ((spr->cstat & 4) > 0) xoff = -xoff;
 					k = spr->ang;
 					l = spr->xrepeat;
-					dax = sintable[k & 2047] * l;
-					day = sintable[(k + 1536) & 2047] * l;
+					dax = bsin(k) * l;
+					day = -bcos(k) * l;
 					l = tileWidth(tilenum);
 					k = (l >> 1) + xoff;
 					x1 -= mulscale16(dax, k);
@@ -503,8 +503,8 @@ bool GameInterface::DrawAutomapPlayer(int cposx, int cposy, int czoom, int cang)
 				if ((spr->cstat & 8) > 0) yoff = -yoff;
 
 				k = spr->ang;
-				cosang = sintable[(k + 512) & 2047];
-				sinang = sintable[k & 2047];
+				cosang = bcos(k);
+				sinang = bsin(k);
 				xspan = tileWidth(tilenum);
 				xrepeat = spr->xrepeat;
 				yspan = tileHeight(tilenum);

--- a/source/games/duke/src/gameexec.cpp
+++ b/source/games/duke/src/gameexec.cpp
@@ -1975,11 +1975,11 @@ int ParseState::parse(void)
 		break;
 	case concmd_strafeleft:
 		insptr++;
-		movesprite_ex(g_ac, sintable[(g_sp->ang + 1024) & 2047] >> 10, sintable[(g_sp->ang + 512) & 2047] >> 10, g_sp->zvel, CLIPMASK0, coll);
+		movesprite_ex(g_ac, -bsin(g_sp->ang, -10), bcos(g_sp->ang, -10), g_sp->zvel, CLIPMASK0, coll);
 		break;
 	case concmd_straferight:
 		insptr++;
-		movesprite_ex(g_ac, sintable[(g_sp->ang - 0) & 2047] >> 10, sintable[(g_sp->ang - 512) & 2047] >> 10, g_sp->zvel, CLIPMASK0, coll);
+		movesprite_ex(g_ac, bsin(g_sp->ang, -10), -bcos(g_sp->ang, -10), g_sp->zvel, CLIPMASK0, coll);
 		break;
 	case concmd_larrybird:
 		insptr++;
@@ -2451,8 +2451,8 @@ int ParseState::parse(void)
 	case concmd_slapplayer:
 		insptr++;
 		forceplayerangle(g_p);
-		ps[g_p].posxv -= sintable[(ps[g_p].angle.ang.asbuild() + 512) & 2047] << 7;
-		ps[g_p].posyv -= sintable[ps[g_p].angle.ang.asbuild() & 2047] << 7;
+		ps[g_p].posxv -= ps[g_p].angle.ang.bcos(7);
+		ps[g_p].posyv -= ps[g_p].angle.ang.bsin(7);
 		return 0;
 	case concmd_wackplayer:
 		insptr++;
@@ -2460,8 +2460,8 @@ int ParseState::parse(void)
 			forceplayerangle(g_p);
 		else
 		{
-			ps[g_p].posxv -= sintable[(ps[g_p].angle.ang.asbuild() + 512) & 2047] << 10;
-			ps[g_p].posyv -= sintable[ps[g_p].angle.ang.asbuild() & 2047] << 10;
+			ps[g_p].posxv -= ps[g_p].angle.ang.bcos(10);
+			ps[g_p].posyv -= ps[g_p].angle.ang.bsin(10);
 			ps[g_p].jumping_counter = 767;
 			ps[g_p].jumping_toggle = 1;
 		}
@@ -3396,8 +3396,7 @@ int ParseState::parse(void)
 		int lValue;
 		insptr++;
 		i = *(insptr++);	// ID of def
-		lValue = GetGameVarID(*insptr, g_ac, g_p);
-		lValue = sintable[lValue & 2047];
+		lValue = bsin(GetGameVarID(*insptr, g_ac, g_p));
 		SetGameVarID(i, lValue, g_ac, g_p);
 		insptr++;
 		break;

--- a/source/games/duke/src/hudweapon_d.cpp
+++ b/source/games/duke/src/hudweapon_d.cpp
@@ -71,9 +71,9 @@ void displayloogie(short snum)
 	y = (ps[snum].loogcnt << 2);
 	for (i = 0; i < ps[snum].numloogs; i++)
 	{
-		a = abs(calcSinTableValue((ps[snum].loogcnt + i) << 5)) / 32;
+		a = abs(bsinf((ps[snum].loogcnt + i) << 5, -5));
 		z = 4096 + ((ps[snum].loogcnt + i) << 9);
-		x = (-getavel(snum)) + (calcSinTableValue((ps[snum].loogcnt + i) << 6) / 1024.);
+		x = -getavel(snum) + bsinf((ps[snum].loogcnt + i) << 6, -10);
 
 		hud_drawsprite(
 			(ps[snum].loogiex[i] + x), (200 + ps[snum].loogiey[i] - y), z - (i << 8), 256 - a,
@@ -99,12 +99,12 @@ int animatefist(int gs, int snum, double look_anghalf)
 
 	looking_arc = fabs(look_anghalf) / 4.5;
 
-	fistzoom = 65536L - (calcSinTableValue(512 + (fisti << 6)) * 4);
+	fistzoom = 65536L - bcosf(fisti << 6, 2);
 	if (fistzoom > 90612L)
 		fistzoom = 90612L;
 	if (fistzoom < 40920)
 		fistzoom = 40290;
-	fistz = 194 + (calcSinTableValue(((6 + fisti) << 7) & 2047) / 512.);
+	fistz = 194 + bsinf((6 + fisti) << 7, -9);
 
 	if (ps[snum].GetActor()->s.pal == 1)
 		fistpal = 1;
@@ -305,11 +305,11 @@ void displayweapon_d(int snum, double smoothratio)
 	gun_pos = 80 - (opos + fmulscale16(npos - opos, smoothratio));
 
 	weapon_xoffset =  (160)-90;
-	weapon_xoffset -= calcSinTableValue((weapon_sway / 2.) + 512) / (1024. + 512.);
+	weapon_xoffset -= bcosf(weapon_sway * 0.5) * (1. / 1536.);
 	weapon_xoffset -= 58 + p->weapon_ang;
 	if( p->GetActor()->s.xrepeat < 32 )
-		gun_pos -= fabs(calcSinTableValue(weapon_sway * 4.) / 512.);
-	else gun_pos -= fabs(calcSinTableValue(weapon_sway / 2.) / 1024.);
+		gun_pos -= fabs(bsinf(weapon_sway * 4., -9));
+	else gun_pos -= fabs(bsinf(weapon_sway * 0.5, -10));
 
 	gun_pos -= hard_landing * 8.;
 
@@ -369,14 +369,14 @@ void displayweapon_d(int snum, double smoothratio)
 			fistsign += i >> 1;
 		}
 		cw = weapon_xoffset;
-		weapon_xoffset += calcSinTableValue(fistsign) / 1024.;
+		weapon_xoffset += bsinf(fistsign, -10);
 		hud_draw(weapon_xoffset + 250 - look_anghalf,
-			looking_arc + 258 - (fabs(calcSinTableValue(fistsign) / 256.)),
+			looking_arc + 258 - fabs(bsinf(fistsign, -8)),
 			FIST, gs, o);
 		weapon_xoffset = cw;
-		weapon_xoffset -= calcSinTableValue(fistsign) / 1024.;
+		weapon_xoffset -= bsinf(fistsign, -10);
 		hud_draw(weapon_xoffset + 40 - look_anghalf,
-			looking_arc + 200 + (fabs(calcSinTableValue(fistsign) / 256.)),
+			looking_arc + 200 + fabs(bsinf(fistsign, -8)),
 			FIST, gs, o | 4);
 	}
 	else
@@ -460,8 +460,8 @@ void displayweapon_d(int snum, double smoothratio)
 				pal = 1;
 			else pal = sector[p->cursectnum].floorpal;
 
-			weapon_xoffset -= calcSinTableValue(768 + (kickback_pic * 128.)) / 2048.;
-			gun_pos += calcSinTableValue(768 + (kickback_pic * 128.)) / 2048.;
+			weapon_xoffset -= bsinf(768 + (kickback_pic * 128.), -11);
+			gun_pos += bsinf(768 + (kickback_pic * 128.), -11);
 
 			if (*kb > 0)
 			{
@@ -512,7 +512,7 @@ void displayweapon_d(int snum, double smoothratio)
 
 			if (*kb > 0)
 			{
-				gun_pos -= calcSinTableValue(kickback_pic * 128.) / 4096.;
+				gun_pos -= bsinf(kickback_pic * 128., -12);
 			}
 
 			if (*kb > 0 && p->GetActor()->s.pal != 1)
@@ -657,7 +657,7 @@ void displayweapon_d(int snum, double smoothratio)
 				pal = sector[p->cursectnum].floorpal;
 
 			if (*kb > 0)
-				gun_pos -= calcSinTableValue(kickback_pic * 128.) / 4096.;
+				gun_pos -= bsinf(kickback_pic * 128., -12);
 
 			if (*kb > 0 && p->GetActor()->s.pal != 1) weapon_xoffset += 1 - (rand() & 3);
 
@@ -770,7 +770,7 @@ void displayweapon_d(int snum, double smoothratio)
 				pal = sector[p->cursectnum].floorpal;
 
 			if (*kb > 0)
-				gun_pos -= calcSinTableValue(kickback_pic * 128.) / 4096.;
+				gun_pos -= bsinf(kickback_pic * 128., -12);
 
 			if (*kb > 0 && p->GetActor()->s.pal != 1) weapon_xoffset += 1 - (rand() & 3);
 
@@ -1105,7 +1105,7 @@ void displayweapon_d(int snum, double smoothratio)
 
 					hud_drawpal(weapon_xoffset + 184 - look_anghalf,
 						looking_arc + 240 - gun_pos, SHRINKER + 2,
-						16 - xs_CRoundToInt(calcSinTableValue(random_club_frame) / 1024.),
+						16 - xs_CRoundToInt(bsinf(random_club_frame, -10)),
 						o, 0);
 
 					hud_drawpal(weapon_xoffset + 188 - look_anghalf,
@@ -1263,7 +1263,7 @@ void displayweapon_d(int snum, double smoothratio)
 				{
 					hud_drawpal(weapon_xoffset + 184 - look_anghalf,
 						looking_arc + 240 - gun_pos, SHRINKER + 2,
-						16 - xs_CRoundToInt(calcSinTableValue(random_club_frame) / 1024.),
+						16 - xs_CRoundToInt(bsinf(random_club_frame, -10)),
 						o, 2);
 
 					hud_drawpal(weapon_xoffset + 188 - look_anghalf,
@@ -1273,7 +1273,7 @@ void displayweapon_d(int snum, double smoothratio)
 				{
 					hud_drawpal(weapon_xoffset + 184 - look_anghalf,
 						looking_arc + 240 - gun_pos, SHRINKER + 2,
-						16 - xs_CRoundToInt(calcSinTableValue(random_club_frame) / 1024.),
+						16 - xs_CRoundToInt(bsinf(random_club_frame, -10)),
 						o, 0);
 
 					hud_drawpal(weapon_xoffset + 188 - look_anghalf,

--- a/source/games/duke/src/hudweapon_r.cpp
+++ b/source/games/duke/src/hudweapon_r.cpp
@@ -80,7 +80,7 @@ void displaymasks_r(int snum, double smoothratio)
 		// to get the proper clock value with regards to interpolation we have add a smoothratio based offset to the value.
 		double interpclock = ud.levelclock + (TICSPERFRAME/65536.) * smoothratio;
 		int pin = RS_STRETCH;
-		hud_drawsprite((320 - (tilesiz[SCUBAMASK].x >> 1) - 15), (200 - (tilesiz[SCUBAMASK].y >> 1) + (calcSinTableValue(interpclock) / 1024.)), 49152, 0, SCUBAMASK, 0, p, 2 + 16 + pin);
+		hud_drawsprite((320 - (tilesiz[SCUBAMASK].x >> 1) - 15), (200 - (tilesiz[SCUBAMASK].y >> 1) + bsinf(interpclock, -10)), 49152, 0, SCUBAMASK, 0, p, 2 + 16 + pin);
 		hud_drawsprite((320 - tilesiz[SCUBAMASK + 4].x), (200 - tilesiz[SCUBAMASK + 4].y), 65536, 0, SCUBAMASK + 4, 0, p, 2 + 16 + pin);
 		hud_drawsprite(tilesiz[SCUBAMASK + 4].x, (200 - tilesiz[SCUBAMASK + 4].y), 65536, 0, SCUBAMASK + 4, 0, p, 2 + 4 + 16 + pin);
 		hud_drawsprite(35, (-1), 65536, 0, SCUBAMASK + 3, 0, p, 2 + 16 + pin);
@@ -144,11 +144,11 @@ void displayweapon_r(int snum, double smoothratio)
 	gun_pos = 80 - (opos + fmulscale16(npos - opos, smoothratio));
 
 	weapon_xoffset =  (160)-90;
-	weapon_xoffset -= calcSinTableValue((weapon_sway / 2.) + 512) / (1024. + 512.);
+	weapon_xoffset -= bcosf(weapon_sway * 0.5) * (1. / 1536.);
 	weapon_xoffset -= 58 + p->weapon_ang;
-	if( p->GetActor()->s.xrepeat < 8 )
-		gun_pos -= fabs(calcSinTableValue(weapon_sway * 4.) / 512.);
-	else gun_pos -= fabs(calcSinTableValue(weapon_sway / 2.) / 1024.);
+	if( p->GetActor()->s.xrepeat < 32 )
+		gun_pos -= fabs(bsinf(weapon_sway * 4., -9));
+	else gun_pos -= fabs(bsinf(weapon_sway * 0.5, -10));
 
 	gun_pos -= (p->ohard_landing + fmulscale16(p->hard_landing - p->ohard_landing, smoothratio)) * 8.;
 
@@ -311,14 +311,14 @@ void displayweapon_r(int snum, double smoothratio)
 			fistsign += i>>1;
 		}
 		cw = weapon_xoffset;
-		weapon_xoffset += calcSinTableValue(fistsign) / 1024.;
+		weapon_xoffset += bsinf(fistsign, -10);
 		hud_draw(weapon_xoffset+250-look_anghalf,
-			 looking_arc+258-abs(calcSinTableValue(fistsign) / 256.),
+			 looking_arc+258-abs(bsinf(fistsign, -8)),
 			 FIST,gs,o);
 		weapon_xoffset = cw;
-		weapon_xoffset -= calcSinTableValue(fistsign) / 1024.;
+		weapon_xoffset -= bsinf(fistsign, -10);
 		hud_draw(weapon_xoffset+40-look_anghalf,
-			 looking_arc+200+abs(calcSinTableValue(fistsign) / 256.),
+			 looking_arc+200+abs(bsinf(fistsign, -8)),
 			 FIST,gs,o|4);
 	}
 	else
@@ -623,7 +623,7 @@ void displayweapon_r(int snum, double smoothratio)
 		auto displayrifle = [&]
 		{
 			if (*kb > 0)
-				gun_pos -= calcSinTableValue((*kb) << 7) / 4096.;
+				gun_pos -= bsinf((*kb) << 7, -12);
 
 			if (*kb > 0 && p->GetActor()->s.pal != 1) weapon_xoffset += 1 - (rand() & 3);
 

--- a/source/games/duke/src/input.cpp
+++ b/source/games/duke/src/input.cpp
@@ -897,18 +897,12 @@ void GameInterface::GetInput(InputPacket* packet, ControlInfo* const hidInput)
 
 	if (packet)
 	{
-		auto const pPlayer = &ps[myconnectindex];
-		auto const ang = pPlayer->angle.ang.asbuild();
+		auto cos = p->angle.ang.bcos();
+		auto sin = p->angle.ang.bsin();
 
 		*packet = loc;
-		auto fvel = loc.fvel;
-		auto svel = loc.svel;
-		packet->fvel = mulscale9(fvel, sintable[(ang + 2560) & 2047]) +
-			mulscale9(svel, sintable[(ang + 2048) & 2047]) +
-			pPlayer->fric.x;
-		packet->svel = mulscale9(fvel, sintable[(ang + 2048) & 2047]) +
-			mulscale9(svel, sintable[(ang + 1536) & 2047]) +
-			pPlayer->fric.y;
+		packet->fvel = mulscale9(loc.fvel, cos) + mulscale9(loc.svel, sin) + p->fric.x;
+		packet->svel = mulscale9(loc.fvel, sin) - mulscale9(loc.svel, cos) + p->fric.y;
 		loc = {};
 	}
 }

--- a/source/games/duke/src/player.cpp
+++ b/source/games/duke/src/player.cpp
@@ -95,8 +95,8 @@ void calcviewpitch(player_struct *p, double factor)
 	int psectlotag = sector[psect].lotag;
 	if (p->aim_mode == 0 && p->on_ground && psectlotag != ST_2_UNDERWATER && (sector[psect].floorstat & 2))
 	{
-		int x = p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 5);
-		int y = p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 5);
+		int x = p->posx + p->angle.ang.bcos(-5);
+		int y = p->posy + p->angle.ang.bsin(-5);
 		short tempsect = psect;
 		updatesector(x, y, &tempsect);
 
@@ -225,7 +225,7 @@ int hits(DDukeActor* actor)
 	if (sp->picnum == TILE_APLAYER) zoff = (40 << 8);
 	else zoff = 0;
 
-	hitscan(sp->x, sp->y, sp->z - zoff, sp->sectnum, sintable[(sp->ang + 512) & 2047], sintable[sp->ang & 2047], 0, &sect, &hw, &d, &sx, &sy, &sz, CLIPMASK1);
+	hitscan(sp->x, sp->y, sp->z - zoff, sp->sectnum, bcos(sp->ang), bsin(sp->ang), 0, &sect, &hw, &d, &sx, &sy, &sz, CLIPMASK1);
 
 	return (FindDistance2D(sx - sp->x, sy - sp->y));
 }
@@ -247,7 +247,7 @@ int hitasprite(DDukeActor* actor, DDukeActor** hitsp)
 	else if (sp->picnum == TILE_APLAYER) zoff = (39 << 8);
 	else zoff = 0;
 
-	hitscan(sp->x, sp->y, sp->z - zoff, sp->sectnum, sintable[(sp->ang + 512) & 2047], sintable[sp->ang & 2047], 0, &sect, &hw, hitsp, &sx, &sy, &sz, CLIPMASK1);
+	hitscan(sp->x, sp->y, sp->z - zoff, sp->sectnum, bcos(sp->ang), bsin(sp->ang), 0, &sect, &hw, hitsp, &sx, &sy, &sz, CLIPMASK1);
 
 	if (hw >= 0 && (wall[hw].cstat & 16) && badguy(actor))
 		return((1 << 30));
@@ -268,7 +268,7 @@ int hitawall(struct player_struct* p, int* hitw)
 	DDukeActor* d;
 
 	hitscan(p->posx, p->posy, p->posz, p->cursectnum,
-		sintable[(p->angle.ang.asbuild() + 512) & 2047], sintable[p->angle.ang.asbuild() & 2047], 0, &sect, &hitw1, &d, &sx, &sy, &sz, CLIPMASK0);
+		p->angle.ang.bcos(), p->angle.ang.bsin(), 0, &sect, &hitw1, &d, &sx, &sy, &sz, CLIPMASK0);
 	*hitw = hitw1;
 
 	return (FindDistance2D(sx - p->posx, sy - p->posy));
@@ -340,13 +340,13 @@ DDukeActor* aim(DDukeActor* actor, int aang)
 
 	smax = 0x7fffffff;
 
-	dx1 = sintable[(a + 512 - aang) & 2047];
-	dy1 = sintable[(a - aang) & 2047];
-	dx2 = sintable[(a + 512 + aang) & 2047];
-	dy2 = sintable[(a + aang) & 2047];
+	dx1 = bcos(a - aang);
+	dy1 = bsin(a - aang);
+	dx2 = bcos(a + aang);
+	dy2 = bsin(a + aang);
 
-	dx3 = sintable[(a + 512) & 2047];
-	dy3 = sintable[a & 2047];
+	dx3 = bcos(a);
+	dy3 = bsin(a);
 
 	for (k = 0; k < 4; k++)
 	{
@@ -1085,8 +1085,8 @@ void shootbloodsplat(DDukeActor* actor, int p, int sx, int sy, int sz, int sa, i
 
 
 	hitscan(sx, sy, sz, sect,
-		sintable[(sa + 512) & 2047],
-		sintable[sa & 2047], zvel << 6,
+		bcos(sa),
+		bsin(sa), zvel << 6,
 		&hitsect, &hitwall, &d, &hitx, &hity, &hitz, CLIPMASK1);
 
 	// oh my...
@@ -1147,8 +1147,8 @@ bool view(struct player_struct* pp, int* vx, int* vy, int* vz, short* vsectnum, 
 	short bakcstat, hitsect, hitwall, daang;
 	DDukeActor* hitsprt;
 
-	nx = (sintable[(ang + 1536) & 2047] >> 4);
-	ny = (sintable[(ang + 1024) & 2047] >> 4);
+	nx = -bcos(ang, -4);
+	ny = -bsin(ang, -4);
 	nz = q16horiz >> 9;
 
 	sp = &pp->GetActor()->s;
@@ -1174,7 +1174,7 @@ bool view(struct player_struct* pp, int* vx, int* vy, int* vz, short* vsectnum, 
 			daang = getangle(wall[wall[hitwall].point2].x - wall[hitwall].x,
 				wall[wall[hitwall].point2].y - wall[hitwall].y);
 
-			i = nx * sintable[daang] + ny * sintable[(daang + 1536) & 2047];
+			i = nx * bsin(daang) + ny * -bcos(daang);
 			if (abs(nx) > abs(ny)) hx -= mulscale28(nx, i);
 			else hy -= mulscale28(ny, i);
 		}

--- a/source/games/duke/src/player_d.cpp
+++ b/source/games/duke/src/player_d.cpp
@@ -113,8 +113,8 @@ static void shootfireball(DDukeActor *actor, int p, int sx, int sy, int sz, int 
 	else
 	{
 		zvel = -mulscale16(ps[p].horizon.sum().asq16(), 98);
-		sx += sintable[(sa + 860) & 0x7FF] / 448;
-		sy += sintable[(sa + 348) & 0x7FF] / 448;
+		sx += bcos(sa + 348) / 448;
+		sy += bsin(sa + 348) / 448;
 		sz += (3 << 8);
 	}
 
@@ -197,8 +197,8 @@ static void shootflamethrowerflame(DDukeActor* actor, int p, int sx, int sy, int
 		spawned->s.zvel = (short)zvel;
 	}
 
-	spawned->s.x = sx + sintable[(sa + 630) & 0x7FF] / 448;
-	spawned->s.y = sy + sintable[(sa + 112) & 0x7FF] / 448;
+	spawned->s.x = sx + bsin(sa + 630) / 448;
+	spawned->s.y = sy + bsin(sa + 112) / 448;
 	spawned->s.z = sz - 256;
 	spawned->s.sectnum = s->sectnum;
 	spawned->s.cstat = 0x80;
@@ -213,8 +213,8 @@ static void shootflamethrowerflame(DDukeActor* actor, int p, int sx, int sy, int
 	{
 		if (s->picnum == BOSS5)
 		{
-			spawned->s.x -= sintable[sa & 2047] / 56;
-			spawned->s.y -= sintable[(sa + 1024 + 512) & 2047] / 56;
+			spawned->s.x -= bsin(sa) / 56;
+			spawned->s.y += bcos(sa) / 56;
 			spawned->s.xrepeat = 10;
 			spawned->s.yrepeat = 10;
 		}
@@ -251,8 +251,8 @@ static void shootknee(DDukeActor* actor, int p, int sx, int sy, int sz, int sa)
 	}
 
 	hitscan(sx, sy, sz, sect,
-		sintable[(sa + 512) & 2047],
-		sintable[sa & 2047], zvel << 6,
+		bcos(sa),
+		bsin(sa), zvel << 6,
 		&hitsect, &hitwall, &hitsprt, &hitx, &hity, &hitz, CLIPMASK1);
 
 
@@ -404,8 +404,8 @@ static void shootweapon(DDukeActor *actor, int p, int sx, int sy, int sz, int sa
 
 	s->cstat &= ~257;
 	hitscan(sx, sy, sz, sect,
-		sintable[(sa + 512) & 2047],
-		sintable[sa & 2047],
+		bcos(sa),
+		bsin(sa),
 		zvel << 6, &hitsect, &hitwall, &hitact, &hitx, &hity, &hitz, CLIPMASK1);
 	s->cstat |= 257;
 
@@ -728,8 +728,8 @@ static void shootrpg(DDukeActor *actor, int p, int sx, int sy, int sz, int sa, i
 	if (p < 0) aimed = nullptr;
 
 	auto spawned = EGS(sect,
-		sx + (sintable[(348 + sa + 512) & 2047] / 448),
-		sy + (sintable[(sa + 348) & 2047] / 448),
+		sx + (bcos(sa + 348) / 448),
+		sy + (bsin(sa + 348) / 448),
 		sz - (1 << 8), atwith, 0, 14, 14, sa, vel, zvel, actor, 4);
 
 	auto spj = &spawned->s;
@@ -748,8 +748,8 @@ static void shootrpg(DDukeActor *actor, int p, int sx, int sy, int sz, int sa, i
 	{
 		if (s->picnum == BOSS3)
 		{
-			int xoffs = sintable[sa & 2047] >> 6;
-			int yoffs = sintable[(sa + 1024 + 512) & 2047] >> 6;
+			int xoffs = bsin(sa, -6);
+			int yoffs = -bcos(sa, -6);
 			int aoffs = 4;
 
 			if ((krand() & 1) != 0)
@@ -776,8 +776,8 @@ static void shootrpg(DDukeActor *actor, int p, int sx, int sy, int sz, int sa, i
 		}
 		else if (s->picnum == BOSS2)
 		{
-			int xoffs = sintable[sa & 2047] / 56;
-			int yoffs = sintable[(sa + 1024 + 512) & 2047] / 56;
+			int xoffs = bsin(sa) / 56;
+			int yoffs = -bcos(sa) / 56;
 			int aoffs = 8 + (krand() & 255) - 128;
 
 			if (isWorldTour()) { // Twentieth Anniversary World Tour
@@ -791,8 +791,8 @@ static void shootrpg(DDukeActor *actor, int p, int sx, int sy, int sz, int sa, i
 			spj->y -= yoffs;
 			spj->ang -= aoffs;
 
-			spj->x -= sintable[sa & 2047] / 56;
-			spj->y -= sintable[(sa + 1024 + 512) & 2047] / 56;
+			spj->x -= bsin(sa) / 56;
+			spj->y += bcos(sa) / 56;
 			spj->ang -= 8 + (krand() & 255) - 128;
 			spj->xrepeat = 24;
 			spj->yrepeat = 24;
@@ -814,13 +814,13 @@ static void shootrpg(DDukeActor *actor, int p, int sx, int sy, int sz, int sa, i
 
 		if (ps[p].hbomb_hold_delay)
 		{
-			spj->x -= sintable[sa & 2047] / 644;
-			spj->y -= sintable[(sa + 1024 + 512) & 2047] / 644;
+			spj->x -= bsin(sa) / 644;
+			spj->y += bcos(sa) / 644;
 		}
 		else
 		{
-			spj->x += sintable[sa & 2047] >> 8;
-			spj->y += sintable[(sa + 1024 + 512) & 2047] >> 8;
+			spj->x += bsin(sa, -8);
+			spj->y -= bcos(sa, -8);
 		}
 		spj->xrepeat >>= 1;
 		spj->yrepeat >>= 1;
@@ -854,8 +854,8 @@ static void shootlaser(DDukeActor* actor, int p, int sx, int sy, int sz, int sa)
 	else zvel = 0;
 
 	hitscan(sx, sy, sz - ps[p].pyoff, sect,
-		sintable[(sa + 512) & 2047],
-		sintable[sa & 2047],
+		bcos(sa),
+		bsin(sa),
 		zvel << 6, &hitsect, &hitwall, &hitsprt, &hitx, &hity, &hitz, CLIPMASK1);
 
 	j = 0;
@@ -967,7 +967,7 @@ static void shootgrowspark(DDukeActor* actor, int p, int sx, int sy, int sz, int
 	//            RESHOOTGROW:
 
 	s->cstat &= ~257;
-	hitscan(sx, sy, sz, sect, sintable[(sa + 512) & 2047], sintable[sa & 2047],
+	hitscan(sx, sy, sz, sect, bcos(sa), bsin(sa),
 		zvel << 6, &hitsect, &hitwall, &hitsprt, &hitx, &hity, &hitz, CLIPMASK1);
 
 	s->cstat |= 257;
@@ -1044,8 +1044,8 @@ void shoot_d(DDukeActor* actor, int atwith)
 			sz -= (7 << 8);
 			if (badguy(s) && s->picnum != COMMANDER)
 			{
-				sx += (sintable[(sa + 1024 + 96) & 2047] >> 7);
-				sy += (sintable[(sa + 512 + 96) & 2047] >> 7);
+				sx -= bsin(sa + 96, -7);
+				sy += bcos(sa + 96, -7);
 			}
 		}
 	}
@@ -1128,8 +1128,8 @@ void shoot_d(DDukeActor* actor, int atwith)
 		vel = x >> 4;
 
 		EGS(sect,
-			sx + (sintable[(512 + sa + 512) & 2047] >> 8),
-			sy + (sintable[(sa + 512) & 2047] >> 8),
+			sx - bsin(sa, -8),
+			sy + bcos(sa, -8),
 			sz + (6 << 8), atwith, -64, 32, 32, sa, vel, zvel, actor, 1);
 		break;
 	}
@@ -1160,8 +1160,8 @@ void shoot_d(DDukeActor* actor, int atwith)
 		else zvel = 0;
 
 		auto j = EGS(sect,
-			sx + (sintable[(512 + sa + 512) & 2047] >> 12),
-			sy + (sintable[(sa + 512) & 2047] >> 12),
+			sx - bsin(sa, -12),
+			sy + bcos(sa, -12),
 			sz + (2 << 8), SHRINKSPARK, -16, 28, 28, sa, 768, zvel, actor, 4);
 
 		j->s.cstat = 128;
@@ -1659,7 +1659,7 @@ static void operateJetpack(int snum, ESyncBits actions, int psectlotag, int fz, 
 
 	p->pycount += 32;
 	p->pycount &= 2047;
-	p->pyoff = sintable[p->pycount] >> 7;
+	p->pyoff = bsin(p->pycount, -7);
 
 	if (p->jetpack_on && S_CheckActorSoundPlaying(pact, DUKE_SCREAM))
 	{
@@ -1741,7 +1741,7 @@ static void movement(int snum, ESyncBits actions, int psect, int fz, int cz, int
 			i = 34;
 			p->pycount += 32;
 			p->pycount &= 2047;
-			p->pyoff = sintable[p->pycount] >> 6;
+			p->pyoff = bsin(p->pycount, -6);
 		}
 		else i = 12;
 
@@ -1877,7 +1877,7 @@ static void movement(int snum, ESyncBits actions, int psect, int fz, int cz, int
 			}
 			else
 			{
-				p->poszv -= (sintable[(2048 - 128 + p->jumping_counter) & 2047]) / 12;
+				p->poszv -= bsin(128 + p->jumping_counter) / 12;
 				p->jumping_counter += 180;
 				p->on_ground = 0;
 			}
@@ -1918,7 +1918,7 @@ static void underwater(int snum, ESyncBits actions, int psect, int fz, int cz)
 
 	p->pycount += 32;
 	p->pycount &= 2047;
-	p->pyoff = sintable[p->pycount] >> 7;
+	p->pyoff = bsin(p->pycount, -7);
 
 	if (!S_CheckActorSoundPlaying(pact, DUKE_UNDERWATER))
 		S_PlayActorSound(DUKE_UNDERWATER, pact);
@@ -1971,10 +1971,8 @@ static void underwater(int snum, ESyncBits actions, int psect, int fz, int cz)
 	if (p->scuba_on && (krand() & 255) < 8)
 	{
 		auto j = spawn(pact, WATERBUBBLE);
-		j->s.x +=
-			sintable[(p->angle.ang.asbuild() + 512 + 64 - (global_random & 128)) & 2047] >> 6;
-		j->s.y +=
-			sintable[(p->angle.ang.asbuild() + 64 - (global_random & 128)) & 2047] >> 6;
+		j->s.x += bcos(p->angle.ang.asbuild() + 64 - (global_random & 128), -6);
+		j->s.y += bsin(p->angle.ang.asbuild() + 64 - (global_random & 128), -6);
 		j->s.xrepeat = 3;
 		j->s.yrepeat = 2;
 		j->s.z = p->posz + (8 << 8);
@@ -1996,8 +1994,8 @@ int operateTripbomb(int snum)
 	DDukeActor* hitsprt;
 
 	hitscan(p->posx, p->posy, p->posz,
-		p->cursectnum, sintable[(p->angle.ang.asbuild() + 512) & 2047],
-		sintable[p->angle.ang.asbuild() & 2047], -p->horizon.sum().asq16() >> 11,
+		p->cursectnum, p->angle.ang.bcos(),
+		p->angle.ang.bsin(), -p->horizon.sum().asq16() >> 11,
 		&sect, &hw, &hitsprt, &sx, &sy, &sz, CLIPMASK1);
 
 	if (sect < 0 || hitsprt)
@@ -2189,8 +2187,8 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 			}
 
 			auto spawned = EGS(p->cursectnum,
-				p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 6),
-				p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 6),
+				p->posx + p->angle.ang.bcos(-6),
+				p->posy + p->angle.ang.bsin(-6),
 				p->posz, HEAVYHBOMB, -16, 9, 9,
 				p->angle.ang.asbuild(), (k + (p->hbomb_hold_delay << 5)), i, pact, 1);
 
@@ -2789,8 +2787,8 @@ void processinput_d(int snum)
 		else if (badguy(clz.actor) && clz.actor->s.xrepeat > 24 && abs(s->z - clz.actor->s.z) < (84 << 8))
 		{
 			j = getangle(clz.actor->s.x - p->posx, clz.actor->s.y - p->posy);
-			p->posxv -= sintable[(j + 512) & 2047] << 4;
-			p->posyv -= sintable[j & 2047] << 4;
+			p->posxv -= bcos(j, 4);
+			p->posyv -= bsin(j, 4);
 		}
 	}
 
@@ -2938,7 +2936,7 @@ void processinput_d(int snum)
 	{
 		p->crack_time = CRACK_TIME;
 
-		k = sintable[p->bobcounter & 2047] >> 12;
+		k = bsin(p->bobcounter, -12);
 
 		if (truefdist < PHEIGHT + (8 << 8) && (k == 1 || k == 3))
 		{
@@ -3049,8 +3047,7 @@ HORIZONLY:
 			{
 				p->pycount += 52;
 				p->pycount &= 2047;
-				p->pyoff =
-					abs(s->xvel * sintable[p->pycount]) / 1596;
+				p->pyoff = abs(s->xvel * bsin(p->pycount)) / 1596;
 			}
 		}
 		else if (psectlotag != 2 && psectlotag != 1)

--- a/source/games/duke/src/player_r.cpp
+++ b/source/games/duke/src/player_r.cpp
@@ -1749,11 +1749,11 @@ static void onMotorcycle(int snum, ESyncBits &actions)
 	}
 
 	int currSpeed = p->MotoSpeed;
-	short currAngle = p->angle.ang.asbuild(), velAdjustment;
+	short velAdjustment;
 	if (p->MotoSpeed >= 20 && p->on_ground == 1 && (p->vehTurnLeft || p->vehTurnRight))
 	{
 		velAdjustment = p->vehTurnLeft ? -10 : 10;
-		short angAdjustment = velAdjustment < 0 ? 350 : -350;
+		auto angAdjustment = buildang(velAdjustment < 0 ? 350 : -350);
 
 		if (p->moto_on_mud || p->moto_on_oil || !p->NotOnWater)
 		{
@@ -1789,17 +1789,17 @@ static void onMotorcycle(int snum, ESyncBits &actions)
 			}
 		}
 
-		p->posxv += currSpeed * bcos(velAdjustment * -51 + currAngle, 4);
-		p->posyv += currSpeed * bsin(velAdjustment * -51 + currAngle, 4);
-		p->angle.addadjustment(FixedToFloat(getincangleq16(p->angle.ang.asq16(), IntToFixed(currAngle - angAdjustment))));
+		p->posxv += currSpeed * bcos(velAdjustment * -51 + p->angle.ang.asbuild(), 4);
+		p->posyv += currSpeed * bsin(velAdjustment * -51 + p->angle.ang.asbuild(), 4);
+		p->angle.addadjustment(getincanglebam(p->angle.ang, p->angle.ang - angAdjustment));
 	}
 	else if (p->MotoSpeed >= 20 && p->on_ground == 1 && (p->moto_on_mud || p->moto_on_oil))
 	{
 		rng = krand() & 1;
 		velAdjustment = rng == 0 ? -10 : 10;
 		currSpeed = mulscale7(currSpeed, p->moto_on_oil ? 10 : 5);
-		p->posxv += currSpeed * bcos(velAdjustment * -51 + currAngle, 4);
-		p->posyv += currSpeed * bsin(velAdjustment * -51 + currAngle, 4);
+		p->posxv += currSpeed * bcos(velAdjustment * -51 + p->angle.ang.asbuild(), 4);
+		p->posyv += currSpeed * bsin(velAdjustment * -51 + p->angle.ang.asbuild(), 4);
 	}
 
 	p->moto_on_mud = 0;
@@ -2030,9 +2030,8 @@ static void onBoat(int snum, ESyncBits &actions)
 	if (p->MotoSpeed > 0 && p->on_ground == 1 && (p->vehTurnLeft || p->vehTurnRight))
 	{
 		int currSpeed = p->MotoSpeed * 4.;
-		short currAngle = p->angle.ang.asbuild();
 		short velAdjustment = p->vehTurnLeft ? -10 : 10;
-		short angAdjustment = velAdjustment < 0 ? 350 : -350;
+		auto angAdjustment = buildang(velAdjustment < 0 ? 350 : -350);
 
 		if (p->moto_do_bump)
 		{
@@ -2045,9 +2044,9 @@ static void onBoat(int snum, ESyncBits &actions)
 			angAdjustment >>= 6;
 		}
 
-		p->posxv += currSpeed * bcos(velAdjustment * -51 + currAngle, 4);
-		p->posyv += currSpeed * bsin(velAdjustment * -51 + currAngle, 4);
-		p->angle.addadjustment(FixedToFloat(getincangleq16(p->angle.ang.asq16(), IntToFixed(currAngle - angAdjustment))));
+		p->posxv += currSpeed * bcos(velAdjustment * -51 + p->angle.ang.asbuild(), 4);
+		p->posyv += currSpeed * bsin(velAdjustment * -51 + p->angle.ang.asbuild(), 4);
+		p->angle.addadjustment(getincanglebam(p->angle.ang, p->angle.ang - angAdjustment));
 	}
 	if (p->NotOnWater && p->MotoSpeed > 50)
 		p->MotoSpeed -= (p->MotoSpeed / 2.);

--- a/source/games/duke/src/player_r.cpp
+++ b/source/games/duke/src/player_r.cpp
@@ -112,8 +112,8 @@ static void shootmelee(DDukeActor *actor, int p, int sx, int sy, int sz, int sa,
 	}
 
 	hitscan(sx, sy, sz, sect,
-		sintable[(sa + 512) & 2047],
-		sintable[sa & 2047], zvel << 6,
+		bcos(sa),
+		bsin(sa), zvel << 6,
 		&hitsect, &hitwall, &hitsprt, &hitx, &hity, &hitz, CLIPMASK1);
 
 	if (isRRRA() && ((sector[hitsect].lotag == 160 && zvel > 0) || (sector[hitsect].lotag == 161 && zvel < 0))
@@ -137,7 +137,7 @@ static void shootmelee(DDukeActor *actor, int p, int sx, int sy, int sz, int sa,
 				{
 					nz = sector[effector->GetOwner()->s.sectnum].ceilingz;
 				}
-				hitscan(nx, ny, nz, effector->GetOwner()->s.sectnum, sintable[(sa + 512) & 2047], sintable[sa & 2047], zvel << 6,
+				hitscan(nx, ny, nz, effector->GetOwner()->s.sectnum, bcos(sa), bsin(sa), zvel << 6,
 					&hitsect, &hitwall, &hitsprt, &hitx, &hity, &hitz, CLIPMASK1);
 				break;
 			}
@@ -270,7 +270,7 @@ static void shootweapon(DDukeActor* actor, int p, int sx, int sy, int sz, int sa
 	}
 
 	s->cstat &= ~257;
-	hitscan(sx, sy, sz, sect, sintable[(sa + 512) & 2047], sintable[sa & 2047],
+	hitscan(sx, sy, sz, sect, bcos(sa), bsin(sa),
 		zvel << 6, &hitsect, &hitwall, &hitsprt, &hitx, &hity, &hitz, CLIPMASK1);
 
 	if (isRRRA() && (((sector[hitsect].lotag == 160 && zvel > 0) || (sector[hitsect].lotag == 161 && zvel < 0))
@@ -294,7 +294,7 @@ static void shootweapon(DDukeActor* actor, int p, int sx, int sy, int sz, int sa
 				{
 					nz = sector[effector->GetOwner()->s.sectnum].ceilingz;
 				}
-				hitscan(nx, ny, nz, effector->GetOwner()->s.sectnum, sintable[(sa + 512) & 2047], sintable[sa & 2047], zvel << 6,
+				hitscan(nx, ny, nz, effector->GetOwner()->s.sectnum, bcos(sa), bsin(sa), zvel << 6,
 					&hitsect, &hitwall, &hitsprt, &hitx, &hity, &hitz, CLIPMASK1);
 				break;
 			}
@@ -496,8 +496,8 @@ static void shootstuff(DDukeActor* actor, int p, int sx, int sy, int sz, int sa,
 		sz -= (4 << 7);
 		if (s->picnum == 4649)
 		{
-			sx += sintable[(s->ang + 512 + 256) & 2047] >> 6;
-			sy += sintable[(s->ang + 256) & 2047] >> 6;
+			sx += bcos(s->ang + 256, -6);
+			sy += bsin(s->ang + 256, -6);
 			sz += (12 << 8);
 		}
 		if (s->picnum == VIXEN)
@@ -510,18 +510,17 @@ static void shootstuff(DDukeActor* actor, int p, int sx, int sy, int sz, int sa,
 	{
 		auto aimed = aim(actor, AUTO_AIM_ANGLE);
 
+		sx += bcos(s->ang + 160, -7);
+		sy += bsin(s->ang + 160, -7);
+
 		if (aimed)
 		{
-			sx += sintable[(s->ang + 512 + 160) & 2047] >> 7;
-			sy += sintable[(s->ang + 160) & 2047] >> 7;
 			int dal = ((aimed->s.xrepeat * tileHeight(aimed->s.picnum)) << 1) - (12 << 8);
 			zvel = ((aimed->s.z - sz - dal) * vel) / ldist(ps[p].GetActor(), aimed);
 			sa = getangle(aimed->s.x - sx, aimed->s.y - sy);
 		}
 		else
 		{
-			sx += sintable[(s->ang + 512 + 160) & 2047] >> 7;
-			sy += sintable[(s->ang + 160) & 2047] >> 7;
 			zvel = -mulscale16(ps[p].horizon.sum().asq16(), 98);
 		}
 	}
@@ -677,8 +676,8 @@ static void shootrpg(DDukeActor* actor, int p, int sx, int sy, int sz, int sa, i
 	}
 
 	auto spawned = EGS(sect,
-		sx + (sintable[(348 + sa + 512) & 2047] / 448),
-		sy + (sintable[(sa + 348) & 2047] / 448),
+		sx + (bcos(sa + 348) / 448),
+		sy + (bsin(sa + 348) / 448),
 		sz - (1 << 8), atwith, 0, 14, 14, sa, vel, zvel, actor, 4);
 
 	if (isRRRA())
@@ -729,13 +728,13 @@ static void shootrpg(DDukeActor* actor, int p, int sx, int sy, int sz, int sa, i
 
 		if (ps[p].hbomb_hold_delay)
 		{
-			spawned->s.x -= sintable[sa & 2047] / 644;
-			spawned->s.y -= sintable[(sa + 1024 + 512) & 2047] / 644;
+			spawned->s.x -= bsin(sa) / 644;
+			spawned->s.y += bcos(sa) / 644;
 		}
 		else
 		{
-			spawned->s.x += sintable[sa & 2047] >> 8;
-			spawned->s.y += sintable[(sa + 1024 + 512) & 2047] >> 8;
+			spawned->s.x += bsin(sa, -8);
+			spawned->s.y -= bcos(sa, -8);
 		}
 		spawned->s.xrepeat >>= 1;
 		spawned->s.yrepeat >>= 1;
@@ -863,8 +862,8 @@ void shoot_r(DDukeActor* actor, int atwith)
 		sz -= (7 << 8);
 		if (badguy(s))
 		{
-			sx += (sintable[(sa + 1024 + 96) & 2047] >> 7);
-			sy += (sintable[(sa + 512 + 96) & 2047] >> 7);
+			sx -= bsin(sa, -7);
+			sy += bcos(sa, -7);
 		}
 	}
 
@@ -955,13 +954,13 @@ void shoot_r(DDukeActor* actor, int atwith)
 
 		if (atwith == CHEERBOMB)
 			EGS(sect,
-				sx + (sintable[(512 + sa + 512) & 2047] >> 8),
-				sy + (sintable[(sa + 512) & 2047] >> 8),
+				sx - bsin(sa + 512, -8),
+				sy + bcos(sa + 512, -8),
 				sz + (6 << 8), atwith, -64, 16, 16, sa, vel, zvel, actor, 1);
 		else
 			EGS(sect,
-				sx + (sintable[(512 + sa + 512) & 2047] >> 8),
-				sy + (sintable[(sa + 512) & 2047] >> 8),
+				sx - bsin(sa + 512, -8),
+				sy + bcos(sa + 512, -8),
 				sz + (6 << 8), atwith, -64, 32, 32, sa, vel, zvel, actor, 1);
 		break;
 	}
@@ -1295,8 +1294,8 @@ int doincrements_r(struct player_struct* p)
 		{
 			p->noise_radius = 16384;
 			madenoise(screenpeek);
-			p->posxv += sintable[(p->angle.ang.asbuild() + 512) & 2047] << 4;
-			p->posyv += sintable[p->angle.ang.asbuild() & 2047] << 4;
+			p->posxv += p->angle.ang.bcos(4);
+			p->posyv += p->angle.ang.bsin(4);
 		}
 		p->eat -= 4;
 		if (p->eat < 0)
@@ -1790,8 +1789,8 @@ static void onMotorcycle(int snum, ESyncBits &actions)
 			}
 		}
 
-		p->posxv += currSpeed * (sintable[(velAdjustment * -51 + currAngle + 512) & 2047] << 4);
-		p->posyv += currSpeed * (sintable[(velAdjustment * -51 + currAngle) & 2047] << 4);
+		p->posxv += currSpeed * bcos(velAdjustment * -51 + currAngle, 4);
+		p->posyv += currSpeed * bsin(velAdjustment * -51 + currAngle, 4);
 		p->angle.addadjustment(FixedToFloat(getincangleq16(p->angle.ang.asq16(), IntToFixed(currAngle - angAdjustment))));
 	}
 	else if (p->MotoSpeed >= 20 && p->on_ground == 1 && (p->moto_on_mud || p->moto_on_oil))
@@ -1799,8 +1798,8 @@ static void onMotorcycle(int snum, ESyncBits &actions)
 		rng = krand() & 1;
 		velAdjustment = rng == 0 ? -10 : 10;
 		currSpeed = mulscale7(currSpeed, p->moto_on_oil ? 10 : 5);
-		p->posxv += currSpeed * (sintable[(velAdjustment * -51 + currAngle + 512) & 2047] << 4);
-		p->posyv += currSpeed * (sintable[(velAdjustment * -51 + currAngle) & 2047] << 4);
+		p->posxv += currSpeed * bcos(velAdjustment * -51 + currAngle, 4);
+		p->posyv += currSpeed * bsin(velAdjustment * -51 + currAngle, 4);
 	}
 
 	p->moto_on_mud = 0;
@@ -2046,8 +2045,8 @@ static void onBoat(int snum, ESyncBits &actions)
 			angAdjustment >>= 6;
 		}
 
-		p->posxv += currSpeed * (sintable[(velAdjustment * -51 + currAngle + 512) & 2047] << 4);
-		p->posyv += currSpeed * (sintable[(velAdjustment * -51 + currAngle) & 2047] << 4);
+		p->posxv += currSpeed * bcos(velAdjustment * -51 + currAngle, 4);
+		p->posyv += currSpeed * bsin(velAdjustment * -51 + currAngle, 4);
 		p->angle.addadjustment(FixedToFloat(getincangleq16(p->angle.ang.asq16(), IntToFixed(currAngle - angAdjustment))));
 	}
 	if (p->NotOnWater && p->MotoSpeed > 50)
@@ -2083,7 +2082,7 @@ static void movement(int snum, ESyncBits actions, int psect, int fz, int cz, int
 			i = 34;
 			p->pycount += 32;
 			p->pycount &= 2047;
-			p->pyoff = sintable[p->pycount] >> 6;
+			p->pyoff = bsin(p->pycount, -6);
 		}
 		else i = 12;
 
@@ -2262,7 +2261,7 @@ static void movement(int snum, ESyncBits actions, int psect, int fz, int cz, int
 			}
 			else
 			{
-				p->poszv -= (sintable[(2048 - 128 + p->jumping_counter) & 2047]) / 12;
+				p->poszv -= bsin(128 + p->jumping_counter) / 12;
 				p->jumping_counter += 180;
 				p->on_ground = 0;
 			}
@@ -2302,7 +2301,7 @@ static void underwater(int snum, ESyncBits actions, int psect, int fz, int cz)
 
 	p->pycount += 32;
 	p->pycount &= 2047;
-	p->pyoff = sintable[p->pycount] >> 7;
+	p->pyoff = bsin(p->pycount, -7);
 
 	if (!S_CheckActorSoundPlaying(pact, DUKE_UNDERWATER))
 		S_PlayActorSound(DUKE_UNDERWATER, pact);
@@ -2352,8 +2351,8 @@ static void underwater(int snum, ESyncBits actions, int psect, int fz, int cz)
 	if (p->scuba_on && (krand() & 255) < 8)
 	{
 		auto j = spawn(pact, WATERBUBBLE);
-		j->s.x += sintable[(p->angle.ang.asbuild() + 512 + 64 - (global_random & 128) + 128) & 2047] >> 6;
-		j->s.y += sintable[(p->angle.ang.asbuild() + 64 - (global_random & 128) + 128) & 2047] >> 6;
+		j->s.x += bcos(p->angle.ang.asbuild() + 64 - (global_random & 128) + 128, -6);
+		j->s.y += bsin(p->angle.ang.asbuild() + 64 - (global_random & 128) + 128, -6);
 		j->s.xrepeat = 3;
 		j->s.yrepeat = 2;
 		j->s.z = p->posz + (8 << 8);
@@ -2476,8 +2475,8 @@ void onMotorcycleHit(int snum, DDukeActor* victim)
 			if (numplayers == 1)
 			{
 				Collision coll;
-				movesprite_ex(victim, sintable[int(p->TiltStatus * 20 + p->angle.ang.asbuild() + 512) & 2047] >> 8,
-					sintable[int(p->TiltStatus * 20 + p->angle.ang.asbuild()) & 2047] >> 8, s->zvel, CLIPMASK0, coll);
+				movesprite_ex(victim, bcos(p->TiltStatus * 20 + p->angle.ang.asbuild(), -8),
+					bsin(p->TiltStatus * 20 + p->angle.ang.asbuild(), -8), s->zvel, CLIPMASK0, coll);
 			}
 		}
 		else
@@ -2538,8 +2537,8 @@ void onBoatHit(int snum, DDukeActor* victim)
 			if (numplayers == 1)
 			{
 				Collision coll;
-				movesprite_ex(victim, sintable[int(p->TiltStatus * 20 + p->angle.ang.asbuild() + 512) & 2047] >> 9,
-					sintable[int(p->TiltStatus * 20 + p->angle.ang.asbuild()) & 2047] >> 9, s->zvel, CLIPMASK0, coll);
+				movesprite_ex(victim, bcos(p->TiltStatus * 20 + p->angle.ang.asbuild(), -9),
+					bsin(p->TiltStatus * 20 + p->angle.ang.asbuild(), -9), s->zvel, CLIPMASK0, coll);
 			}
 		}
 		else
@@ -2752,8 +2751,8 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 			}
 
 			auto spawned = EGS(p->cursectnum,
-				p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 6),
-				p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 6),
+				p->posx + p->angle.ang.bcos(-6),
+				p->posy + p->angle.ang.bsin(-6),
 				p->posz, HEAVYHBOMB, -16, 9, 9,
 				p->angle.ang.asbuild(), (k + (p->hbomb_hold_delay << 5)) * 2, i, pact, 1);
 
@@ -2804,8 +2803,8 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 			p->visibility = 0;
 			if (psectlotag != 857)
 			{
-				p->posxv -= sintable[(p->angle.ang.asbuild() + 512) & 2047] << 4;
-				p->posyv -= sintable[p->angle.ang.asbuild() & 2047] << 4;
+				p->posxv -= p->angle.ang.bcos(4);
+				p->posyv -= p->angle.ang.bsin(4);
 			}
 		}
 		else if (p->kickback_pic == 2)
@@ -2904,14 +2903,14 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 
 				if (psectlotag != 857)
 				{
-					p->posxv -= sintable[(p->angle.ang.asbuild() + 512) & 2047] << 5;
-					p->posyv -= sintable[p->angle.ang.asbuild() & 2047] << 5;
+					p->posxv -= p->angle.ang.bcos(5);
+					p->posyv -= p->angle.ang.bsin(5);
 				}
 			}
 			else if (psectlotag != 857)
 			{
-				p->posxv -= sintable[(p->angle.ang.asbuild() + 512) & 2047] << 4;
-				p->posyv -= sintable[p->angle.ang.asbuild() & 2047] << 4;
+				p->posxv -= p->angle.ang.bcos(4);
+				p->posyv -= p->angle.ang.bsin(4);
 			}
 		}
 
@@ -2995,8 +2994,8 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 
 				if (psectlotag != 857)
 				{
-					p->posxv -= sintable[(p->angle.ang.asbuild() + 512) & 2047] << 4;
-					p->posyv -= sintable[p->angle.ang.asbuild() & 2047] << 4;
+					p->posxv -= p->angle.ang.bcos(4);
+					p->posyv -= p->angle.ang.bsin(4);
 				}
 				checkavailweapon(p);
 
@@ -3136,8 +3135,8 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 		}
 		else if (p->kickback_pic == 12)
 		{
-			p->posxv -= sintable[(p->angle.ang.asbuild() + 512) & 2047] << 4;
-			p->posyv -= sintable[p->angle.ang.asbuild() & 2047] << 4;
+			p->posxv -= p->angle.ang.bcos(4);
+			p->posyv -= p->angle.ang.bsin(4);
 			p->horizon.addadjustment(20);
 			p->recoil += 20;
 		}
@@ -3162,8 +3161,8 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 			}
 
 			EGS(p->cursectnum,
-				p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 6),
-				p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 6),
+				p->posx + p->angle.ang.bcos(-6),
+				p->posy + p->angle.ang.bsin(-6),
 				p->posz, TRIPBOMBSPRITE, -16, 9, 9,
 				p->angle.ang.asbuild(), k * 2, i, pact, 1);
 		}
@@ -3186,8 +3185,8 @@ static void operateweapon(int snum, ESyncBits actions, int psect)
 		}
 		if (p->kickback_pic < 30)
 		{
-			p->posxv += sintable[(p->angle.ang.asbuild() + 512) & 2047] << 4;
-			p->posyv += sintable[p->angle.ang.asbuild() & 2047] << 4;
+			p->posxv += p->angle.ang.bcos(4);
+			p->posyv += p->angle.ang.bsin(4);
 		}
 		p->kickback_pic++;
 		if (p->kickback_pic > 40)
@@ -3489,8 +3488,8 @@ void processinput_r(int snum)
 		else if (badguy(clz.actor) && clz.actor->s.xrepeat > 24 && abs(s->z - clz.actor->s.z) < (84 << 8))
 		{
 			int j = getangle(clz.actor->s.x - p->posx, clz.actor->s.y - p->posy);
-			p->posxv -= sintable[(j + 512) & 2047] << 4;
-			p->posyv -= sintable[j & 2047] << 4;
+			p->posxv -= bcos(j, 4);
+			p->posyv -= bsin(j, 4);
 		}
 		if (clz.actor->s.picnum == RRTILE3587)
 		{
@@ -3603,10 +3602,7 @@ void processinput_r(int snum)
 	{
 		p->pycount += 32;
 		p->pycount &= 2047;
-		if (p->SeaSick)
-			p->pyoff = sintable[p->pycount] >> 2;
-		else
-			p->pyoff = sintable[p->pycount] >> 7;
+		p->pyoff = bsin(p->pycount, -(p->SeaSick ? 2 : 7));
 	}
 
 	if (psectlotag == ST_2_UNDERWATER)
@@ -3664,7 +3660,7 @@ void processinput_r(int snum)
 	{
 		p->crack_time = CRACK_TIME;
 
-		k = sintable[p->bobcounter & 2047] >> 12;
+		k = bsin(p->bobcounter, -12);
 
 		if (isRRRA() && p->spritebridge == 0 && p->on_ground)
 		{
@@ -3895,7 +3891,7 @@ HORIZONLY:
 				p->pycount += 52;
 				p->pycount &= 2047;
 				p->pyoff =
-					abs(s->xvel * sintable[p->pycount]) / 1596;
+					abs(s->xvel * bsin(p->pycount)) / 1596;
 			}
 		}
 		else if (psectlotag != ST_2_UNDERWATER && psectlotag != 1 && (!isRRRA() || !p->sea_sick_stat))
@@ -4123,13 +4119,13 @@ void OffMotorcycle(struct player_struct *p)
 		p->TurbCount = 0;
 		p->posxv = 0;
 		p->posyv = 0;
-		p->posxv -= sintable[(p->angle.ang.asbuild()+512)&2047]<<7;
-		p->posyv -= sintable[p->angle.ang.asbuild()&2047]<<7;
+		p->posxv -= p->angle.ang.bcos(7);
+		p->posyv -= p->angle.ang.bsin(7);
 		p->moto_underwater = 0;
 		auto spawned = spawn(p->GetActor(), EMPTYBIKE);
 		spawned->s.ang = p->angle.ang.asbuild();
-		spawned->s.xvel += sintable[(p->angle.ang.asbuild()+512)&2047]<<7;
-		spawned->s.yvel += sintable[p->angle.ang.asbuild()&2047]<<7;
+		spawned->s.xvel += p->angle.ang.bcos(7);
+		spawned->s.yvel += p->angle.ang.bsin(7);
 		spawned->saved_ammo = p->ammo_amount[MOTORCYCLE_WEAPON];
 	}
 }
@@ -4187,13 +4183,13 @@ void OffBoat(struct player_struct *p)
 		p->TurbCount = 0;
 		p->posxv = 0;
 		p->posyv = 0;
-		p->posxv -= sintable[(p->angle.ang.asbuild()+512)&2047]<<7;
-		p->posyv -= sintable[p->angle.ang.asbuild()&2047]<<7;
+		p->posxv -= p->angle.ang.bcos(7);
+		p->posyv -= p->angle.ang.bsin(7);
 		p->moto_underwater = 0;
 		auto spawned = spawn(p->GetActor(), EMPTYBOAT);
 		spawned->s.ang = p->angle.ang.asbuild();
-		spawned->s.xvel += sintable[(p->angle.ang.asbuild()+512)&2047]<<7;
-		spawned->s.yvel += sintable[p->angle.ang.asbuild()&2047]<<7;
+		spawned->s.xvel += p->angle.ang.bcos(7);
+		spawned->s.yvel += p->angle.ang.bsin(7);
 		spawned->saved_ammo = p->ammo_amount[BOAT_WEAPON];
 	}
 }

--- a/source/games/duke/src/player_w.cpp
+++ b/source/games/duke/src/player_w.cpp
@@ -342,8 +342,8 @@ void operateweapon_ww(int snum, ESyncBits actions, int psect)
 			}
 
 			auto j = EGS(p->cursectnum,
-				p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 6),
-				p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 6),
+				p->posx + p->angle.ang.bcos(-6),
+				p->posy + p->angle.ang.bsin(-6),
 				p->posz, HEAVYHBOMB, -16, 9, 9,
 				p->angle.ang.asbuild(), (k + (p->hbomb_hold_delay << 5)), i, p->GetActor(), 1);
 

--- a/source/games/duke/src/prediction.cpp
+++ b/source/games/duke/src/prediction.cpp
@@ -148,8 +148,8 @@ void fakedomovethings(void)
 
 		if( p->aim_mode == 0 && myonground && psectlotag != 2 && (sector[psect].floorstat&2) )
 		{
-				x = myx+(sintable[(myang+512)&2047]>>5);
-				y = myy+(sintable[myang&2047]>>5);
+				x = myx + bcos(myang, -5);
+				y = myy + bsin(myang, -5);
 				tempsect = psect;
 				updatesector(x,y,&tempsect);
 				if (tempsect >= 0)
@@ -183,8 +183,8 @@ void fakedomovethings(void)
 				 if(badguy(chz.actor) && chz.actor->s.xrepeat > 24 && klabs(p->GetActor()->s.z- chz.actor->s.z) < (84<<8) )
 				 {
 					j = getangle(chz.actor->s.x-myx, chz.actor->s.y-myy);
-					myxvel -= sintable[(j+512)&2047]<<4;
-					myyvel -= sintable[j&2047]<<4;
+					myxvel -= bcos(j, 4);
+					myyvel -= bsin(j, 4);
 				}
 		}
 
@@ -368,7 +368,7 @@ void fakedomovethings(void)
 									 }
 									 else
 									 {
-											 myzvel -= (sintable[(2048-128+myjumpingcounter)&2047])/12;
+											 myzvel -= bsin(128 + myjumpingcounter) / 12;
 											 myjumpingcounter += 180;
 
 											 myonground = 0;

--- a/source/games/duke/src/render.cpp
+++ b/source/games/duke/src/render.cpp
@@ -546,10 +546,10 @@ void displayrooms(int snum, double smoothratio)
 			cposz = omyz + xs_CRoundToInt(fmulscale16(myz - omyz, smoothratio));
 			if (cl_syncinput)
 			{
-				fixed_t ohorz = (omyhoriz.asq16() + omyhorizoff.asq16());
-				fixed_t horz = (myhoriz.asq16() + myhorizoff.asq16());
+				fixed_t ohorz = (omyhoriz + omyhorizoff).asq16();
+				fixed_t horz = (myhoriz + myhorizoff).asq16();
 				choriz = q16horiz(ohorz + xs_CRoundToInt(fmulscale16(horz - ohorz, smoothratio)));
-				cang = bamang(xs_CRoundToUInt(omyang.asbam() + fmulscale16(myang.asbam() - omyang.asbam(), smoothratio)));
+				cang = bamang(xs_CRoundToUInt(omyang.asbam() + fmulscale16((myang - omyang).asbam(), smoothratio)));
 			}
 			else
 			{
@@ -605,7 +605,7 @@ void displayrooms(int snum, double smoothratio)
 		}
 
 		// do screen rotation.
-		renderSetRollAngle(rotscrnang.asbam() / (double)(BAMUNIT));
+		renderSetRollAngle(rotscrnang.asbuildf());
 
 		cz = p->GetActor()->ceilingz;
 		fz = p->GetActor()->floorz;

--- a/source/games/duke/src/sbar_d.cpp
+++ b/source/games/duke/src/sbar_d.cpp
@@ -137,7 +137,7 @@ public:
 		{
 			int s = -8;
 			if (althud_flashing && p->last_extra > max_player_health)
-				s += (sintable[(I_GetBuildTime() << 5) & 2047] / 768);
+				s += bsin(I_GetBuildTime() << 5) / 768;
 			int intens = clamp(255 - 6 * s, 0, 255);
 			format.Format("%d", p->last_extra);
 			SBar_DrawString(this, numberFont, format, 25, texty, DI_TEXT_ALIGN_LEFT, CR_UNTRANSLATED, intens / 255., 0, 0, 1, 1);

--- a/source/games/duke/src/sbar_r.cpp
+++ b/source/games/duke/src/sbar_r.cpp
@@ -112,7 +112,7 @@ public:
 		{
 			int s = -8;
 			if (althud_flashing && p->last_extra > max_player_health)
-				s += (sintable[(I_GetBuildTime() << 5) & 2047] / 768);
+				s += bsin(I_GetBuildTime() << 5) / 768;
 			int intens = clamp(255 - 6 * s, 0, 255);
 			format.Format("%d", p->last_extra);
 			SBar_DrawString(this, numberFont, format, 26.5, -numberFont->mFont->GetHeight() * scale + 4, DI_TEXT_ALIGN_LEFT, CR_UNTRANSLATED, intens / 255., 0, 0, scale, scale);

--- a/source/games/duke/src/sectors.cpp
+++ b/source/games/duke/src/sectors.cpp
@@ -1255,8 +1255,8 @@ void moveclouds(double smoothratio)
 		cloudclock = myclock + 6;
 
 		// cloudx/y were an array, but all entries were always having the same value so a single pair is enough.
-		cloudx += (sintable[(ps[screenpeek].angle.ang.asbuild() + 512) & 2047] >> 9);
-		cloudy += (sintable[ps[screenpeek].angle.ang.asbuild() & 2047] >> 9);
+		cloudx += ps[screenpeek].angle.ang.bcos(-9);
+		cloudy += ps[screenpeek].angle.ang.bsin(-9);
 		for (int i = 0; i < numclouds; i++)
 		{
 			sector[clouds[i]].ceilingxpanning = cloudx >> 6;

--- a/source/games/duke/src/sectors_d.cpp
+++ b/source/games/duke/src/sectors_d.cpp
@@ -149,8 +149,8 @@ void animatewalls_d(void)
 
 				if (wall[i].cstat & 254)
 				{
-					wall[i].xpanning -= t >> 10; // sintable[(t+512)&2047]>>12;
-					wall[i].ypanning -= t >> 10; // sintable[t&2047]>>12;
+					wall[i].xpanning -= t >> 10; // bcos(t, -12);
+					wall[i].ypanning -= t >> 10; // bsin(t, -12);
 
 					if (wall[i].extra == 1)
 					{
@@ -918,13 +918,13 @@ void checkplayerhurt_d(struct player_struct* p, const Collision& coll)
 		p->hurt_delay = 16;
 		SetPlayerPal(p, PalEntry(32, 32, 0, 0));
 
-		p->posxv = -(sintable[(p->angle.ang.asbuild() + 512) & 2047] << 8);
-		p->posyv = -(sintable[(p->angle.ang.asbuild()) & 2047] << 8);
+		p->posxv = -p->angle.ang.bcos(8);
+		p->posyv = -p->angle.ang.bsin(8);
 		S_PlayActorSound(DUKE_LONGTERM_PAIN, p->GetActor());
 
 		fi.checkhitwall(p->GetActor(), j,
-			p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 9),
-			p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 9),
+			p->posx + p->angle.ang.bcos(-9),
+			p->posy + p->angle.ang.bsin(-9),
 			p->posz, -1);
 
 		break;
@@ -932,8 +932,8 @@ void checkplayerhurt_d(struct player_struct* p, const Collision& coll)
 	case BIGFORCE:
 		p->hurt_delay = 26;
 		fi.checkhitwall(p->GetActor(), j,
-			p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 9),
-			p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 9),
+			p->posx + p->angle.ang.bcos(-9),
+			p->posy + p->angle.ang.bsin(-9),
 			p->posz, -1);
 		break;
 

--- a/source/games/duke/src/sectors_r.cpp
+++ b/source/games/duke/src/sectors_r.cpp
@@ -264,8 +264,8 @@ void animatewalls_r(void)
 
 				if (wall[i].cstat & 254)
 				{
-					wall[i].xpanning -= t >> 10; // sintable[(t+512)&2047]>>12;
-					wall[i].ypanning -= t >> 10; // sintable[t&2047]>>12;
+					wall[i].xpanning -= t >> 10; // bcos(t, -12);
+					wall[i].ypanning -= t >> 10; // bsin(t, -12);
 
 					if (wall[i].extra == 1)
 					{
@@ -1414,8 +1414,8 @@ void checkplayerhurt_r(struct player_struct* p, const Collision &coll)
 	case BIGFORCE:
 		p->hurt_delay = 26;
 		fi.checkhitwall(p->GetActor(), j,
-			p->posx + (sintable[(p->angle.ang.asbuild() + 512) & 2047] >> 9),
-			p->posy + (sintable[p->angle.ang.asbuild() & 2047] >> 9),
+			p->posx + p->angle.ang.bcos(-9),
+			p->posy + p->angle.ang.bsin(-9),
 			p->posz, -1);
 		break;
 

--- a/source/games/duke/src/sounds.cpp
+++ b/source/games/duke/src/sounds.cpp
@@ -390,7 +390,7 @@ void GameInterface::UpdateSounds(void)
 
 	if (c != nullptr)
 	{
-		listener.angle = -(float)ca * pi::pi() / 1024; // Build uses a period of 2048.
+		listener.angle = -ca * BAngRadian; // Build uses a period of 2048.
 		listener.velocity.Zero();
 		listener.position = GetSoundPos(c);
 		listener.underwater = false; 

--- a/source/games/duke/src/spawn.cpp
+++ b/source/games/duke/src/spawn.cpp
@@ -456,8 +456,8 @@ void initshell(DDukeActor* actj, DDukeActor* acti, bool isshell)
 			sp->z = spj->z - PHEIGHT + (3 << 8);
 		}
 
-		sp->x = spj->x + (sintable[(a + 512) & 2047] >> 7);
-		sp->y = spj->y + (sintable[a & 2047] >> 7);
+		sp->x = spj->x + bcos(a, -7);
+		sp->y = spj->y + bsin(a, -7);
 
 		sp->shade = -8;
 

--- a/source/sw/src/actor.cpp
+++ b/source/sw/src/actor.cpp
@@ -304,8 +304,8 @@ DoDebrisCurrent(SPRITEp sp)
 
     //sp->clipdist = (256+128)>>2;
 
-    nx = DIV4(sectu->speed) * (int) sintable[NORM_ANGLE(sectu->ang + 512)] >> 14;
-    ny = DIV4(sectu->speed) * (int) sintable[sectu->ang] >> 14;
+    nx = mulscale14(DIV4(sectu->speed), bcos(sectu->ang));
+    ny = mulscale14(DIV4(sectu->speed), bsin(sectu->ang));
 
     // faster than move_sprite
     //move_missile(sp-sprite, nx, ny, 0, Z(2), Z(0), 0, ACTORMOVETICS);
@@ -316,8 +316,8 @@ DoDebrisCurrent(SPRITEp sp)
     {
         short rang = RANDOM_P2(2048);
 
-        nx = DIV4(sectu->speed) * (int) sintable[NORM_ANGLE(sectu->ang + rang + 512)] >> 14;
-        ny = DIV4(sectu->speed) * (int) sintable[NORM_ANGLE(sectu->ang + rang)] >> 14;
+        nx = mulscale14(DIV4(sectu->speed), bcos(sectu->ang + rang));
+        nx = mulscale14(DIV4(sectu->speed), bsin(sectu->ang + rang));
 
         move_sprite(sp-sprite, nx, ny, 0, u->ceiling_dist, u->floor_dist, 0, ACTORMOVETICS);
     }
@@ -442,10 +442,10 @@ DoActorDebris(short SpriteNum)
         }
         else
         {
-            //nx = sp->xvel * ACTORMOVETICS * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-            //ny = sp->xvel * ACTORMOVETICS * (int) sintable[sp->ang] >> 14;
-            nx = ACTORMOVETICS * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-            ny = ACTORMOVETICS * (int) sintable[sp->ang] >> 14;
+            //nx = sp->xvel * ACTORMOVETICS * bcos(sp->ang) >> 14;
+            //ny = sp->xvel * ACTORMOVETICS * bsin(sp->ang) >> 14;
+            nx = mulscale14(ACTORMOVETICS, bcos(sp->ang));
+            ny = mulscale14(ACTORMOVETICS, bsin(sp->ang));
 
             //sp->clipdist = (256+128)>>2;
 
@@ -458,8 +458,8 @@ DoActorDebris(short SpriteNum)
         if (SectUser[sp->sectnum] && SectUser[sp->sectnum]->depth > 10) // JBF: added null check
         {
             u->WaitTics = (u->WaitTics + (ACTORMOVETICS << 3)) & 1023;
-            //sp->z = Z(2) + u->loz + ((Z(4) * (int) sintable[u->WaitTics]) >> 14);
-            sp->z = u->loz - ((Z(2) * (int) sintable[u->WaitTics]) >> 14);
+            //sp->z = Z(2) + u->loz + ((Z(4) * (int) bsin(u->WaitTics)) >> 14);
+            sp->z = u->loz - mulscale14(Z(2), bsin(u->WaitTics));
         }
     }
     else
@@ -478,8 +478,8 @@ DoFireFly(short SpriteNum)
     USERp u = User[SpriteNum];
     int nx, ny;
 
-    nx = 4 * ACTORMOVETICS * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = 4 * ACTORMOVETICS * (int) sintable[sp->ang] >> 14;
+    nx = 4 * ACTORMOVETICS * bcos(sp->ang) >> 14;
+    ny = 4 * ACTORMOVETICS * bsin(sp->ang) >> 14;
 
     sp->clipdist = 256>>2;
     if (!move_actor(SpriteNum, nx, ny, 0L))
@@ -489,7 +489,7 @@ DoFireFly(short SpriteNum)
 
     u->WaitTics = (u->WaitTics + (ACTORMOVETICS << 1)) & 2047;
 
-    sp->z = u->sz + ((Z(32) * (int) sintable[u->WaitTics]) >> 14);
+    sp->z = u->sz + mulscale14(Z(32), bsin(u->WaitTics));
     return 0;
 }
 
@@ -635,8 +635,8 @@ DoActorSlide(short SpriteNum)
     USERp u = User[SpriteNum];
     int nx, ny;
 
-    nx = u->slide_vel * (int) sintable[NORM_ANGLE(u->slide_ang + 512)] >> 14;
-    ny = u->slide_vel * (int) sintable[u->slide_ang] >> 14;
+    nx = mulscale14(u->slide_vel, bcos(u->slide_ang));
+    ny = mulscale14(u->slide_vel, bsin(u->slide_ang));
 
     if (!move_actor(SpriteNum, nx, ny, 0L))
     {
@@ -853,8 +853,8 @@ DoActorDeathMove(short SpriteNum)
             DoActorFall(SpriteNum);
     }
 
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     sp->clipdist = (128+64)>>2;
     move_actor(SpriteNum, nx, ny, 0);

--- a/source/sw/src/ai.cpp
+++ b/source/sw/src/ai.cpp
@@ -347,8 +347,8 @@ CanHitPlayer(short SpriteNum)
     ang = getangle(hp->x - sp->x, hp->y - sp->y);
 
     // get x,yvect
-    xvect = sintable[NORM_ANGLE(ang + 512)];
-    yvect = sintable[NORM_ANGLE(ang)];
+    xvect = bcos(ang);
+    yvect = bsin(ang);
 
     // get zvect
     zhh = hp->z - DIV2(SPRITEp_SIZE_Z(hp));
@@ -1127,8 +1127,8 @@ DoActorMoveCloser(short SpriteNum)
     SPRITEp sp = User[SpriteNum]->SpriteP;
     int nx, ny;
 
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     // if cannot move the sprite
     if (!move_actor(SpriteNum, nx, ny, 0L))
@@ -1707,8 +1707,8 @@ DoActorMoveJump(short SpriteNum)
 
     // Move while jumping
 
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     move_actor(SpriteNum, nx, ny, 0L);
 
@@ -1753,8 +1753,8 @@ int move_scan(short SpriteNum, short ang, int dist, int *stopx, int *stopy, int 
 
     // do the move
     sp->ang = ang;
-    nx = (dist) * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = (dist) * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(dist, bcos(sp->ang));
+    ny = mulscale14(dist, bsin(sp->ang));
 
     ret = move_sprite(SpriteNum, nx, ny, 0, u->ceiling_dist, u->floor_dist, cliptype, 1);
     // move_sprite DOES do a getzrange point?
@@ -2042,8 +2042,8 @@ DoActorReposition(short SpriteNum)
     SPRITEp sp = User[SpriteNum]->SpriteP;
     int nx, ny;
 
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     // still might hit something and have to handle it.
     if (!move_actor(SpriteNum, nx, ny, 0L))
@@ -2129,8 +2129,8 @@ DoActorReposition(short SpriteNum)
     SPRITEp sp = User[SpriteNum]->SpriteP;
     int nx, ny;
 
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     if (!move_actor(SpriteNum, nx, ny, 0L))
     {

--- a/source/sw/src/bunny.cpp
+++ b/source/sw/src/bunny.cpp
@@ -859,7 +859,7 @@ DoBunnyBeginJumpAttack(short SpriteNum)
 
     tang = getangle(psp->x - sp->x, psp->y - sp->y);
 
-    if (move_sprite(SpriteNum, sintable[NORM_ANGLE(tang+512)] >> 7, sintable[tang] >> 7,
+    if (move_sprite(SpriteNum, bcos(tang, -7), bsin(tang, -7),
                     0L, u->ceiling_dist, u->floor_dist, CLIPMASK_ACTOR, ACTORMOVETICS))
         sp->ang = NORM_ANGLE(sp->ang + 1024) + (RANDOM_NEG(256, 6) >> 6);
     else
@@ -895,8 +895,8 @@ DoBunnyMoveJump(short SpriteNum)
         int nx, ny;
 
         // Move while jumping
-        nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-        ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+        nx = mulscale14(sp->xvel, bcos(sp->ang));
+        ny = mulscale14(sp->xvel, bsin(sp->ang));
 
         move_actor(SpriteNum, nx, ny, 0L);
 

--- a/source/sw/src/coolg.cpp
+++ b/source/sw/src/coolg.cpp
@@ -697,7 +697,7 @@ int DoCoolgMatchPlayerZ(short SpriteNum)
     u->sz = max(u->sz, hiz + u->ceiling_dist);
 
     u->Counter = (u->Counter + (ACTORMOVETICS<<3)) & 2047;
-    sp->z = u->sz + ((COOLG_BOB_AMT * (int)sintable[u->Counter]) >> 14);
+    sp->z = u->sz + mulscale14(COOLG_BOB_AMT, bsin(u->Counter));
 
     bound = u->hiz + u->ceiling_dist + COOLG_BOB_AMT;
     if (sp->z < bound)
@@ -751,8 +751,8 @@ int DoCoolgCircle(short SpriteNum)
 
     sp->ang = NORM_ANGLE(sp->ang + u->Counter2);
 
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     if (!move_actor(SpriteNum, nx, ny, 0L))
     {
@@ -812,8 +812,8 @@ DoCoolgDeath(short SpriteNum)
         DoActorSlide(SpriteNum);
 
     // slide while falling
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     u->ret = move_sprite(SpriteNum, nx, ny, 0L, u->ceiling_dist, u->floor_dist, CLIPMASK_MISSILE, ACTORMOVETICS);
     DoFindGroundPoint(SpriteNum);

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -350,7 +350,7 @@ DoShadows(tspriteptr_t tsp, int viewz, bool mirror)
     else
     {
         int const camang = mirror ? NORM_ANGLE(2048 - Player[screenpeek].siang) : Player[screenpeek].siang;
-        vec2_t const ofs = { sintable[NORM_ANGLE(camang+512)]>>11, sintable[NORM_ANGLE(camang)]>>11};
+        vec2_t const ofs = { bcos(camang, -11), bsin(camang, -11) };
 
         New->x += ofs.x;
         New->y += ofs.y;
@@ -947,8 +947,8 @@ BackView(int *nx, int *ny, int *nz, short *vsect, binangle *nang, fixed_t q16hor
     ang = nang->asbuild() + pp->view_outside_dang;
 
     // Calculate the vector (nx,ny,nz) to shoot backwards
-    vx = (sintable[NORM_ANGLE(ang + 1536)] >> 3);
-    vy = (sintable[NORM_ANGLE(ang + 1024)] >> 3);
+    vx = -bcos(ang, -3);
+    vy = -bsin(ang, -3);
     vz = q16horiz >> 8;
 
     // Player sprite of current view
@@ -986,7 +986,7 @@ BackView(int *nx, int *ny, int *nz, short *vsect, binangle *nang, fixed_t q16hor
             daang = getangle(wall[wall[hitinfo.wall].point2].x - wall[hitinfo.wall].x,
                              wall[wall[hitinfo.wall].point2].y - wall[hitinfo.wall].y);
 
-            i = vx * sintable[daang] + vy * sintable[NORM_ANGLE(daang + 1536)];
+            i = vx * bsin(daang) + vy * -bcos(daang);
             if (klabs(vx) > klabs(vy))
                 hx -= mulscale28(vx, i);
             else
@@ -1021,7 +1021,7 @@ BackView(int *nx, int *ny, int *nz, short *vsect, binangle *nang, fixed_t q16hor
                 // same as wall calculation
                 daang = NORM_ANGLE(sp->ang-512);
 
-                i = vx * sintable[daang] + vy * sintable[NORM_ANGLE(daang + 1536)];
+                i = vx * bsin(daang) + vy * -bcos(daang);
                 if (klabs(vx) > klabs(vy))
                     hx -= mulscale28(vx, i);
                 else
@@ -1071,8 +1071,8 @@ CircleCamera(int *nx, int *ny, int *nz, short *vsect, binangle *nang, fixed_t q1
     ang = *nang + buildang(pp->circle_camera_ang);
 
     // Calculate the vector (nx,ny,nz) to shoot backwards
-    vx = (sintable[NORM_ANGLE(ang.asbuild() + 1536)] >> 4);
-    vy = (sintable[NORM_ANGLE(ang.asbuild() + 1024)] >> 4);
+    vx = -ang.bcos(-4);
+    vy = -ang.bsin(-4);
 
     // lengthen the vector some
     vx += DIV2(vx);
@@ -1108,7 +1108,7 @@ CircleCamera(int *nx, int *ny, int *nz, short *vsect, binangle *nang, fixed_t q1
             daang = getangle(wall[wall[hitinfo.wall].point2].x - wall[hitinfo.wall].x,
                              wall[wall[hitinfo.wall].point2].y - wall[hitinfo.wall].y);
 
-            i = vx * sintable[daang] + vy * sintable[NORM_ANGLE(daang + 1536)];
+            i = vx * bsin(daang) + vy * -bcos(daang);
             if (klabs(vx) > klabs(vy))
                 hx -= mulscale28(vx, i);
             else
@@ -1315,8 +1315,8 @@ void CameraView(PLAYERp pp, int *tx, int *ty, int *tz, short *tsectnum, binangle
 
                     pp->last_camera_sp = sp;
 
-                    xvect = sintable[NORM_ANGLE(ang.asbuild() + 512)] >> 3;
-                    yvect = sintable[NORM_ANGLE(ang.asbuild())] >> 3;
+                    xvect = ang.bcos(-3);
+                    yvect = ang.bsin(-3);
 
                     zdiff = sp->z - *tz;
                     if (labs(sp->x - *tx) > 1000)
@@ -1893,8 +1893,8 @@ bool GameInterface::DrawAutomapPlayer(int cposx, int cposy, int czoom, int cang)
     bool sprisplayer = false;
     short txt_x, txt_y;
 
-    xvect = sintable[(2048 - cang) & 2047] * czoom;
-    yvect = sintable[(1536 - cang) & 2047] * czoom;
+    xvect = -bsin(cang) * czoom;
+    yvect = -bcos(cang) * czoom;
     xvect2 = mulscale16(xvect, yxaspect);
     yvect2 = mulscale16(yvect, yxaspect);
 
@@ -1984,8 +1984,8 @@ bool GameInterface::DrawAutomapPlayer(int cposx, int cposy, int czoom, int cang)
                         xoff = -xoff;
                     k = spr->ang;
                     l = spr->xrepeat;
-                    dax = sintable[k & 2047] * l;
-                    day = sintable[(k + 1536) & 2047] * l;
+                    dax = bsin(k) * l;
+                    day = -bcos(k) * l;
                     l = tileWidth(tilenum);
                     k = (l >> 1) + xoff;
                     x1 -= mulscale16(dax, k);
@@ -2019,8 +2019,8 @@ bool GameInterface::DrawAutomapPlayer(int cposx, int cposy, int czoom, int cang)
                             yoff = -yoff;
 
                         k = spr->ang;
-                        cosang = sintable[(k + 512) & 2047];
-                        sinang = sintable[k];
+                        cosang = bcos(k);
+                        sinang = bsin(k);
                         xspan = tileWidth(tilenum);
                         xrepeat = spr->xrepeat;
                         yspan = tileHeight(tilenum);

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -1755,7 +1755,7 @@ drawscreen(PLAYERp pp, double smoothratio)
 
 
     videoSetCorrectedAspect();
-    renderSetAspect(xs_CRoundToInt(double(viewingrange)* tan(r_fov* (PI / 360.))), yxaspect);
+    renderSetAspect(xs_CRoundToInt(double(viewingrange)* tan(r_fov * (pi::pi() / 360.))), yxaspect);
     OverlapDraw = true;
     DrawOverlapRoom(tx, ty, tz, tang.asq16(), thoriz.asq16(), tsectnum);
     OverlapDraw = false;

--- a/source/sw/src/draw.cpp
+++ b/source/sw/src/draw.cpp
@@ -1667,7 +1667,7 @@ drawscreen(PLAYERp pp, double smoothratio)
     }
     tsectnum = camerapp->cursectnum;
 
-    renderSetRollAngle(trotscrnang.asbam() / (double)BAMUNIT);
+    renderSetRollAngle(trotscrnang.asbuildf());
 
     COVERupdatesector(tx, ty, &tsectnum);
 

--- a/source/sw/src/eel.cpp
+++ b/source/sw/src/eel.cpp
@@ -545,7 +545,7 @@ int DoEelMatchPlayerZ(short SpriteNum)
     u->sz = max(u->sz, hiz + u->ceiling_dist);
 
     u->Counter = (u->Counter + (ACTORMOVETICS << 3) + (ACTORMOVETICS << 1)) & 2047;
-    sp->z = u->sz + ((EEL_BOB_AMT * (int)sintable[u->Counter]) >> 14);
+    sp->z = u->sz + mulscale14(EEL_BOB_AMT, bsin(u->Counter));
 
     bound = u->hiz + u->ceiling_dist + EEL_BOB_AMT;
     if (sp->z < bound)
@@ -578,8 +578,8 @@ DoEelDeath(short SpriteNum)
         DoActorSlide(SpriteNum);
 
     // slide while falling
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     u->ret = move_sprite(SpriteNum, nx, ny, 0L, u->ceiling_dist, u->floor_dist, CLIPMASK_MISSILE, ACTORMOVETICS);
     DoFindGroundPoint(SpriteNum);

--- a/source/sw/src/game.h
+++ b/source/sw/src/game.h
@@ -267,8 +267,8 @@ int StdRandomRange(int range);
 
 #define RANDOM_NEG(x,y) ((RANDOM_P2(((x)<<(y))<<1) - (x))<<(y))
 
-#define MOVEx(vel,ang) (((int)(vel) * (int)sintable[NORM_ANGLE((ang) + 512)]) >> 14)
-#define MOVEy(vel,ang) (((int)(vel) * (int)sintable[NORM_ANGLE((ang))]) >> 14)
+#define MOVEx(vel,ang) (mulscale14(vel, bcos(ang)))
+#define MOVEy(vel,ang) (mulscale14(vel, bsin(ang)))
 
 #define DIST(x1, y1, x2, y2) ksqrt( SQ((x1) - (x2)) + SQ((y1) - (y2)) )
 
@@ -353,7 +353,7 @@ int StdRandomRange(int range);
 
 #define SQ(val) ((val) * (val))
 
-#define KENFACING_PLAYER(pp,sp) (sintable[NORM_ANGLE(sp->ang+512)]*(pp->posy-sp->y) >= sintable[NORM_ANGLE(sp-ang)]*(pp->posx-sp->x))
+#define KENFACING_PLAYER(pp,sp) (bcos(sp->ang)*(pp->posy-sp->y) >= bsin(sp-ang)*(pp->posx-sp->x))
 #define FACING_PLAYER(pp,sp) (abs(getincangle(getangle((pp)->posx - (sp)->x, (pp)->posy - (sp)->y), (sp)->ang)) < 512)
 #define PLAYER_FACING(pp,sp) (abs(getincangle(getangle((sp)->x - (pp)->posx, (sp)->y - (pp)->posy), (pp)->angle.ang.asbuild())) < 320)
 #define FACING(sp1,sp2) (abs(getincangle(getangle((sp1)->x - (sp2)->x, (sp1)->y - (sp2)->y), (sp2)->ang)) < 512)

--- a/source/sw/src/girlninj.cpp
+++ b/source/sw/src/girlninj.cpp
@@ -796,8 +796,8 @@ GirlNinjaJumpActionFunc(short SpriteNum)
     int nx, ny;
 
     // Move while jumping
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     // if cannot move the sprite
     if (!move_actor(SpriteNum, nx, ny, 0L))

--- a/source/sw/src/hornet.cpp
+++ b/source/sw/src/hornet.cpp
@@ -409,7 +409,7 @@ int DoHornetMatchPlayerZ(short SpriteNum)
     u->sz = max(u->sz, hiz + u->ceiling_dist);    
 
     u->Counter = (u->Counter + (ACTORMOVETICS << 3) + (ACTORMOVETICS << 1)) & 2047;
-    sp->z = u->sz + ((HORNET_BOB_AMT * (int)sintable[u->Counter]) >> 14);
+    sp->z = u->sz + mulscale14(HORNET_BOB_AMT, bsin(u->Counter));
 
     bound = u->hiz + u->ceiling_dist + HORNET_BOB_AMT;
     if (sp->z < bound)
@@ -461,8 +461,8 @@ int DoHornetCircle(short SpriteNum)
 
     sp->ang = NORM_ANGLE(sp->ang + u->Counter2);
 
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     if (!move_actor(SpriteNum, nx, ny, 0L))
     {
@@ -471,8 +471,8 @@ int DoHornetCircle(short SpriteNum)
         // try moving in the opposite direction
         u->Counter2 = -u->Counter2;
         sp->ang = NORM_ANGLE(sp->ang + 1024);
-        nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-        ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+        nx = mulscale14(sp->xvel, bcos(sp->ang));
+        ny = mulscale14(sp->xvel, bsin(sp->ang));
 
         if (!move_actor(SpriteNum, nx, ny, 0L))
         {
@@ -531,8 +531,8 @@ DoHornetDeath(short SpriteNum)
         DoActorSlide(SpriteNum);
 
     // slide while falling
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     u->ret = move_sprite(SpriteNum, nx, ny, 0L, u->ceiling_dist, u->floor_dist, 1, ACTORMOVETICS);
 

--- a/source/sw/src/input.cpp
+++ b/source/sw/src/input.cpp
@@ -231,12 +231,13 @@ void GameInterface::GetInput(InputPacket *packet, ControlInfo* const hidInput)
 
     if (packet)
     {
-        auto const ang = pp->angle.ang.asbuild();
+        auto const cos = pp->angle.ang.bcos();
+        auto const sin = pp->angle.ang.bsin();
 
         *packet = loc;
 
-        packet->fvel = mulscale9(loc.fvel, sintable[NORM_ANGLE(ang + 512)]) + mulscale9(loc.svel, sintable[NORM_ANGLE(ang)]);
-        packet->svel = mulscale9(loc.fvel, sintable[NORM_ANGLE(ang)]) + mulscale9(loc.svel, sintable[NORM_ANGLE(ang + 1536)]);
+        packet->fvel = mulscale9(loc.fvel, cos) + mulscale9(loc.svel, sin);
+        packet->svel = mulscale9(loc.fvel, sin) - mulscale9(loc.svel, cos);
 
         loc = {};
     }

--- a/source/sw/src/mclip.cpp
+++ b/source/sw/src/mclip.cpp
@@ -65,8 +65,8 @@ int MultiClipMove(PLAYERp pp, int z, int floor_dist)
         xs = pp->posx;
         ys = pp->posy;
 
-        xvect = (sop->clipbox_vdist[i] * sintable[NORM_ANGLE(ang + 512)]);
-        yvect = (sop->clipbox_vdist[i] * sintable[ang]);
+        xvect = sop->clipbox_vdist[i] * bcos(ang);
+        yvect = sop->clipbox_vdist[i] * bsin(ang);
         clipmoveboxtracenum = 1;
         ret_start = clipmove_old(&xs, &ys, &z, &pp->cursectnum, xvect, yvect, (int)sop->clipbox_dist[i], Z(4), floor_dist, CLIPMASK_PLAYER);
         clipmoveboxtracenum = 3;
@@ -77,8 +77,8 @@ int MultiClipMove(PLAYERp pp, int z, int floor_dist)
             min_dist = 0;
             min_ndx = i;
             // ox is where it should be
-            ox[i] = x[i] = pp->posx + (sop->clipbox_vdist[i] * sintable[NORM_ANGLE(ang + 512)] >> 14);
-            oy[i] = y[i] = pp->posy + (sop->clipbox_vdist[i] * sintable[ang] >> 14);
+            ox[i] = x[i] = pp->posx + mulscale14(sop->clipbox_vdist[i], bcos(ang));
+            oy[i] = y[i] = pp->posy + mulscale14(sop->clipbox_vdist[i], bsin(ang));
 
             // xs is where it hit
             x[i] = xs;
@@ -144,8 +144,8 @@ short MultiClipTurn(PLAYERp pp, short new_ang, int z, int floor_dist)
         x = pp->posx;
         y = pp->posy;
 
-        xvect = (sop->clipbox_vdist[i] * sintable[NORM_ANGLE(ang + 512)]);
-        yvect = (sop->clipbox_vdist[i] * sintable[ang]);
+        xvect = sop->clipbox_vdist[i] * bcos(ang);
+        yvect = sop->clipbox_vdist[i] * bsin(ang);
 
         // move the box
         ret = clipmove_old(&x, &y, &z, &cursectnum, xvect, yvect, (int)sop->clipbox_dist[i], Z(4), floor_dist, CLIPMASK_PLAYER);
@@ -156,8 +156,8 @@ short MultiClipTurn(PLAYERp pp, short new_ang, int z, int floor_dist)
         {
             // attempt to move a bit when turning against a wall
             //ang = NORM_ANGLE(ang + 1024);
-            //pp->xvect += 20 * sintable[NORM_ANGLE(ang + 512)];
-            //pp->yvect += 20 * sintable[ang];
+            //pp->xvect += 20 * bcos(ang);
+            //pp->yvect += 20 * bsin(ang);
             return false;
         }
     }

--- a/source/sw/src/morph.cpp
+++ b/source/sw/src/morph.cpp
@@ -288,8 +288,8 @@ void ScaleRandomPoint(SECTOR_OBJECTp sop, short k, short ang, int x, int y, int 
     xmul = (sop->scale_point_dist[k] * sop->scale_x_mult)>>8;
     ymul = (sop->scale_point_dist[k] * sop->scale_y_mult)>>8;
 
-    *dx = x + ((xmul * sintable[NORM_ANGLE(ang+512)]) >> 14);
-    *dy = y + ((ymul * sintable[ang]) >> 14);
+    *dx = x + mulscale14(xmul, bcos(ang));
+    *dy = y + mulscale14(ymul, bsin(ang));
 }
 
 //
@@ -322,8 +322,8 @@ MorphTornado(SECTOR_OBJECTp sop)
     sy = y;
 
     // move it from last x,y
-    mx = x + (((sop->morph_speed) * sintable[NORM_ANGLE(sop->morph_ang+512)]) >> 14);
-    my = y + (((sop->morph_speed) * sintable[sop->morph_ang]) >> 14);
+    mx = x + mulscale14(sop->morph_speed, bcos(sop->morph_ang));
+    my = y + mulscale14(sop->morph_speed, bsin(sop->morph_ang));
 
     // bound check radius
     if (ksqrt(SQ(sop->xmid - mx) + SQ(sop->ymid - my)) > sop->morph_dist_max + sop->scale_dist)
@@ -334,8 +334,8 @@ MorphTornado(SECTOR_OBJECTp sop)
         sop->morph_ang = NORM_ANGLE(sop->morph_ang + 1024);
 
         // move back some from last point
-        mx = sx + (((sop->morph_speed*2) * sintable[NORM_ANGLE(sop->morph_ang+512)]) >> 14);
-        my = sy + (((sop->morph_speed*2) * sintable[sop->morph_ang]) >> 14);
+        mx = sx + mulscale14(sop->morph_speed << 1, bcos(sop->morph_ang));
+        my = sy + mulscale14(sop->morph_speed << 1, bsin(sop->morph_ang));
 
         sop->morph_xoff = sop->xmid - mx;
         sop->morph_yoff = sop->ymid - my;
@@ -400,8 +400,8 @@ MorphFloor(SECTOR_OBJECTp sop)
     y = sop->ymid - sop->morph_yoff;
 
     // move it from last x,y
-    mx = x + (((sop->morph_speed) * sintable[NORM_ANGLE(sop->morph_ang+512)]) >> 14);
-    my = y + (((sop->morph_speed) * sintable[sop->morph_ang]) >> 14);
+    mx = x + mulscale14(sop->morph_speed, bcos(sop->morph_ang));
+    my = y + mulscale14(sop->morph_speed, bsin(sop->morph_ang));
 
     // save x,y back as offset info
     sop->morph_xoff = sop->xmid - mx;
@@ -415,8 +415,8 @@ MorphFloor(SECTOR_OBJECTp sop)
         sop->morph_ang = NORM_ANGLE(sop->morph_ang + 1024);
 
         // back it up and save it off
-        mx = x + (((sop->morph_speed) * sintable[NORM_ANGLE(sop->morph_ang+512)]) >> 14);
-        my = y + (((sop->morph_speed) * sintable[sop->morph_ang]) >> 14);
+        mx = x + mulscale14(sop->morph_speed, bcos(sop->morph_ang));
+        my = y + mulscale14(sop->morph_speed, bsin(sop->morph_ang));
         sop->morph_xoff = sop->xmid - mx;
         sop->morph_yoff = sop->ymid - my;
 

--- a/source/sw/src/ninja.cpp
+++ b/source/sw/src/ninja.cpp
@@ -2067,8 +2067,8 @@ NinjaJumpActionFunc(short SpriteNum)
     int nx, ny;
 
     // Move while jumping
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     // if cannot move the sprite
     if (!move_actor(SpriteNum, nx, ny, 0L))

--- a/source/sw/src/panel.cpp
+++ b/source/sw/src/panel.cpp
@@ -1024,8 +1024,8 @@ pSwordSlide(PANEL_SPRITEp psp)
 
     vel_adj = 24;
 
-    nx += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    ny += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    nx += psp->vel * synctics * bcosf(psp->ang, -6);
+    ny += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -1055,8 +1055,10 @@ pSwordSlideDown(PANEL_SPRITEp psp)
     vel_adj = 20;
     vel = 2500;
 
-    nx += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(SwordAng + psp->ang + psp->PlayerP->SwordAng + 512)) / 64.;
-    ny += psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(SwordAng + psp->ang + psp->PlayerP->SwordAng)) / 64.;
+    auto ang = SwordAng + psp->ang + psp->PlayerP->SwordAng;
+
+    nx += psp->vel * synctics * bcosf(ang, -6);
+    ny += psp->vel * synctics * -bsinf(ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -1117,8 +1119,8 @@ pSwordSlideR(PANEL_SPRITEp psp)
 
     vel_adj = 24;
 
-    nx += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 1024 + 512)) / 64.;
-    ny += psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(psp->ang + 1024)) / 64.;
+    nx += psp->vel * synctics * -bcosf(psp->ang, -6);
+    ny += psp->vel * synctics * bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -1148,8 +1150,10 @@ pSwordSlideDownR(PANEL_SPRITEp psp)
     vel_adj = 24;
     vel = 2500;
 
-    nx += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(SwordAng + psp->ang - psp->PlayerP->SwordAng + 1024 + 512)) / 64.;
-    ny += psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(SwordAng + psp->ang - psp->PlayerP->SwordAng + 1024)) / 64.;
+    auto ang = SwordAng + psp->ang - psp->PlayerP->SwordAng;
+
+    nx += psp->vel * synctics * -bcosf(ang, -6);
+    ny += psp->vel * synctics * bsinf(ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -1880,8 +1884,8 @@ pUziReload(PANEL_SPRITEp nclip)
     double xgun = xs_CRoundToInt(gun->x * FRACUNIT) | gun->xfract;
     double ygun = xs_CRoundToInt(gun->y * FRACUNIT) | gun->yfract;
 
-    nx = nclip->vel * synctics * calcSinTableValue(NORM_ANGLE(nclip->ang + 512)) / 64.;
-    ny = nclip->vel * synctics * -calcSinTableValue(nclip->ang) / 64.;
+    nx = nclip->vel * synctics * bcosf(nclip->ang, -6);
+    ny = nclip->vel * synctics * -bsinf(nclip->ang, -6);
 
     nclip->vel += 14 * synctics;
 
@@ -1896,8 +1900,8 @@ pUziReload(PANEL_SPRITEp nclip)
     nclip->yfract = LSW(y);
     nclip->y = y / FRACUNIT;
 
-    nx = gun->vel * synctics * calcSinTableValue(NORM_ANGLE(gun->ang + 512)) / 64.;
-    ny = gun->vel * synctics * -calcSinTableValue(gun->ang) / 64.;
+    nx = gun->vel * synctics * bcosf(gun->ang, -6);
+    ny = gun->vel * synctics * -bsinf(gun->ang, -6);
 
     xgun -= nx;
     ygun -= ny;
@@ -1952,8 +1956,8 @@ pUziReloadRetract(PANEL_SPRITEp nclip)
     double xgun = xs_CRoundToInt(gun->x * FRACUNIT) | gun->xfract;
     double ygun = xs_CRoundToInt(gun->y * FRACUNIT) | gun->yfract;
 
-    nx = nclip->vel * synctics * calcSinTableValue(NORM_ANGLE(nclip->ang + 512)) / 64.;
-    ny = nclip->vel * synctics * -calcSinTableValue(nclip->ang) / 64.;
+    nx = nclip->vel * synctics * bcosf(nclip->ang, -6);
+    ny = nclip->vel * synctics * -bsinf(nclip->ang, -6);
 
     nclip->vel += 18 * synctics;
 
@@ -2041,8 +2045,8 @@ pUziClip(PANEL_SPRITEp oclip)
     ox = x;
     oy = y;
 
-    nx = oclip->vel * synctics * calcSinTableValue(NORM_ANGLE(oclip->ang + 512)) / 64.;
-    ny = oclip->vel * synctics * -calcSinTableValue(oclip->ang) / 64.;
+    nx = oclip->vel * synctics * bcosf(oclip->ang, -6);
+    ny = oclip->vel * synctics * -bsinf(oclip->ang, -6);
 
     oclip->vel += 16 * synctics;
 
@@ -2066,8 +2070,8 @@ pUziClip(PANEL_SPRITEp oclip)
         // so it will end up the same for all synctic values
         for (x = ox, y = oy; oclip->y < UZI_RELOAD_YOFF; )
         {
-            x += oclip->vel * calcSinTableValue(NORM_ANGLE(oclip->ang + 512)) / 64.;
-            y += oclip->vel * -calcSinTableValue(oclip->ang) / 64.;
+            x += oclip->vel * bcosf(oclip->ang, -6);
+            y += oclip->vel * -bsinf(oclip->ang, -6);
         }
 
         oclip->xfract = LSW(x);
@@ -2596,7 +2600,7 @@ pUziShell(PANEL_SPRITEp psp)
 
     // get height
     psp->oy = psp->y = psp->yorig;
-    psp->y += psp->sin_amt * -calcSinTableValue(psp->sin_ndx) / 16384.;
+    psp->y += psp->sin_amt * -bsinf(psp->sin_ndx, -14);
 
     // if off of the screen kill them
     if (psp->x > 330 || psp->x < -10)
@@ -2845,8 +2849,8 @@ pShotgunRecoilDown(PANEL_SPRITEp psp)
     else
         targetvel = 780;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -2873,8 +2877,8 @@ pShotgunRecoilUp(PANEL_SPRITEp psp)
     double x = xs_CRoundToInt(psp->x * FRACUNIT) | psp->xfract;
     double y = xs_CRoundToInt(psp->y * FRACUNIT) | psp->yfract;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -3351,8 +3355,8 @@ pRailRecoilDown(PANEL_SPRITEp psp)
     double x = xs_CRoundToInt(psp->x * FRACUNIT) | psp->xfract;
     double y = xs_CRoundToInt(psp->y * FRACUNIT) | psp->yfract;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -3379,8 +3383,8 @@ pRailRecoilUp(PANEL_SPRITEp psp)
     double x = xs_CRoundToInt(psp->x * FRACUNIT) | psp->xfract;
     double y = xs_CRoundToInt(psp->y * FRACUNIT) | psp->yfract;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -4245,8 +4249,8 @@ pMicroRecoilDown(PANEL_SPRITEp psp)
     double x = xs_CRoundToInt(psp->x * FRACUNIT) | psp->xfract;
     double y = xs_CRoundToInt(psp->y * FRACUNIT) | psp->yfract;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -4273,8 +4277,8 @@ pMicroRecoilUp(PANEL_SPRITEp psp)
     double x = xs_CRoundToInt(psp->x * FRACUNIT) | psp->xfract;
     double y = xs_CRoundToInt(psp->y * FRACUNIT) | psp->yfract;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -5259,8 +5263,8 @@ pGrenadeRecoilDown(PANEL_SPRITEp psp)
     double x = xs_CRoundToInt(psp->x * FRACUNIT) | psp->xfract;
     double y = xs_CRoundToInt(psp->y * FRACUNIT) | psp->yfract;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -5290,8 +5294,8 @@ pGrenadeRecoilUp(PANEL_SPRITEp psp)
     double x = xs_CRoundToInt(psp->x * FRACUNIT) | psp->xfract;
     double y = xs_CRoundToInt(psp->y * FRACUNIT) | psp->yfract;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -5324,8 +5328,8 @@ pGrenadePresent(PANEL_SPRITEp psp)
     if (TEST(psp->PlayerP->Flags, PF_WEAPON_RETRACT))
         return;
 
-    x += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang + 512)) / 64.;
-    y += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    x += psp->vel * synctics * bcosf(psp->ang, -6);
+    y += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     psp->ox = psp->x;
     psp->oy = psp->y;
@@ -6267,8 +6271,8 @@ pFistSlide(PANEL_SPRITEp psp)
 
     vel_adj = 68;
 
-    //nx += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang)) / 64.;
-    ny += psp->vel * synctics * -calcSinTableValue(psp->ang) / 64.;
+    //nx += psp->vel * synctics * bsinf(psp->ang, -6);
+    ny += psp->vel * synctics * -bsinf(psp->ang, -6);
 
     //psp->ox = psp->x;
     psp->oy = psp->y;
@@ -6298,12 +6302,14 @@ pFistSlideDown(PANEL_SPRITEp psp)
     vel_adj = 48;
     vel = 3500;
 
+    auto ang = FistAng + psp->ang + psp->PlayerP->FistAng;
+
     if (psp->ActionState == ps_Kick || psp->PlayerP->WpnKungFuMove == 3)
-        ny += (psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(FistAng + psp->ang + psp->PlayerP->FistAng)) / 64.);
+        ny += psp->vel * synctics * -bsinf(ang, -6);
     else
     {
-        nx -= psp->vel * synctics * calcSinTableValue(NORM_ANGLE(FistAng + psp->ang + psp->PlayerP->FistAng)) / 64.;
-        ny += 3*(psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(FistAng + psp->ang + psp->PlayerP->FistAng)) / 64.);
+        nx -= psp->vel * synctics * bsinf(ang, -6);
+        ny += psp->vel * synctics * -bsinf(ang, -6) * 3;
     }
 
     psp->ox = psp->x;
@@ -6394,8 +6400,8 @@ pFistSlideR(PANEL_SPRITEp psp)
 
     vel_adj = 68;
 
-    //nx += psp->vel * synctics * calcSinTableValue(NORM_ANGLE(psp->ang)) / 64.;
-    ny += psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(psp->ang + 1024)) / 64.;
+    //nx += psp->vel * synctics * bsinf(psp->ang, -6);
+    ny += psp->vel * synctics * bsinf(psp->ang, -6);
 
     //psp->ox = psp->x;
     psp->oy = psp->y;
@@ -6425,12 +6431,14 @@ pFistSlideDownR(PANEL_SPRITEp psp)
     vel_adj = 48;
     vel = 3500;
 
+    auto ang = FistAng + psp->ang + psp->PlayerP->FistAng;
+
     if (psp->ActionState == ps_Kick || psp->PlayerP->WpnKungFuMove == 3)
-        ny += (psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(FistAng + psp->ang + psp->PlayerP->FistAng)) / 64.);
+        ny += psp->vel * synctics * -bsinf(ang, -6);
     else
     {
-        nx -= psp->vel * synctics * calcSinTableValue(NORM_ANGLE(FistAng + psp->ang + psp->PlayerP->FistAng)) / 64.;
-        ny += 3*(psp->vel * synctics * -calcSinTableValue(NORM_ANGLE(FistAng + psp->ang + psp->PlayerP->FistAng)) / 64.);
+        nx -= psp->vel * synctics * bsinf(ang, -6);
+        ny += psp->vel * synctics * -bsinf(ang, -6) * 3;
     }
 
     psp->ox = psp->x;
@@ -6877,7 +6885,7 @@ pWeaponBob(PANEL_SPRITEp psp, short condition)
         psp->sin_ndx &= 2047;
 
         // get height
-        xdiff = psp->sin_amt * calcSinTableValue(psp->sin_ndx) / 16384.;
+        xdiff = psp->sin_amt * bsinf(psp->sin_ndx, -14);
 
         // //
         // bob_xxx moves the weapon up-down
@@ -6889,7 +6897,7 @@ pWeaponBob(PANEL_SPRITEp psp, short condition)
 
         // base bob_amt on the players velocity - Max of 128
         bob_amt = bobvel / psp->bob_height_divider;
-        ydiff = bob_amt * calcSinTableValue(bob_ndx) / 16384.;
+        ydiff = bob_amt * bsinf(bob_ndx, -14);
     }
 
     // Back up current coordinates for interpolating.

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -7223,7 +7223,7 @@ domovethings(void)
         // auto tracking mode for single player multi-game
         if (numplayers <= 1 && PlayerTrackingMode && pnum == screenpeek && screenpeek != myconnectindex)
         {
-            Player[screenpeek].angle.settarget(FixedToFloat(gethiq16angle(Player[myconnectindex].posx - Player[screenpeek].posx, Player[myconnectindex].posy - Player[screenpeek].posy)));
+            Player[screenpeek].angle.settarget(bvectangf(Player[myconnectindex].posx - Player[screenpeek].posx, Player[myconnectindex].posy - Player[screenpeek].posy));
         }
 
         if (!TEST(pp->Flags, PF_DEAD))

--- a/source/sw/src/player.cpp
+++ b/source/sw/src/player.cpp
@@ -6198,7 +6198,7 @@ void DoPlayerDeathFollowKiller(PLAYERp pp)
 
         if (FAFcansee(kp->x, kp->y, SPRITEp_TOS(kp), kp->sectnum, pp->posx, pp->posy, pp->posz, pp->cursectnum))
         {
-            pp->angle.addadjustment(getincangleq16(pp->angle.ang.asq16(), gethiq16angle(kp->x - pp->posx, kp->y - pp->posy)) / (double)(FRACUNIT << 4));
+            pp->angle.addadjustment(getincanglebam(pp->angle.ang, bvectangbam(kp->x - pp->posx, kp->y - pp->posy)) >> 4);
         }
     }
 }

--- a/source/sw/src/ripper.cpp
+++ b/source/sw/src/ripper.cpp
@@ -953,9 +953,9 @@ InitRipperHang(short SpriteNum)
         tang = NORM_ANGLE(sp->ang + dang);
 
         FAFhitscan(sp->x, sp->y, sp->z - SPRITEp_SIZE_Z(sp), sp->sectnum,  // Start position
-                   sintable[NORM_ANGLE(tang + 512)],   // X vector of 3D ang
-                   sintable[tang],             // Y vector of 3D ang
-                   0,                          // Z vector of 3D ang
+                   bcos(tang),   // X vector of 3D ang
+                   bsin(tang),   // Y vector of 3D ang
+                   0,            // Z vector of 3D ang
                    &hitinfo, CLIPMASK_MISSILE);
 
         //ASSERT(hitinfo.sect >= 0);
@@ -1020,8 +1020,8 @@ DoRipperMoveHang(short SpriteNum)
     int nx, ny;
 
     // Move while jumping
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     // if cannot move the sprite
     if (!move_actor(SpriteNum, nx, ny, 0L))
@@ -1093,7 +1093,7 @@ DoRipperBeginJumpAttack(short SpriteNum)
 
     tang = getangle(psp->x - sp->x, psp->y - sp->y);
 
-    if (move_sprite(SpriteNum, sintable[NORM_ANGLE(tang+512)] >> 7, sintable[tang] >> 7,
+    if (move_sprite(SpriteNum, bcos(tang, -7), bsin(tang, -7),
                     0L, u->ceiling_dist, u->floor_dist, CLIPMASK_ACTOR, ACTORMOVETICS))
         sp->ang = NORM_ANGLE((sp->ang + 1024) + (RANDOM_NEG(256, 6) >> 6));
     else

--- a/source/sw/src/ripper2.cpp
+++ b/source/sw/src/ripper2.cpp
@@ -953,9 +953,9 @@ InitRipper2Hang(short SpriteNum)
         tang = NORM_ANGLE(sp->ang + dang);
 
         FAFhitscan(sp->x, sp->y, sp->z - SPRITEp_SIZE_Z(sp), sp->sectnum,  // Start position
-                   sintable[NORM_ANGLE(tang + 512)],   // X vector of 3D ang
-                   sintable[tang],             // Y vector of 3D ang
-                   0,                          // Z vector of 3D ang
+                   bcos(tang),   // X vector of 3D ang
+                   bsin(tang),   // Y vector of 3D ang
+                   0,            // Z vector of 3D ang
                    &hitinfo, CLIPMASK_MISSILE);
 
         if (hitinfo.sect < 0)
@@ -1020,8 +1020,8 @@ DoRipper2MoveHang(short SpriteNum)
     int nx, ny;
 
     // Move while jumping
-    nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-    ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+    nx = mulscale14(sp->xvel, bcos(sp->ang));
+    ny = mulscale14(sp->xvel, bsin(sp->ang));
 
     // if cannot move the sprite
     if (!move_actor(SpriteNum, nx, ny, 0L))
@@ -1103,7 +1103,7 @@ DoRipper2BeginJumpAttack(short SpriteNum)
     // Always jump at player if mad.
     //if(u->speed < FAST_SPEED)
     //{
-    if (move_sprite(SpriteNum, sintable[NORM_ANGLE(tang+512)] >> 7, sintable[tang] >> 7,
+    if (move_sprite(SpriteNum, bcos(tang, -7), bsin(tang, -7),
                     0L, u->ceiling_dist, u->floor_dist, CLIPMASK_ACTOR, ACTORMOVETICS))
         sp->ang = NORM_ANGLE((sp->ang + 1024) + (RANDOM_NEG(256, 6) >> 6));
     else

--- a/source/sw/src/rooms.cpp
+++ b/source/sw/src/rooms.cpp
@@ -290,8 +290,8 @@ FAFcansee(int32_t xs, int32_t ys, int32_t zs, int16_t sects,
     ang = getangle(xe - xs, ye - ys);
 
     // get x,y,z, vectors
-    xvect = sintable[NORM_ANGLE(ang + 512)];
-    yvect = sintable[NORM_ANGLE(ang)];
+    xvect = bcos(ang);
+    yvect = bsin(ang);
 
     // find the distance to the target
     dist = ksqrt(SQ(xe - xs) + SQ(ye - ys));

--- a/source/sw/src/sbar.cpp
+++ b/source/sw/src/sbar.cpp
@@ -803,7 +803,7 @@ private:
         {
             int s = -8;
             if (althud_flashing && u->Health > u->MaxHealth)
-                s += (sintable[(PlayClock << 5) & 2047] >> 10);
+                s += bsin(PlayClock << 5, -10);
             int intens = clamp(255 - 4 * s, 0, 255);
             auto pe = PalEntry(255, intens, intens, intens);
             format.Format("%d", u->Health);

--- a/source/sw/src/sector.cpp
+++ b/source/sw/src/sector.cpp
@@ -2351,9 +2351,9 @@ bool NearThings(PLAYERp pp)
         short dang = pp->angle.ang.asbuild();
 
         FAFhitscan(pp->posx, pp->posy, pp->posz - Z(30), pp->cursectnum,    // Start position
-                   sintable[NORM_ANGLE(dang + 512)],  // X vector of 3D ang
-                   sintable[NORM_ANGLE(dang)],        // Y vector of 3D ang
-                   0,                                 // Z vector of 3D ang
+                   bcos(dang),  // X vector of 3D ang
+                   bsin(dang),  // Y vector of 3D ang
+                   0,           // Z vector of 3D ang
                    &hitinfo, CLIPMASK_MISSILE);
 
         if (hitinfo.sect < 0)
@@ -2760,13 +2760,13 @@ DoSineWaveFloor(void)
 
             if (TEST(flags, SINE_FLOOR))
             {
-                newz = swf->floor_origz + ((swf->range * sintable[swf->sintable_ndx]) >> 14);
+                newz = swf->floor_origz + mulscale14(swf->range, bsin(swf->sintable_ndx));
                 sector[swf->sector].floorz = newz;
             }
 
             if (TEST(flags, SINE_CEILING))
             {
-                newz = swf->ceiling_origz + ((swf->range * sintable[swf->sintable_ndx]) >> 14);
+                newz = swf->ceiling_origz + mulscale14(swf->range, bsin(swf->sintable_ndx));
                 sector[swf->sector].ceilingz = newz;
             }
 
@@ -2824,13 +2824,13 @@ DoSineWaveWall(void)
 
             if (!sw->type)
             {
-                New = sw->orig_xy + ((sw->range * sintable[sw->sintable_ndx]) >> 14);
+                New = sw->orig_xy + mulscale14(sw->range, bsin(sw->sintable_ndx));
                 // wall[sw->wall].y = New;
                 dragpoint(sw->wall, wall[sw->wall].x, New, 0);
             }
             else
             {
-                New = sw->orig_xy + ((sw->range * sintable[sw->sintable_ndx]) >> 14);
+                New = sw->orig_xy + mulscale14(sw->range, bsin(sw->sintable_ndx));
                 // wall[sw->wall].x = New;
                 dragpoint(sw->wall, New, wall[sw->wall].y, 0);
             }
@@ -3207,8 +3207,8 @@ DoPanning(void)
         sp = &sprite[i];
         sectp = &sector[sp->sectnum];
 
-        nx = (((int) sintable[NORM_ANGLE(sp->ang + 512)]) * sp->xvel) >> 20;
-        ny = (((int) sintable[sp->ang]) * sp->xvel) >> 20;
+        nx = mulscale20(sp->xvel, bcos(sp->ang));
+        ny = mulscale20(sp->xvel, bsin(sp->ang));
 
         sectp->floorxpanning += nx;
         sectp->floorypanning += ny;
@@ -3223,8 +3223,8 @@ DoPanning(void)
         sp = &sprite[i];
         sectp = &sector[sp->sectnum];
 
-        nx = (((int) sintable[NORM_ANGLE(sp->ang + 512)]) * sp->xvel) >> 20;
-        ny = (((int) sintable[sp->ang]) * sp->xvel) >> 20;
+        nx = mulscale20(sp->xvel, bcos(sp->ang));
+        ny = mulscale20(sp->xvel, bsin(sp->ang));
 
         sectp->ceilingxpanning += nx;
         sectp->ceilingypanning += ny;
@@ -3239,8 +3239,8 @@ DoPanning(void)
         sp = &sprite[i];
         wallp = &wall[sp->owner];
 
-        nx = (((int) sintable[NORM_ANGLE(sp->ang + 512)]) * sp->xvel) >> 20;
-        ny = (((int) sintable[sp->ang]) * sp->xvel) >> 20;
+        nx = mulscale20(sp->xvel, bcos(sp->ang));
+        ny = mulscale20(sp->xvel, bsin(sp->ang));
 
         wallp->xpanning += nx;
         wallp->ypanning += ny;

--- a/source/sw/src/skull.cpp
+++ b/source/sw/src/skull.cpp
@@ -438,8 +438,8 @@ int DoSkullBob(short SpriteNum)
 #define SKULL_BOB_AMT (Z(16))
 
     u->Counter = (u->Counter + (ACTORMOVETICS << 3) + (ACTORMOVETICS << 1)) & 2047;
-    sp->z = u->sz + ((SKULL_BOB_AMT * (int)sintable[u->Counter]) >> 14) +
-            ((DIV2(SKULL_BOB_AMT) * (int)sintable[u->Counter]) >> 14);
+    sp->z = u->sz + mulscale14(SKULL_BOB_AMT, bsin(u->Counter)) +
+            mulscale14(DIV2(SKULL_BOB_AMT), bsin(u->Counter));
 
     return 0;
 }
@@ -849,8 +849,8 @@ int DoBettyBob(short SpriteNum)
 #define BETTY_BOB_AMT (Z(16))
 
     u->Counter = (u->Counter + (ACTORMOVETICS << 3) + (ACTORMOVETICS << 1)) & 2047;
-    sp->z = u->sz + ((BETTY_BOB_AMT * (int)sintable[u->Counter]) >> 14) +
-            ((DIV2(BETTY_BOB_AMT) * (int)sintable[u->Counter]) >> 14);
+    sp->z = u->sz + mulscale14(BETTY_BOB_AMT, bsin(u->Counter)) +
+            mulscale14(DIV2(BETTY_BOB_AMT), bsin(u->Counter));
 
     return 0;
 }

--- a/source/sw/src/sounds.cpp
+++ b/source/sw/src/sounds.cpp
@@ -590,7 +590,7 @@ void GameInterface::UpdateSounds(void)
     PLAYERp pp = Player + screenpeek;
     SoundListener listener;
 
-    listener.angle = -(pp->angle.ang.asbam() / (double)BAMUNIT) * pi::pi() / 1024; // Build uses a period of 2048.
+    listener.angle = -pp->angle.ang.asbuild() * BAngRadian; // Build uses a period of 2048.
     listener.velocity.Zero();
     listener.position = GetSoundPos((vec3_t*)&pp->posx);
     listener.underwater = false;

--- a/source/sw/src/sprite.cpp
+++ b/source/sw/src/sprite.cpp
@@ -2137,9 +2137,9 @@ SpriteSetup(void)
                     hitdata_t hitinfo;
 
                     hitscan(&hit_pos, sp->sectnum,    // Start position
-                            sintable[NORM_ANGLE(sp->ang + 512)],    // X vector of 3D ang
-                            sintable[sp->ang],      // Y vector of 3D ang
-                            0,      // Z vector of 3D ang
+                            bcos(sp->ang),    // X vector of 3D ang
+                            bsin(sp->ang),    // Y vector of 3D ang
+                            0,                // Z vector of 3D ang
                             &hitinfo, CLIPMASK_MISSILE);
 
                     if (hitinfo.wall == -1)
@@ -2167,9 +2167,9 @@ SpriteSetup(void)
                     hitdata_t hitinfo;
 
                     hitscan(&hit_pos, sp->sectnum,    // Start position
-                            sintable[NORM_ANGLE(sp->ang + 512)],    // X vector of 3D ang
-                            sintable[sp->ang],      // Y vector of 3D ang
-                            0,      // Z vector of 3D ang
+                            bcos(sp->ang),    // X vector of 3D ang
+                            bcos(sp->ang),    // Y vector of 3D ang
+                            0,                // Z vector of 3D ang
                             &hitinfo, CLIPMASK_MISSILE);
 
                     if (hitinfo.wall == -1)
@@ -4785,8 +4785,8 @@ getzrangepoint(int x, int y, int z, short sectnum,
         // Calculate all 4 points of the floor sprite.
         // (x1,y1),(x2,y2),(x3,y3),(x4,y4)
         // These points will already have (x,y) subtracted from them
-        cosang = sintable[NORM_ANGLE(spr->ang + 512)];
-        sinang = sintable[spr->ang];
+        cosang = bcos(spr->ang);
+        sinang = bsin(spr->ang);
         xspan = tileWidth(tilenum);
         dax = ((xspan >> 1) + xoff) * spr->xrepeat;
         yspan = tileHeight(tilenum);

--- a/source/sw/src/track.cpp
+++ b/source/sw/src/track.cpp
@@ -399,15 +399,15 @@ void QuickJumpSetup(short stat, short lotag, short type)
 
         // add jump point
         nsp = &sprite[SpriteNum];
-        nsp->x += 64 * (int) sintable[NORM_ANGLE(nsp->ang + 512)] >> 14;
-        nsp->y += 64 * (int) sintable[nsp->ang] >> 14;
+        nsp->x += mulscale14(64, bcos(nsp->ang));
+        nsp->y += mulscale14(64, bsin(nsp->ang));
         nsp->lotag = lotag;
         TrackAddPoint(t, tp, SpriteNum);
 
         // add end point
         nsp = &sprite[end_sprite];
-        nsp->x += 2048 * (int) sintable[NORM_ANGLE(nsp->ang + 512)] >> 14;
-        nsp->y += 2048 * (int) sintable[nsp->ang] >> 14;
+        nsp->x += mulscale14(2048, bcos(nsp->ang));
+        nsp->y += mulscale14(2048, bsin(nsp->ang));
         nsp->lotag = TRACK_END;
         nsp->hitag = 0;
         TrackAddPoint(t, tp, end_sprite);
@@ -458,8 +458,8 @@ void QuickScanSetup(short stat, short lotag, short type)
         nsp = &sprite[start_sprite];
         nsp->lotag = TRACK_START;
         nsp->hitag = 0;
-        nsp->x += 64 * (int) sintable[NORM_ANGLE(nsp->ang + 1024 + 512)] >> 14;
-        nsp->y += 64 * (int) sintable[NORM_ANGLE(nsp->ang + 1024)] >> 14;
+        nsp->x += mulscale14(64, -bcos(nsp->ang));
+        nsp->y += mulscale14(64, -bsin(nsp->ang));
         TrackAddPoint(t, tp, start_sprite);
 
         // add jump point
@@ -469,8 +469,8 @@ void QuickScanSetup(short stat, short lotag, short type)
 
         // add end point
         nsp = &sprite[end_sprite];
-        nsp->x += 64 * (int) sintable[NORM_ANGLE(nsp->ang + 512)] >> 14;
-        nsp->y += 64 * (int) sintable[nsp->ang] >> 14;
+        nsp->x += mulscale14(64, bcos(nsp->ang));
+        nsp->y += mulscale14(64, bsin(nsp->ang));
         nsp->lotag = TRACK_END;
         nsp->hitag = 0;
         TrackAddPoint(t, tp, end_sprite);
@@ -525,8 +525,8 @@ void QuickExitSetup(short stat, short type)
 
         // add end point
         nsp = &sprite[end_sprite];
-        nsp->x += 1024 * (int) sintable[NORM_ANGLE(nsp->ang + 512)] >> 14;
-        nsp->y += 1024 * (int) sintable[nsp->ang] >> 14;
+        nsp->x += mulscale14(1024, bcos(nsp->ang));
+        nsp->y += mulscale14(1024, bsin(nsp->ang));
         nsp->lotag = TRACK_END;
         nsp->hitag = 0;
         TrackAddPoint(t, tp, end_sprite);
@@ -1984,8 +1984,8 @@ void RefreshPoints(SECTOR_OBJECTp sop, int nx, int ny, bool dynamic)
                                 int xmul = (sop->scale_dist * sop->scale_x_mult)>>8;
                                 int ymul = (sop->scale_dist * sop->scale_y_mult)>>8;
 
-                                dx = x + ((xmul * sintable[NORM_ANGLE(ang+512)]) >> 14);
-                                dy = y + ((ymul * sintable[ang]) >> 14);
+                                dx = x + mulscale14(xmul, bcos(ang));
+                                dy = y + mulscale14(ymul, bsin(ang));
                             }
                         }
                     }
@@ -2180,7 +2180,7 @@ MoveZ(SECTOR_OBJECTp sop)
     if (sop->bob_amt)
     {
         sop->bob_sine_ndx = (PlayClock << sop->bob_speed) & 2047;
-        sop->bob_diff = ((sop->bob_amt * (int) sintable[sop->bob_sine_ndx]) >> 14);
+        sop->bob_diff = mulscale14(sop->bob_amt, bsin(sop->bob_sine_ndx));
 
         // for all sectors
         for (i = 0, sectp = &sop->sectp[0]; *sectp; sectp++, i++)
@@ -2763,8 +2763,8 @@ void DoTrack(SECTOR_OBJECTp sop, short locktics, int *nx, int *ny)
     // calculate a new x and y
     if (sop->vel && !TEST(sop->flags,SOBJ_MOVE_VERTICAL))
     {
-        *nx = (DIV256(sop->vel)) * locktics * (int) sintable[NORM_ANGLE(sop->ang_moving + 512)] >> 14;
-        *ny = (DIV256(sop->vel)) * locktics * (int) sintable[sop->ang_moving] >> 14;
+        *nx = (DIV256(sop->vel)) * locktics * bcos(sop->ang_moving) >> 14;
+        *ny = (DIV256(sop->vel)) * locktics * bsin(sop->ang_moving) >> 14;
 
         dist = Distance(sop->xmid, sop->ymid, sop->xmid + *nx, sop->ymid + *ny);
         sop->target_dist -= dist;
@@ -2789,7 +2789,7 @@ OperateSectorObjectForTics(SECTOR_OBJECTp sop, short newang, int newx, int newy,
     if (sop->bob_amt)
     {
         sop->bob_sine_ndx = (PlayClock << sop->bob_speed) & 2047;
-        sop->bob_diff = ((sop->bob_amt * (int) sintable[sop->bob_sine_ndx]) >> 14);
+        sop->bob_diff = mulscale14(sop->bob_amt, bsin(sop->bob_sine_ndx));
 
         // for all sectors
         for (i = 0, sectp = &sop->sectp[0]; *sectp; sectp++, i++)
@@ -2933,8 +2933,8 @@ DoTornadoObject(SECTOR_OBJECTp sop)
     int ret;
     short *ang = &sop->ang_moving;
 
-    xvect = (sop->vel * sintable[NORM_ANGLE(*ang + 512)]);
-    yvect = (sop->vel * sintable[NORM_ANGLE(*ang)]);
+    xvect = sop->vel * bcos(*ang);
+    yvect = sop->vel * bcos(*ang);
 
     cursect = sop->op_main_sector; // for sop->vel
     floor_dist = DIV4(labs(sector[cursect].ceilingz - sector[cursect].floorz));
@@ -3128,8 +3128,8 @@ ActorLeaveTrack(short SpriteNum)
 /*
 ScanToWall
 (lsp->x, lsp->y, SPRITEp_TOS(sp) - DIV2(SPRITEp_SIZE_Z(sp)), lsp->sectnum,
-    sintable[NORM_ANGLE(lsp->ang + 1024 + 512)],
-    sintable[lsp->ang + 1024],
+    -bcos(lsp->ang),
+    -bsin(lsp->ang),
     0,
     &hitinfo);
 */
@@ -3275,9 +3275,9 @@ ActorTrackDecide(TRACK_POINTp tpoint, short SpriteNum)
                 RESET(sp->cstat, CSTAT_SPRITE_BLOCK);
 
                 FAFhitscan(sp->x, sp->y, sp->z - Z(24), sp->sectnum,      // Start position
-                           sintable[NORM_ANGLE(sp->ang + 512)],      // X vector of 3D ang
-                           sintable[sp->ang],    // Y vector of 3D ang
-                           0,                            // Z vector of 3D ang
+                           bcos(sp->ang),    // X vector of 3D ang
+                           bsin(sp->ang),    // Y vector of 3D ang
+                           0,                // Z vector of 3D ang
                            &hitinfo, CLIPMASK_MISSILE);
 
                 SET(sp->cstat, CSTAT_SPRITE_BLOCK);
@@ -3830,8 +3830,8 @@ ActorFollowTrack(short SpriteNum, short locktics)
         else
         {
             // calculate a new x and y
-            nx = sp->xvel * (int) sintable[NORM_ANGLE(sp->ang + 512)] >> 14;
-            ny = sp->xvel * (int) sintable[sp->ang] >> 14;
+            nx = mulscale14(sp->xvel, bcos(sp->ang));
+            ny = mulscale14(sp->xvel, bsin(sp->ang));
         }
 
         nz = 0;

--- a/source/sw/src/track.cpp
+++ b/source/sw/src/track.cpp
@@ -1688,7 +1688,7 @@ MovePlayer(PLAYERp pp, SECTOR_OBJECTp sop, int nx, int ny)
 
     // New angle is formed by taking last known angle and
     // adjusting by the delta angle
-    pp->angle.addadjustment((pp->angle.ang - (pp->RevolveAng + buildang(pp->RevolveDeltaAng))).asbam() / (double)BAMUNIT);
+    pp->angle.addadjustment(pp->angle.ang - (pp->RevolveAng + buildang(pp->RevolveDeltaAng)));
 
     UpdatePlayerSprite(pp);
 }

--- a/source/sw/src/wallmove.cpp
+++ b/source/sw/src/wallmove.cpp
@@ -65,8 +65,8 @@ void SOwallmove(SECTOR_OBJECTp sop, SPRITEp sp, WALLp find_wallp, int dist, int 
                 ASSERT(User[sp - sprite]);
                 ang = User[sp - sprite]->sang;
 
-                *nx = ((dist * sintable[NORM_ANGLE(ang + 512)])>>14);
-                *ny = ((dist * sintable[ang])>>14);
+                *nx = mulscale14(dist, bcos(ang));
+                *ny = mulscale14(dist, bsin(ang));
 
                 sop->xorig[wallcount] -= *nx;
                 sop->yorig[wallcount] -= *ny;
@@ -101,8 +101,8 @@ int DoWallMove(SPRITEp sp)
     if (dang)
         ang = NORM_ANGLE(ang + (RANDOM_RANGE(dang) - dang/2));
 
-    nx = (dist * sintable[NORM_ANGLE(ang + 512)])>>14;
-    ny = (dist * sintable[ang])>>14;
+    nx = mulscale14(dist, bcos(ang));
+    ny = mulscale14(dist, bsin(ang));
 
     for (wallp = wall; wallp < &wall[numwalls]; wallp++)
     {

--- a/source/sw/src/weapon.cpp
+++ b/source/sw/src/weapon.cpp
@@ -3822,8 +3822,8 @@ AutoShrap:
                 shrap_ysize = u->sy = 12 + (RANDOM_P2(32<<8)>>8);
                 u->Counter = (RANDOM_P2(2048<<5)>>5);
 
-                nx = sintable[NORM_ANGLE(sp->ang+512)]>>6;
-                ny = sintable[sp->ang]>>6;
+                nx = bcos(sp->ang, -6);
+                ny = bsin(sp->ang, -6);
                 move_missile(SpriteNum, nx, ny, 0, Z(8), Z(8), CLIPMASK_MISSILE, MISSILEMOVETICS);
 
                 if (RANDOM_P2(1024)<700)
@@ -3897,9 +3897,8 @@ DoVomit(short SpriteNum)
     USERp u = User[SpriteNum];
 
     u->Counter = NORM_ANGLE(u->Counter + (30*MISSILEMOVETICS));
-    sp->xrepeat = u->sx + ((12 * sintable[NORM_ANGLE(u->Counter+512)]) >> 14);
-    sp->yrepeat = u->sy + ((12 * sintable[u->Counter]) >> 14);
-
+    sp->xrepeat = u->sx + mulscale14(12, bcos(u->Counter));
+    sp->yrepeat = u->sy + mulscale14(12, bsin(u->Counter));
     if (TEST(u->Flags, SPR_JUMPING))
     {
         DoJump(SpriteNum);
@@ -3948,8 +3947,8 @@ DoVomit(short SpriteNum)
     USERp u = User[SpriteNum];
 
     u->Counter = NORM_ANGLE(u->Counter + (30*MISSILEMOVETICS));
-    sp->xrepeat = u->sx + ((12 * sintable[NORM_ANGLE(u->Counter+512)]) >> 14);
-    sp->yrepeat = u->sy + ((12 * sintable[u->Counter]) >> 14);
+    sp->xrepeat = u->sx + mulscale14(12, bcos(u->Counter));
+    sp->yrepeat = u->sy + mulscale14(12, bsin(u->Counter));
 
     if (TEST(u->Flags, SPR_JUMPING))
     {
@@ -4684,9 +4683,9 @@ WeaponMoveHit(short SpriteNum)
         // on walls, so look with hitscan
 
         hitscan((vec3_t *)sp, sp->sectnum,   // Start position
-                sintable[NORM_ANGLE(sp->ang + 512)],    // X vector of 3D ang
-                sintable[NORM_ANGLE(sp->ang)],  // Y vector of 3D ang
-                sp->zvel,               // Z vector of 3D ang
+                bcos(sp->ang),    // X vector of 3D ang
+                bsin(sp->ang),    // Y vector of 3D ang
+                sp->zvel,         // Z vector of 3D ang
                 &hitinfo, CLIPMASK_MISSILE);
 
         if (hitinfo.sect < 0)
@@ -8821,9 +8820,9 @@ void WallBounce(short SpriteNum, short ang)
     u->bounce++;
 
     //k = cos(ang) * sin(ang) * 2
-    k = mulscale13(sintable[NORM_ANGLE(ang+512)], sintable[ang]);
+    k = mulscale13(bcos(ang), bsin(ang));
     //l = cos(ang * 2)
-    l = sintable[NORM_ANGLE((ang*2)+512)];
+    l = bcos(ang << 1);
 
     dax = -u->xchange;
     day = -u->ychange;
@@ -8893,8 +8892,8 @@ bool SlopeBounce(short SpriteNum, bool *hit_wall)
     // k is now the slope of the ceiling or floor
 
     // normal vector of the slope
-    dax = mulscale14(slope, sintable[(daang)&2047]);
-    day = mulscale14(slope, sintable[(daang+1536)&2047]);
+    dax = mulscale14(slope, bsin(daang));
+    day = mulscale14(slope, -bcos(daang));
     daz = 4096; // 4096 = 45 degrees
 
     // reflection code
@@ -11716,9 +11715,9 @@ InitMineShrap(short SpriteNum)
         daz -= DIV2(Z(48)<<3);
 
         FAFhitscan(sp->x, sp->y, sp->z - Z(30), sp->sectnum,   // Start position
-                   sintable[NORM_ANGLE(ang + 512)],        // X vector of 3D ang
-                   sintable[NORM_ANGLE(ang)],              // Y vector of 3D ang
-                   daz,                                    // Z vector of 3D ang
+                   bcos(ang),        // X vector of 3D ang
+                   bsin(ang),        // Y vector of 3D ang
+                   daz,              // Z vector of 3D ang
                    &hitinfo, CLIPMASK_MISSILE);
 
         if (hitinfo.sect < 0)
@@ -12310,8 +12309,8 @@ DoBloodWorm(int16_t Weapon)
 
     ang = NORM_ANGLE(sp->ang + 512);
 
-    xvect = sintable[NORM_ANGLE(ang+512)];
-    yvect = sintable[ang];
+    xvect = bcos(ang);
+    yvect = bsin(ang);
 
     bx = sp->x;
     by = sp->y;
@@ -12423,8 +12422,8 @@ DoBloodWorm(int16_t Weapon)
 
     ang = NORM_ANGLE(sp->ang + 512);
 
-    xvect = sintable[NORM_ANGLE(ang+512)];
-    yvect = sintable[ang];
+    xvect = bcos(ang);
+    yvect = bsin(ang);
 
     bx = sp->x;
     by = sp->y;
@@ -12825,8 +12824,8 @@ DoRing(int16_t Weapon)
     sp->ang = NORM_ANGLE(sp->ang + (4 * RINGMOVETICS) + RINGMOVETICS);
 
     // put it out there
-    sp->x += ((int) u->Dist * (int) sintable[NORM_ANGLE(sp->ang + 512)]) >> 14;
-    sp->y += ((int) u->Dist * (int) sintable[sp->ang]) >> 14;
+    sp->x += mulscale14(u->Dist, bcos(sp->ang));
+    sp->y += mulscale14(u->Dist, bsin(sp->ang));
     if (User[sp->owner]->PlayerP)
         sp->z += (u->Dist * (-pp->horizon.horiz.asq16() >> 9)) >> 9;
 
@@ -12913,8 +12912,8 @@ InitSpellRing(PLAYERp pp)
         //SET(u->Flags, SPR_XFLIP_TOGGLE);
 
         // put it out there
-        sp->x += ((int) u->Dist * (int) sintable[NORM_ANGLE(sp->ang + 512)]) >> 14;
-        sp->y += ((int) u->Dist * (int) sintable[sp->ang]) >> 14;
+        sp->x += mulscale14(u->Dist, bcos(sp->ang));
+        sp->y += mulscale14(u->Dist, bsin(sp->ang));
         sp->z = pp->posz + Z(20) + ((u->Dist * (-pp->horizon.horiz.asq16() >> 9)) >> 9);
 
         sp->ang = NORM_ANGLE(sp->ang + 512);
@@ -12975,8 +12974,8 @@ DoSerpRing(int16_t Weapon)
         sp->ang = NORM_ANGLE(sp->ang - (28 * RINGMOVETICS));
 
     // put it out there
-    sp->x += ((int) u->Dist * (int) sintable[NORM_ANGLE(u->slide_ang + 512)]) >> 14;
-    sp->y += ((int) u->Dist * (int) sintable[u->slide_ang]) >> 14;
+    sp->x += mulscale14(u->Dist, bcos(u->slide_ang));
+    sp->y += mulscale14(u->Dist, bsin(u->slide_ang));
 
     setsprite(Weapon, (vec3_t *)sp);
 
@@ -13228,8 +13227,8 @@ InitSerpRing(short SpriteNum)
         nu->spal = np->pal = 27; // Bright Green
 
         // put it out there
-        np->x += ((int) nu->Dist * (int) sintable[NORM_ANGLE(np->ang + 512)]) >> 14;
-        np->y += ((int) nu->Dist * (int) sintable[np->ang]) >> 14;
+        np->x += mulscale14(nu->Dist, bcos(np->ang));
+        np->y += mulscale14(nu->Dist, bsin(np->ang));
         np->z = SPRITEp_TOS(sp) + Z(20);
 
         np->ang = NORM_ANGLE(np->ang + 512);
@@ -13764,9 +13763,9 @@ InitSwordAttack(PLAYERp pp)
         daz = -mulscale16(pp->horizon.horiz.asq16(), 2000) + (RANDOM_RANGE(24000) - 12000);
 
         FAFhitscan(pp->posx, pp->posy, pp->posz, pp->cursectnum,       // Start position
-                   sintable[NORM_ANGLE(daang + 512)],      // X vector of 3D ang
-                   sintable[NORM_ANGLE(daang)],    // Y vector of 3D ang
-                   daz,                            // Z vector of 3D ang
+                   bcos(daang),      // X vector of 3D ang
+                   bsin(daang),      // Y vector of 3D ang
+                   daz,              // Z vector of 3D ang
                    &hitinfo, CLIPMASK_MISSILE);
 
         if (hitinfo.sect < 0)
@@ -13955,9 +13954,9 @@ InitFistAttack(PLAYERp pp)
         daz = -mulscale16(pp->horizon.horiz.asq16(), 2000) + (RANDOM_RANGE(24000) - 12000);
 
         FAFhitscan(pp->posx, pp->posy, pp->posz, pp->cursectnum,       // Start position
-                   sintable[NORM_ANGLE(daang + 512)],      // X vector of 3D ang
-                   sintable[NORM_ANGLE(daang)],    // Y vector of 3D ang
-                   daz,                            // Z vector of 3D ang
+                   bcos(daang),      // X vector of 3D ang
+                   bsin(daang),      // Y vector of 3D ang
+                   daz,              // Z vector of 3D ang
                    &hitinfo, CLIPMASK_MISSILE);
 
         if (hitinfo.sect < 0)
@@ -14461,8 +14460,8 @@ AimHitscanToTarget(SPRITEp sp, int *z, short *ang, int z_ratio)
     {
         zh = SPRITEp_UPPER(hp);
 
-        xvect = sintable[NORM_ANGLE(*ang + 512)];
-        yvect = sintable[NORM_ANGLE(*ang)];
+        xvect = bcos(*ang);
+        yvect = bsin(*ang);
 
         if (hp->x - sp->x != 0)
             //*z = xvect * ((zh - *z)/(hp->x - sp->x));
@@ -14523,8 +14522,8 @@ WeaponAutoAimHitscan(SPRITEp sp, int *z, short *ang, bool test)
         {
             zh = SPRITEp_TOS(hp) + DIV4(SPRITEp_SIZE_Z(hp));
 
-            xvect = sintable[NORM_ANGLE(*ang + 512)];
-            yvect = sintable[NORM_ANGLE(*ang)];
+            xvect = bcos(*ang);
+            yvect = bsin(*ang);
 
             if (hp->x - sp->x != 0)
                 //*z = xvect * ((zh - *z)/(hp->x - sp->x));
@@ -14562,8 +14561,8 @@ WeaponHitscanShootFeet(SPRITEp sp, SPRITEp hp, int *zvect)
         zh = SPRITEp_BOS(hp) + Z(20);
         z = sp->z;
 
-        xvect = sintable[NORM_ANGLE(ang + 512)];
-        yvect = sintable[NORM_ANGLE(ang)];
+        xvect = bcos(ang);
+        yvect = bsin(ang);
 
         if (hp->x - sp->x != 0)
             //*z = xvect * ((zh - *z)/(hp->x - sp->x));
@@ -14988,8 +14987,8 @@ InitShotgun(PLAYERp pp)
             ndaang = NORM_ANGLE(daang + (RANDOM_RANGE(70) - 30));
         }
 
-        xvect = sintable[NORM_ANGLE(ndaang + 512)];
-        yvect = sintable[NORM_ANGLE(ndaang)];
+        xvect = bcos(ndaang);
+        yvect = bsin(ndaang);
         zvect = ndaz;
         FAFhitscan(nx, ny, nz, nsect,               // Start position
                    xvect, yvect, zvect,
@@ -16105,9 +16104,9 @@ WallSpriteInsideSprite(SPRITEp wsp, SPRITEp sp)
         xoff = -xoff;
 
     // x delta
-    dax = sintable[wsp->ang] * wsp->xrepeat;
+    dax = bsin(wsp->ang) * wsp->xrepeat;
     // y delta
-    day = sintable[NORM_ANGLE(wsp->ang + 1024 + 512)] * wsp->xrepeat;
+    day = -bcos(wsp->ang) * wsp->xrepeat;
 
     xsiz = tilesiz[wsp->picnum].x;
     mid_dist = DIV2(xsiz) + xoff;
@@ -17081,8 +17080,8 @@ InitCoolgFire(short SpriteNum)
     wu->ychange = MOVEy(wp->xvel, wp->ang);
     wu->zchange = wp->zvel;
 
-    nx = ((int) 728 * (int) sintable[NORM_ANGLE(nang + 512)]) >> 14;
-    ny = ((int) 728 * (int) sintable[nang]) >> 14;
+    nx = mulscale14(728, bcos(nang));
+    ny = mulscale14(728, bsin(nang));
 
     move_missile(w, nx, ny, 0L, wu->ceiling_dist, wu->floor_dist, 0, 3L);
 
@@ -17734,9 +17733,9 @@ int SpawnWallHole(short hit_sect, short hit_wall, int hit_x, int hit_y, int hit_
 
     sp->ang = NORM_ANGLE(wall_ang + 1024);
 
-//    int nx,ny;
-    //nx = (sintable[(512 + Player[0].angle.ang.asbuild()) & 2047] >> 7);
-    //ny = (sintable[Player[0].angle.ang.asbuild()] >> 7);
+    //int nx,ny;
+    //nx = Player[0].angle.ang.bcos(-7);
+    //ny = Player[0].angle.ang.bsin(-7);
     //sp->x -= nx;
     //sp->y -= ny;
 
@@ -17764,12 +17763,12 @@ HitscanSpriteAdjust(short SpriteNum, short hit_wall)
 #endif
 
 #if 0
-    xvect = (sintable[(512 + ang) & 2047] >> 7);
-    yvect = (sintable[ang] >> 7);
+    xvect = bcos(ang, -7);
+    yvect = bsin(ang, -7);
     move_missile(SpriteNum, xvect, yvect, 0L, CEILING_DIST, FLOOR_DIST, CLIPMASK_MISSILE, 4L);
 #else
-    xvect = sintable[(512 + ang) & 2047] << 4;
-    yvect = sintable[ang] << 4;
+    xvect = bcos(ang, 4);
+    yvect = bsin(ang, 4);
 
     clipmoveboxtracenum = 1;
 
@@ -17848,8 +17847,8 @@ InitUzi(PLAYERp pp)
     }
 
 
-    xvect = sintable[NORM_ANGLE(daang + 512)];
-    yvect = sintable[NORM_ANGLE(daang)];
+    xvect = bcos(daang);
+    yvect = bsin(daang);
     zvect = daz;
     FAFhitscan(pp->posx, pp->posy, nz, pp->cursectnum,       // Start position
                xvect,yvect,zvect,
@@ -18034,9 +18033,9 @@ InitEMP(PLAYERp pp)
     }
 
     FAFhitscan(pp->posx, pp->posy, nz, pp->cursectnum,       // Start position
-               sintable[NORM_ANGLE(daang + 512)],      // X vector of 3D ang
-               sintable[NORM_ANGLE(daang)],    // Y vector of 3D ang
-               daz,                            // Z vector of 3D ang
+               bcos(daang),      // X vector of 3D ang
+               bsin(daang),      // Y vector of 3D ang
+               daz,              // Z vector of 3D ang
                &hitinfo, CLIPMASK_MISSILE);
 
     j = SpawnSprite(STAT_MISSILE, EMP, s_EMPBurst, hitinfo.sect, hitinfo.pos.x, hitinfo.pos.y, hitinfo.pos.z, daang, 0);
@@ -18585,9 +18584,9 @@ InitSobjMachineGun(short SpriteNum, PLAYERp pp)
     }
 
     FAFhitscan(nx, ny, nz, nsect,       // Start position
-               sintable[NORM_ANGLE(daang + 512)],      // X vector of 3D ang
-               sintable[NORM_ANGLE(daang)],    // Y vector of 3D ang
-               daz,                            // Z vector of 3D ang
+               bcos(daang),      // X vector of 3D ang
+               bsin(daang),      // Y vector of 3D ang
+               daz,              // Z vector of 3D ang
                &hitinfo, CLIPMASK_MISSILE);
 
     if (hitinfo.sect < 0)
@@ -18997,8 +18996,8 @@ InitTurretMgun(SECTOR_OBJECTp sop)
                 }
             }
 
-            xvect = sintable[NORM_ANGLE(daang + 512)];
-            yvect = sintable[NORM_ANGLE(daang)];
+            xvect = bcos(daang);
+            yvect = bsin(daang);
             zvect = daz;
 
             FAFhitscan(nx, ny, nz, nsect,       // Start position
@@ -19146,9 +19145,9 @@ InitEnemyUzi(short SpriteNum)
     }
 
     FAFhitscan(sp->x, sp->y, sp->z - zh, sp->sectnum,      // Start position
-               sintable[NORM_ANGLE(daang + 512)],      // X vector of 3D ang
-               sintable[NORM_ANGLE(daang)],    // Y vector of 3D ang
-               daz,                            // Z vector of 3D ang
+               bcos(daang),      // X vector of 3D ang
+               bsin(daang),      // Y vector of 3D ang
+               daz,              // Z vector of 3D ang
                &hitinfo, CLIPMASK_MISSILE);
 
     if (hitinfo.sect < 0)
@@ -19486,7 +19485,7 @@ InitMine(PLAYERp pp)
     wu->xchange = MOVEx(wp->xvel, wp->ang);
     wu->ychange = MOVEy(wp->xvel, wp->ang);
 
-    dot = DOT_PRODUCT_2D(pp->xvect, pp->yvect, sintable[NORM_ANGLE(pp->angle.ang.asbuild()+512)], sintable[pp->angle.ang.asbuild()]);
+    dot = DOT_PRODUCT_2D(pp->xvect, pp->yvect, pp->angle.ang.bcos(), pp->angle.ang.bsin());
 
     // don't adjust for strafing
     if (labs(dot) > 10000)
@@ -20632,8 +20631,8 @@ int QueueHole(short hit_sect, short hit_wall, int hit_x, int hit_y, int hit_z)
     sp->ang = wall_ang;
 
     // move it back some
-    nx = sintable[(512 + sp->ang) & 2047]<<4;
-    ny = sintable[sp->ang]<<4;
+    nx = bcos(sp->ang, 4);
+    ny = bsin(sp->ang, 4);
 
     sectnum = sp->sectnum;
 
@@ -20876,9 +20875,9 @@ int QueueWallBlood(short hit_sprite, short ang)
     dang = (ang+(RANDOM_P2(128<<5) >> 5)) - DIV2(128);
 
     FAFhitscan(hsp->x, hsp->y, hsp->z - Z(30), hsp->sectnum,    // Start position
-               sintable[NORM_ANGLE(dang + 512)],  // X vector of 3D ang
-               sintable[NORM_ANGLE(dang)],                             // Y vector of 3D ang
-               daz,                                                    // Z vector of 3D ang
+               bcos(dang),      // X vector of 3D ang
+               bsin(dang),      // Y vector of 3D ang
+               daz,              // Z vector of 3D ang
                &hitinfo, CLIPMASK_MISSILE);
 
     if (hitinfo.sect < 0)
@@ -20951,8 +20950,8 @@ int QueueWallBlood(short hit_sprite, short ang)
     sp->ang = wall_ang;
 
     // move it back some
-    nx = sintable[(512 + sp->ang) & 2047]<<4;
-    ny = sintable[sp->ang]<<4;
+    nx = bcos(sp->ang, 4);
+    ny = bsin(sp->ang, 4);
 
     sectnum = sp->sectnum;
 


### PR DESCRIPTION
PR'ing this on the back of previous discussions.

* Wrap `sintable[]` access with shift-aware inline functions `bsin()` and `bcos()`. Example: `sintable[ang & 2047] >> 2` -> `bsin(ang, -2)`.
* Define `bsinf()` and `bcosf()` as double-precision Build sine/cosine functions with shift awareness and to replace `calcSinTableValue()`.
* Replace `sintable[]` access within all games with `bsin()` and `bcos()`.
* Replace `Sin()` and `Cos()` within Exhumed with `bsin()` and `bcos()`.
* Define double precision `getangle()` function as `bvectangf()`.
* Define inline conversion wrappers for `bvectangf()` to Build, Q16.16 and BAM scaling.
* Define function `getincangbam()` to avoid scaling BAM angles to Q16.16 game-side.
* Refine multiple overloads for `PlayerAngle` struct method `addadjustment()` and remove game-side format conversions to accomodate previous single method overload.
* Repeat of above for `PlayerAngle` struct method `settarget()`.