### PR TITLE
[Blood] Fix ceiling panning angle

### DIFF
--- a/source/games/blood/src/sectorfx.cpp
+++ b/source/games/blood/src/sectorfx.cpp
@@ -300,9 +300,9 @@ void DoSectorPanning(void)
 				if (pSector->ceilingstat & CSTAT_SECTOR_ALIGN)
 					angle -= 512;
 				int xBits = tileWidth(nTile) >> int((pSector->ceilingstat & CSTAT_SECTOR_TEXHALF) != 0);
-				int px = MulScale(speed << 2, Cos(angle), 30) / xBits;
+				int px = MulScale(speed << 2, Cos(-angle), 30) / xBits;
 				int yBits = tileHeight(nTile) >> int((pSector->ceilingstat & CSTAT_SECTOR_TEXHALF) != 0);
-				int py = MulScale(speed << 2, Sin(angle), 30) / yBits;
+				int py = MulScale(speed << 2, Sin(-angle), 30) / yBits;
 				pSector->addceilingxpan(px * (1.f / 256));
 				pSector->addceilingypan(-py * (1.f / 256));
 			}


### PR DESCRIPTION
This PR fixes the incorrect direction used for non-relative ceiling panning sectors as described in issue https://github.com/coelckers/Raze/issues/649.

I've attached a before/after along with the modified test level used for the video examples.

https://user-images.githubusercontent.com/38839485/153956033-44a907a4-50f5-4bf7-be23-3bc06e7a6c91.mp4


https://user-images.githubusercontent.com/38839485/153956195-66011299-6361-44b9-bff6-66c4d4d72a6d.mp4

[test.zip](https://github.com/coelckers/Raze/files/8064344/test.zip)