### PR TITLE
Fix so small font is displayed correctly

### DIFF
--- a/source/core/razefont.cpp
+++ b/source/core/razefont.cpp
@@ -227,5 +227,5 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Raze, PickSmallFont, PickSmallFont_)
 	PARAM_PROLOGUE;
 	PARAM_STRING(text);
 	//PARAM_POINTER(cr, int);
-	ACTION_RETURN_POINTER(PickBigFont(text));
+	ACTION_RETURN_POINTER(PickSmallFont(text));
 }


### PR DESCRIPTION
Bug fix for small fonts on ARM when using Clang. Not sure why it seems to work on Windows builds without this fix.