### PR TITLE
[Blood] Fix negative priority event processing, fix sector path markers not working

### DIFF
--- a/source/blood/src/eventq.cpp
+++ b/source/blood/src/eventq.cpp
@@ -557,7 +557,7 @@ void evKill(int index, int type, CALLBACK_ID cb)
 
 void evProcess(unsigned int time)
 {
-	while (queue.size() > 0 && time >= queue.begin()->priority)
+	while (queue.size() > 0 && (int)time >= queue.begin()->priority)
 	{
 		EVENT event = *queue.begin();
 		queue.erase(queue.begin());

--- a/source/blood/src/triggers.cpp
+++ b/source/blood/src/triggers.cpp
@@ -1498,7 +1498,7 @@ void OperatePath(unsigned int nSector, XSECTOR *pXSector, EVENT event)
     spritetype *pSprite2 = &sprite[pXSector->marker0];
     XSPRITE *pXSprite2 = &xsprite[pSprite2->extra];
     int nId = pXSprite2->data2;
-    StatIterator it(kStatMarker);
+    StatIterator it(kStatPathMarker);
     while ((nSprite = it.NextIndex()) >= 0)
     {
         pSprite = &sprite[nSprite];
@@ -1652,7 +1652,7 @@ void InitPath(unsigned int nSector, XSECTOR *pXSector)
     XSPRITE *pXSprite;
     assert(nSector < (unsigned int)numsectors);
     int nId = pXSector->data;
-    StatIterator it(kStatMarker);
+    StatIterator it(kStatPathMarker);
     while ((nSprite = it.NextIndex()) >= 0)
     {
         pSprite = &sprite[nSprite];


### PR DESCRIPTION
This PR fixes two following bugs:
1. Sectors that move through a path (sector type 612) do not work, due to path markers (sprite type 15) being looked for in the wrong statlist.
2. Events with negative priority break map event queue processing, completely preventing any map events from being handled.

During map initialization, some sprites can add an event with negative priority, for example, [general trigger (sprite type 700)](https://github.com/coelckers/Raze/blob/master/source/blood/src/triggers.cpp#L2216), or water/blood drip (sprite type 701/702). Despite being highest priority events, [comparison with with the game timer](https://github.com/coelckers/Raze/blob/master/source/blood/src/eventq.cpp#L560) returns false even at tick 0 due to an implicit unsigned cast, which stops event processing dead in its tracks and prevents any map events from ever being processed. This breaks a lot of maps.

I attached a small test map that reproduces both of these bugs. In the map, pressing the switch should cause the platform to move between 3 path markers. The map also contains many water drip sprites, some of which add a negative priority event to the queue. Without the bugfixes, the water drip effect never plays, and the platform doesn't activate. With the statnum fix, the platform moves to the first path marker and stops, since the broken event queue prevents the next move in sequence. With both fixes, the behavior is identical to DOS Blood and BloodGDX.

[PATHTEST.zip](https://github.com/coelckers/Raze/files/5757539/PATHTEST.zip)
