### PR TITLE
[Blood] Match view height clamping behavior to 1.21

### DIFF
--- a/source/games/blood/src/view.cpp
+++ b/source/games/blood/src/view.cpp
@@ -679,13 +679,13 @@ void viewDrawScreen(bool sceneonly)
 
         int ceilingZ, floorZ;
         getzsofslope(nSectnum, cX, cY, &ceilingZ, &floorZ);
-        if (cZ >= floorZ)
+        if ((cZ > floorZ - (1 << 8)) && (gUpperLink[nSectnum] == -1)) // clamp to floor
         {
-            cZ = floorZ - (gUpperLink[nSectnum] >= 0 ? 0 : (8 << 8));
+            cZ = floorZ - (1 << 8);
         }
-        if (cZ <= ceilingZ)
+        if ((cZ < ceilingZ + (1 << 8)) && (gLowerLink[nSectnum] == -1)) // clamp to ceiling
         {
-            cZ = ceilingZ + (gLowerLink[nSectnum] >= 0 ? 0 : (8 << 8));
+            cZ = ceilingZ + (1 << 8);
         }
         cH = q16horiz(ClipRange(cH.asq16(), gi->playerHorizMin(), gi->playerHorizMax()));
 


### PR DESCRIPTION
This PR tweaks view height clamping to match the original 1.21 DOS executable behavior.

When the view is pressed up against a ceiling or floor, it will buffer 1<<8 units from the surface.

https://user-images.githubusercontent.com/38839485/138536779-0551533c-ed2e-43dd-bb4c-1f4d1d1c578d.mp4


https://user-images.githubusercontent.com/38839485/138536791-4ae32104-fb41-4fed-8c74-e729542f1967.mp4


https://user-images.githubusercontent.com/38839485/138536937-03b29153-497e-4a04-9075-1d6827eb248d.mp4