### PR TITLE
Display game data path when no game data files are found

### DIFF
--- a/source/core/gamecontrol.cpp
+++ b/source/core/gamecontrol.cpp
@@ -654,7 +654,11 @@ static TArray<GrpEntry> SetupGame()
 	{
 		// Abort if no game data found.
 		G_SaveConfig();
-		I_Error("Unable to find any game data. Please verify your settings.");
+		I_Error("Unable to find any game data. Please verify your settings.\n"
+		"Install game data files in subfolders of: " + M_GetAppDataPath(false) + "\n\n"
+		"For example, you can create a 'duke' folder inside the above folder\n"
+		"and place DUKE3D.GRP and DUKE.RTS (case-insensitive) in the 'duke' folder.\n"
+		"Subfolders can have any name. The name has no bearing on game recognition.");
 	}
 
 	decltype(groups) usedgroups;


### PR DESCRIPTION
This helps users find the location where they should place game data files.

This implementation isn't great, but it likely does the job well enough. That said, it would be more convenient if `.GRP`/`.RTS` files could be dropped into the top-level folder insted of having to create a subfolder.

This closes https://github.com/coelckers/Raze/issues/434.

## Preview (Linux + KDE)

![image](https://user-images.githubusercontent.com/180032/122472079-62038380-cfc0-11eb-8602-24b1200b5f86.png)
