### PR TITLE
Fix crash when exiting with no game data

### DIFF
--- a/source/common/engine/m_joy.cpp
+++ b/source/common/engine/m_joy.cpp
@@ -169,7 +169,7 @@ void M_SaveJoystickConfig(IJoystickConfig *joy)
 	char key[32], value[32];
 	int axislen, numaxes;
 
-	if (M_SetJoystickConfigSection(joy, true))
+	if (GameConfig != NULL && M_SetJoystickConfigSection(joy, true))
 	{
 		GameConfig->ClearCurrentSection();
 		if (!joy->IsSensitivityDefault())


### PR DESCRIPTION
When shutting down with no game data, GameConfig is saved and the
pointer is nulled. If a joystick was present, a null dereference occurs
when the engine tries to save the joystick config later in the shutdown
sequence.

Add a check to avoid a crash in this scenario.

![image](https://user-images.githubusercontent.com/5890747/177626200-436d4dcd-03ef-4125-9bc5-6d94dd5d8efc.png)
