### PR TITLE
Another attempt to fix SerializeMemory

### DIFF
--- a/source/common/engine/serializer.cpp
+++ b/source/common/engine/serializer.cpp
@@ -784,6 +784,7 @@ FSerializer &FSerializer::SerializeMemory(const char *key, void* mem, size_t len
 	if (isWriting())
 	{
 		auto array = base64_encode((const uint8_t*)mem, length);
+		array.Push(0); // Ensure no out-of-bounds accesses occur
 		AddString(key, (const char*)array.Data());
 	}
 	else


### PR DESCRIPTION
Add a null byte to the end of the base64-encoded text so that MakeUTF8 doesn't keep reading memory it shouldn't.

Alternative to #363 