### PR TITLE
[Blood] Tweaked next/prev weapon behavior underwater

### DIFF
--- a/source/games/blood/src/weapon.cpp
+++ b/source/games/blood/src/weapon.cpp
@@ -2091,6 +2091,7 @@ void WeaponProcess(PLAYER *pPlayer) {
             return;
         break;
     }
+    const int prevNewWeaponVal = pPlayer->input.getNewWeapon(); // used to fix scroll issue for banned weapons 
     if (VanillaMode())
     {
         if (pPlayer->nextWeapon)
@@ -2202,6 +2203,25 @@ void WeaponProcess(PLAYER *pPlayer) {
     }
     if (pPlayer->newWeapon)
     {
+        if (pPlayer->isUnderwater && BannedUnderwater(pPlayer->newWeapon) && !checkFired6or7(pPlayer)) // skip banned weapons when underwater and using next/prev weapon key inputs
+        {
+            const bool next = prevNewWeaponVal == WeaponSel_Next, prev = prevNewWeaponVal == WeaponSel_Prev;
+            if ((next || prev) && !VanillaMode() && !DemoRecordStatus()) // if player switched weapons
+            {
+                PLAYER tmpPlayer = *pPlayer;
+                tmpPlayer.curWeapon = pPlayer->newWeapon; // set current banned weapon to curweapon so WeaponFindNext() can find the next weapon
+                for (int i = 0; i < 3; i++) // attempt twice to find a new weapon
+                {
+                    tmpPlayer.curWeapon = WeaponFindNext(&tmpPlayer, NULL, next ? 1 : 0);
+                    if (!BannedUnderwater(tmpPlayer.curWeapon)) // if new weapon is not a banned weapon, set to new current weapon
+                    {
+                        pPlayer->newWeapon = tmpPlayer.curWeapon;
+                        pPlayer->weaponMode[pPlayer->newWeapon] = 0;
+                        break;
+                    }
+                }
+            }
+        }
         if (pPlayer->newWeapon == 6)
         {
             if (pPlayer->curWeapon == 6)

--- a/source/games/blood/src/weapon.cpp
+++ b/source/games/blood/src/weapon.cpp
@@ -2091,7 +2091,7 @@ void WeaponProcess(PLAYER *pPlayer) {
             return;
         break;
     }
-    const int prevNewWeaponVal = pPlayer->input.getNewWeapon(); // used to fix scroll issue for banned weapons 
+    const int prevNewWeaponVal = pPlayer->input.getNewWeapon(); // used to fix scroll issue for banned weapons
     if (VanillaMode())
     {
         if (pPlayer->nextWeapon)
@@ -2203,16 +2203,15 @@ void WeaponProcess(PLAYER *pPlayer) {
     }
     if (pPlayer->newWeapon)
     {
-        if (pPlayer->isUnderwater && BannedUnderwater(pPlayer->newWeapon) && !checkFired6or7(pPlayer)) // skip banned weapons when underwater and using next/prev weapon key inputs
+        if (pPlayer->isUnderwater && BannedUnderwater(pPlayer->newWeapon) && !checkFired6or7(pPlayer) && !VanillaMode() && !DemoRecordStatus()) // skip banned weapons when underwater and using next/prev weapon key inputs
         {
-            const bool next = prevNewWeaponVal == WeaponSel_Next, prev = prevNewWeaponVal == WeaponSel_Prev;
-            if ((next || prev) && !VanillaMode() && !DemoRecordStatus()) // if player switched weapons
+            if (prevNewWeaponVal == WeaponSel_Next || prevNewWeaponVal == WeaponSel_Prev) // if player switched weapons
             {
                 PLAYER tmpPlayer = *pPlayer;
                 tmpPlayer.curWeapon = pPlayer->newWeapon; // set current banned weapon to curweapon so WeaponFindNext() can find the next weapon
                 for (int i = 0; i < 3; i++) // attempt twice to find a new weapon
                 {
-                    tmpPlayer.curWeapon = WeaponFindNext(&tmpPlayer, NULL, next ? 1 : 0);
+                    tmpPlayer.curWeapon = WeaponFindNext(&tmpPlayer, NULL, (char)(prevNewWeaponVal == WeaponSel_Next));
                     if (!BannedUnderwater(tmpPlayer.curWeapon)) // if new weapon is not a banned weapon, set to new current weapon
                     {
                         pPlayer->newWeapon = tmpPlayer.curWeapon;


### PR DESCRIPTION
This will fix the issues of using next/prev weapon inputs underwater. For both NBlood/Dos this issue remains intact while BloodGDX has fixed it.

When underwater it would always skip the telsa cannon and select the proxy remote when using next weapon, and when trying to pick previous weapon it'll be stuck on the telsa cannon. With this fix it'll skip over the banned weapons and keep the weapon scroll behavior the same as when on land.

https://user-images.githubusercontent.com/38839485/129360258-0c1d14c5-6752-482f-ad8c-b92d042baff0.mp4

https://user-images.githubusercontent.com/38839485/129360348-0b1bc267-08a0-4df3-8836-8fc92a9baf76.mp4

