### PR TITLE
[Blood] Don't trigger fall scream if player is dead

### DIFF
--- a/source/games/blood/src/actor.cpp
+++ b/source/games/blood/src/actor.cpp
@@ -5011,8 +5011,12 @@ void MoveDude(spritetype *pSprite)
     }
     if (pPlayer && zvel[nSprite] > 0x155555 && !pPlayer->fallScream && pXSprite->height > 0)
     {
-        pPlayer->fallScream = 1;
-        sfxPlay3DSound(pSprite, 719, 0, 0);
+        const bool playerAlive = (pXSprite->health > 0) || VanillaMode() || DemoRecordStatus(); // only trigger falling scream if player is alive
+        if (playerAlive)
+	{
+            pPlayer->fallScream = 1;
+            sfxPlay3DSound(pSprite, 719, 0, 0);
+	}
     }
     vec3_t const oldpos = pSprite->pos;
     int nLink = CheckLink(pSprite);


### PR DESCRIPTION
This PR will prevent the fall scream triggering if the player has died.

https://user-images.githubusercontent.com/38839485/129496887-0340c971-d9c9-47a8-a7e6-389d7f645890.mp4


https://user-images.githubusercontent.com/38839485/129496893-348c13b1-c95c-4d42-afe2-396358cceb5c.mp4

