### PR TITLE
[Blood] Fix self collisions for lifeleech projectiles

### DIFF
--- a/source/games/blood/src/triggers.cpp
+++ b/source/games/blood/src/triggers.cpp
@@ -266,6 +266,8 @@ void LifeLeechOperate(spritetype *pSprite, XSPRITE *pXSprite, EVENT event)
                             pXSprite->stateTimer = 1;
                             evPost(pSprite->index, 3, t2, kCallbackLeechStateTimer);
                             pXSprite->data3 = ClipLow(pXSprite->data3-1, 0);
+                            if (!VanillaMode()) // disable collisions so lifeleech doesn't do that weird bobbing
+                                missile->s().cstat &= ~CSTAT_SPRITE_BLOCK_ALL;
                         }
                         pSprite->ang = angBak;
                     }


### PR DESCRIPTION
This PR changes the cstat flags for spawned projectiles for the lifeleech sentry alt fire mode.

https://user-images.githubusercontent.com/38839485/137407798-a67548e8-7552-4d7c-a4a4-69b7a1c96324.mp4

https://user-images.githubusercontent.com/38839485/137408083-34f6b9b7-e8d6-4278-9e01-26e6b3653f3f.mp4
