### PR TITLE
[Blood] Fix various issues with burning enemies

### DIFF
--- a/source/games/blood/src/actor.cpp
+++ b/source/games/blood/src/actor.cpp
@@ -5734,7 +5734,6 @@ void actProcessSprites(void)
         int nXSprite = pSprite->extra;
         if (nXSprite > 0) {
             XSPRITE *pXSprite = &xsprite[nXSprite];
-            const bool fixBurnGlitch = IsBurningDude(pSprite) && !VanillaMode() && !DemoRecordStatus(); // if enemies are these types, always apply burning damage per tick
             switch (pSprite->type) {
                 case kThingBloodBits:
                 case kThingBloodChunks:
@@ -5743,7 +5742,7 @@ void actProcessSprites(void)
                     break;
             }
 
-            if ((pXSprite->burnTime > 0) || fixBurnGlitch)
+            if (pXSprite->burnTime > 0)
             {
                 pXSprite->burnTime = ClipLow(pXSprite->burnTime-4,0);
                 actDamageSprite(pXSprite->burnSource, pSprite, kDamageBurn, 8);
@@ -6189,7 +6188,8 @@ void actProcessSprites(void)
         if (nXSprite > 0)
         {
             XSPRITE *pXSprite = &xsprite[nXSprite];
-            if (pXSprite->burnTime > 0)
+            const bool fixBurnGlitch = IsBurningDude(pSprite) && !VanillaMode() && !DemoRecordStatus(); // if enemies are burning, always apply burning damage per tick
+            if ((pXSprite->burnTime > 0) || fixBurnGlitch)
             {
                 switch (pSprite->type)
                 {

--- a/source/games/blood/src/actor.cpp
+++ b/source/games/blood/src/actor.cpp
@@ -3096,7 +3096,7 @@ static bool actKillDudeStage1(DBloodActor* actor, DAMAGE_TYPE damageType)
 		if (damageType == kDamageBurn && pXSprite->medium == kMediumNormal)
 		{
 			pSprite->type = kDudeBurningTinyCaleb;
-			aiNewState(actor, &innocentBurnGoto);
+			aiNewState(actor, &tinycalebBurnGoto);
 			actHealDude(actor, dudeInfo[39].startHealth, dudeInfo[39].startHealth);
 			return true;
 		}

--- a/source/games/blood/src/ai.cpp
+++ b/source/games/blood/src/ai.cpp
@@ -1113,7 +1113,7 @@ int aiDamageSprite(DBloodActor* source, DBloodActor* actor, DAMAGE_TYPE nDmgType
                 pSprite->type = kDudeBurningInnocent;
                 if (!VanillaMode() && !DemoRecordStatus()) // fix burning sprite for tiny caleb
                     pSprite->type = kDudeBurningTinyCaleb;
-                aiNewState(actor, &cultistBurnGoto);
+                aiNewState(actor, &tinycalebBurnGoto);
                 aiPlay3DSound(pSprite, 361, AI_SFX_PRIORITY_0, -1);
                 gDudeExtra[pSprite->extra].time = PlayClock+360;
                 actHealDude(pXSprite, dudeInfo[39].startHealth, dudeInfo[39].startHealth);

--- a/source/games/blood/src/ai.cpp
+++ b/source/games/blood/src/ai.cpp
@@ -1110,10 +1110,16 @@ int aiDamageSprite(DBloodActor* source, DBloodActor* actor, DAMAGE_TYPE nDmgType
         case kDudeTinyCaleb:
             if (nDmgType == kDamageBurn && pXSprite->health <= (unsigned int)pDudeInfo->fleeHealth/* && (pXSprite->at17_6 != 1 || pXSprite->at17_6 != 2)*/)
             {
-                pSprite->type = kDudeBurningInnocent;
                 if (!VanillaMode() && !DemoRecordStatus()) // fix burning sprite for tiny caleb
+                {
                     pSprite->type = kDudeBurningTinyCaleb;
-                aiNewState(actor, &tinycalebBurnGoto);
+                    aiNewState(actor, &tinycalebBurnGoto);
+                }
+                else
+                {
+                    pSprite->type = kDudeBurningInnocent;
+                    aiNewState(actor, &cultistBurnGoto);
+                }
                 aiPlay3DSound(pSprite, 361, AI_SFX_PRIORITY_0, -1);
                 gDudeExtra[pSprite->extra].time = PlayClock+360;
                 actHealDude(pXSprite, dudeInfo[39].startHealth, dudeInfo[39].startHealth);


### PR DESCRIPTION
This PR fixes the following issues
* All cultists randomly switching between shotgun/tommy gun types when extinguished in water
* Tiny Caleb enemy using incorrectly scaled innocent burning sprite type when ignited
* Rare chance of enemies outlasting burn timer damage and locking them in a state of burning

Cultists will now restore back to their original type when extinguished in water (only if inittype is valid). This will work for all cultists types, including telsa if you manage to ignite them and let them fall in water.
Tiny Caleb will now use the unused sprite type `kDudeBurningTinyCaleb` as well as AI functions for burning tiny Caleb.
All burning enemies will have damage applied to their state every tick, even if burn time has reached zero.

All of these changes check with VanillaMode() before applying.

https://user-images.githubusercontent.com/38839485/129472717-d45b988e-11d1-4eac-8286-7050b3d69acd.mp4

