### PR TITLE
Pass the missing fullscreen flag when creating a Vukan window.

### DIFF
--- a/source/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/source/common/platform/posix/sdl/sdlglvideo.cpp
@@ -408,7 +408,7 @@ SDLVideo::SDLVideo ()
 
 	if (Priv::vulkanEnabled)
 	{
-		Priv::CreateWindow(Priv::VulkanWindowFlag | SDL_WINDOW_HIDDEN);
+		Priv::CreateWindow(Priv::VulkanWindowFlag | SDL_WINDOW_HIDDEN | (vid_fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0));
 
 		if (Priv::window == nullptr)
 		{


### PR DESCRIPTION
This is necessary so the in-use resolution is used as the window size for Vulkan windows when they are fullscreen.
This is already done in GL windows, it's just that this flag was missing from Vulkan windows.
It's specially important because Vulkan on KMSDRM (=no X11) only supports windows with a matching physical resolution available.