### PR TITLE
Fix blood voxels when loading voxel pack

### DIFF
--- a/source/core/gamecontrol.cpp
+++ b/source/core/gamecontrol.cpp
@@ -895,7 +895,6 @@ static void InitTextures()
 	TileFiles.LoadArtSet("tiles%03d.art"); // it's the same for all games.
 	voxInit();
 	gi->LoadGameTextures(); // loads game-side data that must be present before processing the .def files.
-	LoadDefinitions();
 	InitFont();				// InitFonts may only be called once all texture data has been initialized.
 
 	lookups.postLoadTables();

--- a/source/games/blood/src/blood.cpp
+++ b/source/games/blood/src/blood.cpp
@@ -426,7 +426,7 @@ void GameInterface::app_init()
 	tileInit();
 
 	levelLoadDefaults();
-
+	LoadDefinitions();
 	//---------
 	SetTileNames();
 	C_InitConback(TexMan.CheckForTexture("BACKTILE", ETextureType::Any), true, 0.25);


### PR DESCRIPTION
I don't think this is the correct fix but might be a clue to fix the regression when loading Voxel pack in Blood:
https://github.com/fgsfds/Blood-Voxel-Pack

Without it the voxels are all random.

Issue here: https://github.com/coelckers/Raze/issues/422
