### PR TITLE
Remove useless code introduced in bad17f29

### DIFF
--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -2699,10 +2699,6 @@ static int32_t polymost_lintersect(int32_t x1, int32_t y1, int32_t x2, int32_t y
 #define TSPR_OFFSET_FACTOR .0002f
 #define TSPR_OFFSET(tspr) (TSPR_OFFSET_FACTOR + ((tspr->owner != -1 ? tspr->owner & 63 : 0) * TSPR_OFFSET_FACTOR))
 
-#define TSPR_OFFSET_FACTOR2 .000008f
-#define TSPR_OFFSET2(tspr) ((TSPR_OFFSET_FACTOR + ((tspr->owner != -1 ? tspr->owner & 63 : 1) * TSPR_OFFSET_FACTOR)) * (float)sepdist(globalposx - tspr->x, globalposy - tspr->y, globalposz - tspr->z) * 0.025f)
-
-
 void polymost_drawsprite(int32_t snum)
 {
     auto const tspr = tspriteptr[snum];
@@ -2814,8 +2810,6 @@ void polymost_drawsprite(int32_t snum)
             int const ang = (getangle(tspr->x - globalposx, tspr->y - globalposy) + 1024) & 2047;
 
             float foffs = TSPR_OFFSET(tspr);
-            float foffs2 = TSPR_OFFSET(tspr);
-			if (fabs(foffs2) < fabs(foffs)) foffs = foffs2;
 
             vec2f_t const offs = { float(bcosf(ang, -6) * foffs), float(bsinf(ang, -6) * foffs) };
 


### PR DESCRIPTION
This never actually did what it was supposed to. The function `sepdist()` has also been removed since.