### PR TITLE
Fix buffer overflow at maploader.cpp:392

### DIFF
--- a/source/build/include/build.h
+++ b/source/build/include/build.h
@@ -146,7 +146,7 @@ struct usermaphack_t
 };
 
 extern spriteext_t spriteext[MAXSPRITES];
-extern spritesmooth_t spritesmooth[MAXSPRITES];
+extern spritesmooth_t spritesmooth[MAXSPRITES + MAXUNIQHUDID];
 
 extern sectortype sector[MAXSECTORS];
 extern walltype wall[MAXWALLS];

--- a/source/build/src/engine.cpp
+++ b/source/build/src/engine.cpp
@@ -42,7 +42,7 @@
 #endif
 
 spriteext_t spriteext[MAXSPRITES];
-spritesmooth_t spritesmooth[MAXSPRITES];
+spritesmooth_t spritesmooth[MAXSPRITES + MAXUNIQHUDID];
 
 sectortype sector[MAXSECTORS];
 walltype wall[MAXWALLS];


### PR DESCRIPTION
A memset exceeded the array bounds.  I assumed the memset was correct and expanded the array.