### PR TITLE
[Blood] Fix weapon state glitch when collecting dropped life leech

### DIFF
--- a/source/games/blood/src/misc.h
+++ b/source/games/blood/src/misc.h
@@ -43,6 +43,7 @@ void HookReplaceFunctions();
 
 struct PLAYER;
 
+bool checkFired6or7(PLAYER *pPlayer);
 void WeaponInit(void);
 void WeaponDraw(PLAYER *pPlayer, int a2, double a3, double a4, int a5);
 void WeaponRaise(PLAYER *pPlayer);

--- a/source/games/blood/src/player.cpp
+++ b/source/games/blood/src/player.cpp
@@ -978,20 +978,56 @@ char PickupItem(PLAYER *pPlayer, spritetype *pItem) {
             }
         }
         return 0;
-        case kItemFlagA:
+        case kItemFlagA: {
             if (gGameOptions.nGameType != 3) return 0;
-            evKill(pItem->index, 3, kCallbackReturnFlag);
-            pPlayer->hasFlag |= 1;
-            pPlayer->used2[0] = pItem->index;
             gBlueFlagDropped = false;
+            const bool enemyTeam = (pPlayer->teamId&1) == 1;
+            if (!enemyTeam && (pItem->owner >= 0) && (pItem->owner < kMaxSprites)) {
+                pPlayer->hasFlag &= ~1;
+                pPlayer->used2[0] = -1;
+                spritetype* pOwner = &sprite[pItem->owner];
+                XSPRITE* pXOwner = &xsprite[pOwner->extra];
+                trTriggerSprite(pOwner->index, pXOwner, kCmdOn);
+                sprintf(buffer, "%s returned Blue Flag", gProfile[pPlayer->nPlayer].name);
+                sndStartSample(8003, 255, 2, 0);
+                viewSetMessage(buffer);
+                break;
+            }
+            pPlayer->hasFlag |= 1;
+            pPlayer->used2[0] = pItem->owner;
+            if (enemyTeam)
+            {
+                sprintf(buffer, "%s stole Blue Flag", gProfile[pPlayer->nPlayer].name);
+                sndStartSample(8007, 255, 2, 0);
+                viewSetMessage(buffer);
+            }
             break;
-        case kItemFlagB:
+        }
+        case kItemFlagB: {
             if (gGameOptions.nGameType != 3) return 0;
-            evKill(pItem->index, 3, kCallbackReturnFlag);
-            pPlayer->hasFlag |= 2;
-            pPlayer->used2[1] = pItem->index;
             gRedFlagDropped = false;
+            const bool enemyTeam = (pPlayer->teamId&1) == 0;
+            if (!enemyTeam && (pItem->owner >= 0) && (pItem->owner < kMaxSprites)) {
+                pPlayer->hasFlag &= ~2;
+                pPlayer->used2[1] = -1;
+                spritetype* pOwner = &sprite[pItem->owner];
+                XSPRITE* pXOwner = &xsprite[pOwner->extra];
+                trTriggerSprite(pOwner->index, pXOwner, kCmdOn);
+                sprintf(buffer, "%s returned Red Flag", gProfile[pPlayer->nPlayer].name);
+                sndStartSample(8002, 255, 2, 0);
+                viewSetMessage(buffer);
+                break;
+            }
+            pPlayer->hasFlag |= 2;
+            pPlayer->used2[1] = pItem->owner;
+            if (enemyTeam)
+            {
+                sprintf(buffer, "%s stole Red Flag", gProfile[pPlayer->nPlayer].name);
+                sndStartSample(8006, 255, 2, 0);
+                viewSetMessage(buffer);
+            }
             break;
+        }
         case kItemArmorBasic:
         case kItemArmorBody:
         case kItemArmorFire:

