### PR TITLE
[Blood] Prevent missiles from self colliding on MoveMissile()

### DIFF
--- a/source/games/blood/src/actor.cpp
+++ b/source/games/blood/src/actor.cpp
@@ -5440,10 +5440,15 @@ int MoveMissile(spritetype *pSprite)
         int z = pSprite->z;
         int nSector2 = pSprite->sectnum;
         clipmoveboxtracenum = 1;
-        if ((pSprite->owner >= 0) && !isFlameSprite && !cl_bloodvanillaexplosions && !VanillaMode())
+        const short bakSpriteCstat = pSprite->cstat;
+        if (pOwner && !isFlameSprite && !cl_bloodvanillaexplosions && !VanillaMode())
+        {
             enginecompatibility_mode = ENGINECOMPATIBILITY_NONE; // improved clipmove accuracy
+            pSprite->cstat &= ~257; // remove self collisions for accurate clipmove
+        }
         int vdx = ClipMove(&x, &y, &z, &nSector2, vx, vy, pSprite->clipdist<<2, (z-top)/4, (bottom-z)/4, CLIPMASK0);
         enginecompatibility_mode = bakCompat; // restore
+        pSprite->cstat = bakSpriteCstat;
         clipmoveboxtracenum = 3;
         short nSector = nSector2;
         if (nSector2 < 0)


### PR DESCRIPTION
This PR fixes a bug introduced with the new accurate clipmove() feature.

For the bloated butchers, their kMissileButcherKnife missile attack will instantly collide with itself after spawning. This is fixed by setting the missile's collision off before calling clipmove(), and restoring cstat (like how Blood does with projectile's owner).

https://user-images.githubusercontent.com/38839485/130475800-f0479dcb-f968-4c53-8d83-46fd4cfbb754.mp4


https://user-images.githubusercontent.com/38839485/130475949-3fef2800-352a-45c5-adac-aa7ce7d484de.mp4