### PR TITLE
Destroy FStartupScreen before initializing video

### DIFF
--- a/source/core/gamecontrol.cpp
+++ b/source/core/gamecontrol.cpp
@@ -1013,6 +1013,7 @@ int RunGame()
 	lookups.postLoadLookups();
 	FMaterial::SetLayerCallback(setpalettelayer);
 	if (GameStartupInfo.Name.IsNotEmpty()) I_SetWindowTitle(GameStartupInfo.Name);
+	DeleteStartupScreen();
 
 	V_Init2();
 	twod->Begin(screen->GetWidth(), screen->GetHeight());


### PR DESCRIPTION
Fixes terminal output cutoff on console tab completion on Unix systems.