--- a/source/games/blood/src/player.cpp
+++ b/source/games/blood/src/player.cpp
@@ -988,7 +988,7 @@ char PickupItem(PLAYER *pPlayer, spritetype *pItem) {
                 spritetype* pOwner = &sprite[pItem->owner];
                 XSPRITE* pXOwner = &xsprite[pOwner->extra];
                 trTriggerSprite(pOwner->index, pXOwner, kCmdOn);
-                sprintf(buffer, "%s returned Blue Flag", gProfile[pPlayer->nPlayer].name);
+                sprintf(buffer, "%s returned Blue Flag", PlayerName(pPlayer->nPlayer));
                 sndStartSample(8003, 255, 2, 0);
                 viewSetMessage(buffer);
                 break;
@@ -997,7 +997,7 @@ char PickupItem(PLAYER *pPlayer, spritetype *pItem) {
             pPlayer->used2[0] = pItem->owner;
             if (enemyTeam)
             {
-                sprintf(buffer, "%s stole Blue Flag", gProfile[pPlayer->nPlayer].name);
+                sprintf(buffer, "%s stole Blue Flag", PlayerName(pPlayer->nPlayer));
                 sndStartSample(8007, 255, 2, 0);
                 viewSetMessage(buffer);
             }
@@ -1013,7 +1013,7 @@ char PickupItem(PLAYER *pPlayer, spritetype *pItem) {
                 spritetype* pOwner = &sprite[pItem->owner];
                 XSPRITE* pXOwner = &xsprite[pOwner->extra];
                 trTriggerSprite(pOwner->index, pXOwner, kCmdOn);
-                sprintf(buffer, "%s returned Red Flag", gProfile[pPlayer->nPlayer].name);
+                sprintf(buffer, "%s returned Red Flag", PlayerName(pPlayer->nPlayer));
                 sndStartSample(8002, 255, 2, 0);
                 viewSetMessage(buffer);
                 break;
@@ -1022,7 +1022,7 @@ char PickupItem(PLAYER *pPlayer, spritetype *pItem) {
             pPlayer->used2[1] = pItem->owner;
             if (enemyTeam)
             {
-                sprintf(buffer, "%s stole Red Flag", gProfile[pPlayer->nPlayer].name);
+                sprintf(buffer, "%s stole Red Flag", PlayerName(pPlayer->nPlayer));
                 sndStartSample(8006, 255, 2, 0);
                 viewSetMessage(buffer);
             }

--- a/source/games/blood/src/triggers.cpp
+++ b/source/games/blood/src/triggers.cpp
@@ -206,14 +206,16 @@ void LifeLeechOperate(spritetype *pSprite, XSPRITE *pXSprite, EVENT event)
             PLAYER *pPlayer = &gPlayer[nPlayer];
             if (pPlayer->pXSprite->health > 0)
             {
+                evKill(pSprite->index, 3);
                 pPlayer->ammoCount[8] = ClipHigh(pPlayer->ammoCount[8]+pXSprite->data3, gAmmoInfo[8].max);
                 pPlayer->hasWeapon[9] = 1;
                 if (pPlayer->curWeapon != kWeapLifeLeech)
                 {
+                    if (!VanillaMode() && checkFired6or7(pPlayer)) // if tnt/spray is actively used, do not switch weapon
+                        break;
                     pPlayer->weaponState = 0;
                     pPlayer->nextWeapon = 9;
                 }
-                evKill(pSprite->index, 3);
             }
         }
         break;

--- a/source/games/blood/src/triggers.cpp
+++ b/source/games/blood/src/triggers.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "compat.h"
 
 #include "blood.h"
+#include "misc.h"
 #include "d_net.h"
 
 BEGIN_BLD_NS

--- a/source/games/blood/src/weapon.cpp
+++ b/source/games/blood/src/weapon.cpp
@@ -140,7 +140,7 @@ enum
     nClientAltFireNapalm,
 };
 
-static bool checkFired6or7(PLAYER *pPlayer)
+bool checkFired6or7(PLAYER *pPlayer)
 {
     switch (pPlayer->curWeapon)
     {


### PR DESCRIPTION
This PR fixes a weapon state glitch when collecting a dropped life leech with an ignited TNT/spray can. Instead now it'll first check if TNT/spray can is active, and if true will not forcefully switch weapon to life leech.

https://user-images.githubusercontent.com/38839485/131180401-18ca35e0-278c-4360-a586-341fd55a3065.mp4


https://user-images.githubusercontent.com/38839485/131182619-426e0421-6516-468a-a746-b9a6a9ef95ba.mp4