### PR TITLE
Add cvars to control automap line alpha and thickness

### DIFF
--- a/source/core/automap.cpp
+++ b/source/core/automap.cpp
@@ -49,6 +49,8 @@ Modifications for JonoF's port by Jonathon Fowler (jf@jonof.id.au)
 
 CVAR(Bool, am_followplayer, true, CVAR_ARCHIVE)
 CVAR(Bool, am_rotate, true, CVAR_ARCHIVE)
+CVAR(Float, am_linealpha, 1.0f, CVAR_ARCHIVE)
+CVAR(Int, am_linethickness, 1, CVAR_ARCHIVE)
 CVAR(Bool, am_textfont, false, CVAR_ARCHIVE)
 CVAR(Bool, am_showlabel, false, CVAR_ARCHIVE)
 CVAR(Bool, am_nameontop, false, CVAR_ARCHIVE)
@@ -322,7 +324,12 @@ void MarkSectorSeen(int i)
 
 void drawlinergb(int32_t x1, int32_t y1, int32_t x2, int32_t y2, PalEntry p)
 {
-	twod->AddLine(x1 / 4096.f, y1 / 4096.f, x2 / 4096.f, y2 / 4096.f, windowxy1.x, windowxy1.y, windowxy2.x, windowxy2.y, p);
+	if (am_linethickness >= 2) {
+		twod->AddThickLine(x1 / 4096.f, y1 / 4096.f, x2 / 4096.f, y2 / 4096.f, am_linethickness, p, uint8_t(am_linealpha * 255));
+	} else {
+		// Use more efficient thin line drawing routine.
+		twod->AddLine(x1 / 4096.f, y1 / 4096.f, x2 / 4096.f, y2 / 4096.f, windowxy1.x, windowxy1.y, windowxy2.x, windowxy2.y, p, uint8_t(am_linealpha * 255));
+	}
 }
 
 //---------------------------------------------------------------------------

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1147,6 +1147,8 @@ OptionMenu "AutomapOptions"
 	StaticText ""
 	Option "$AUTOMAPMNU_ROTATE",				"am_rotate",					"OnOff"
 	Option "$AUTOMAPMNU_FOLLOW",				"am_followplayer",				"OnOff"
+	Slider "$AUTOMAPMNU_LINEALPHA",				"am_linealpha", 0.1, 1.0, 0.1, 1
+	Slider "$AUTOMAPMNU_LINETHICKNESS",			"am_linethickness", 1, 8, 1, 0
 
 	// todo:
 	//CVAR(Bool, am_textfont, false, CVAR_ARCHIVE)


### PR DESCRIPTION
Raze port of https://github.com/coelckers/gzdoom/pull/1429. Works with the same cvars and menu options.

This can be used to improve automap readability on high-resolution displays.

## Preview