### PR TITLE
Enable SoftPoly renderer backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,9 +207,9 @@ if( MSVC )
 	# Function-level linking
 	# Disable run-time type information
 	if ( HAVE_VULKAN )
-		set( ALL_C_FLAGS "/GF /Gy /permissive- /DHAVE_VULKAN" )
+		set( ALL_C_FLAGS "/GF /Gy /permissive- /DHAVE_SOFTPOLY /DHAVE_VULKAN" )
 	else()
-		set( ALL_C_FLAGS "/GF /Gy /permissive-" )
+		set( ALL_C_FLAGS "/GF /Gy /permissive- /DHAVE_SOFTPOLY" )
 	endif()
 
 	# Use SSE 2 as minimum always as the true color drawers needs it for __vectorcall
@@ -253,9 +253,9 @@ if( MSVC )
 else()
 	set( REL_LINKER_FLAGS "" )
 	if ( HAVE_VULKAN )
-		set( ALL_C_FLAGS "-ffp-contract=off -DHAVE_VULKAN" )
+		set( ALL_C_FLAGS "-ffp-contract=off -DHAVE_SOFTPOLY -DHAVE_VULKAN" )
 	else()
-		set( ALL_C_FLAGS "-ffp-contract=off" )
+		set( ALL_C_FLAGS "-ffp-contract=off -DHAVE_SOFTPOLY" )
 	endif()
 	set( ALL_C_FLAGS "${ALL_C_FLAGS} -DUSE_OPENGL=1 -DNOASM=1" )
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -709,6 +709,7 @@ set( POLYRENDER_SOURCES
 # without being compiled.
 set( NOT_COMPILED_SOURCE_FILES
 	${OTHER_SYSTEM_SOURCES}
+	${POLYRENDER_SOURCES}
 	sc_man_scanner.h
 	common/engine/sc_man_scanner.re
 	common/scripting/frontend/zcc-parse.lemon
@@ -964,6 +965,7 @@ set( VM_JIT_SOURCES
 set( FASTMATH_SOURCES
 
 	common/rendering/gl_load/gl_load.c
+	common/rendering/polyrenderer/poly_all.cpp
 	common/textures/hires/hqnx/init.cpp
 	common/textures/hires/hqnx/hq2x.cpp
 	common/textures/hires/hqnx/hq3x.cpp
@@ -1014,7 +1016,7 @@ set (POLYBACKEND_SOURCES
 	common/rendering/polyrenderer/backend/poly_hwtexture.cpp
 	common/rendering/polyrenderer/backend/poly_renderstate.cpp
 )
-set (FASTMATH_SOURCES ${FASTMATH_SOURCES})
+set (FASTMATH_SOURCES ${FASTMATH_SOURCES} ${POLYBACKEND_SOURCES})
 
 set (PCH_SOURCES
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1492,7 +1492,7 @@ OptionValue PreferBackend
 	0, "$OPTVAL_OPENGL"
 	1, "$OPTVAL_VULKAN"
 	// Enable when HAVE_SOFTPOLY will be defined
-	//2, "$OPTVAL_SOFTPOLY"
+	2, "$OPTVAL_SOFTPOLY"
 }
 
 OptionMenu VideoModeMenu protected


### PR DESCRIPTION
This PR enables the SoftPoly renderer backend for Raze.

It seems to work fine for the most part but there are a couple of issues I have noticed so far:

1. Palette emulation mode is really broken (everything displayed in the level is distorted/garbled/corrupted but 2D is fine).
2. Dark areas are too dark.
3. Fade in/outs aren't working.
4. Crosshair will disappear at lower resolutions (also happening with GZDoom).
5. Voxel rendering is really, really slow (also seems to be an issue with other renderer backends with FPS getting 6 times low but still maintaining 60+ FPS).

Marking this as draft unless @dpjudas considers this ready.